### PR TITLE
fixed VRGDG combine import 

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -639,7 +639,7 @@ class VRGDG_CombinevideosV2:
             },
             "optional": {
                 # when True, repeats the last frame to reach target length
-                "pad_short_videos": ("BOOL", {"default": True}),
+                "pad_short_videos": ("BOOLEAN", {"default": True}),
                 # optional meta from VRGDG_LoadAudioSplitDynamic
                 "audio_meta": ("DICT",),
                 **opt_videos,


### PR DESCRIPTION
line 642 in nodes.py used "BOOL" instead of "BOOLEAN" for the pad_short_videos widget
  type. ComfyUI expects "BOOLEAN" as the correct type name for boolean widgets. 