### PR TITLE
fix: stream FastFilmGrain per batch to fix OOM on long videos (#25)

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -40,11 +40,14 @@ class FastFilmGrain:
 
     def apply_grain(self, images, grain_intensity, saturation_mix, batch_size):
         device = comfy.model_management.get_torch_device()
-        images = images.to(device)
+
+        # batch_size==0 (allowed by INPUT_TYPES min) would crash range();
+        # treat as "process everything in a single batch".
+        step = batch_size if batch_size > 0 else images.shape[0]
 
         outputs = []
-        for i in range(0, images.shape[0], batch_size):
-            batch = images[i:i + batch_size]
+        for i in range(0, images.shape[0], step):
+            batch = images[i:i + step].to(device)
             grain = torch.randn_like(batch)
 
             grain[:, :, :, 0] *= 2.0  # red
@@ -55,7 +58,8 @@ class FastFilmGrain:
 
             output = batch + grain * grain_intensity
             output = output.clamp(0.0, 1.0)
-            outputs.append(output)
+            outputs.append(output.cpu())
+            del batch, grain, gray, output
 
         output = torch.cat(outputs, dim=0)
         output = output.to(comfy.model_management.intermediate_device())


### PR DESCRIPTION
## Bug

`FastFilmGrain` OOMs on long videos regardless of `batch_size`, as reported in #25 (700-frame 1600x900 input crashes a 32GB 5090 even at `batch_size=1`).

## Root cause

In the current `apply_grain` (nodes.py:41-62) the loop divides the *work* but not the *GPU residency*:

```python
images = images.to(device)                    # whole input on GPU upfront
outputs = []
for i in range(0, images.shape[0], batch_size):
    batch = images[i:i + batch_size]
    ...
    outputs.append(output)                    # each output stays on GPU
output = torch.cat(outputs, dim=0)            # concat all on GPU
```

At 1600x900 / 700 frames / float32 that's ~12 GB just for the input, plus another ~12 GB of outputs accumulating, plus the per-batch grain + the `.repeat(1,1,1,3)` gray broadcast in flight. Easy to blow 32 GB even at `batch_size=1`.

## Fix

Stream per batch. This is the same pattern `ColorMatchToReference` already uses in this same file (nodes.py:100-115):

- Drop the upfront `images.to(device)`.
- Move each batch to GPU inside the loop.
- Move each output back to CPU before append.
- Explicit `del` to free per-batch tensors.

Net result: at most one batch + grain on GPU at a time. `batch_size=1` becomes bulletproof, large `batch_size` still works on machines that can fit it.

Strict reduction in GPU memory residency — can't regress workflows that already worked.

## Bonus: latent `batch_size=0` crash

`INPUT_TYPES` has `\"min\": 0`, but `range(start, stop, 0)` raises `ValueError: range() arg 3 must not be zero`. Default is 4 so most users miss it, but a slider drag would hit it. Treating 0 as \"process everything in a single batch\" instead. If you'd rather just bump the min to 1, happy to change it — let me know.

## Diff

```diff
     def apply_grain(self, images, grain_intensity, saturation_mix, batch_size):
         device = comfy.model_management.get_torch_device()
-        images = images.to(device)
+
+        # batch_size==0 (allowed by INPUT_TYPES min) would crash range();
+        # treat as \"process everything in a single batch\".
+        step = batch_size if batch_size > 0 else images.shape[0]
 
         outputs = []
-        for i in range(0, images.shape[0], batch_size):
-            batch = images[i:i + batch_size]
+        for i in range(0, images.shape[0], step):
+            batch = images[i:i + step].to(device)
             grain = torch.randn_like(batch)
 
             grain[:, :, :, 0] *= 2.0  # red
@@ ...
             output = batch + grain * grain_intensity
             output = output.clamp(0.0, 1.0)
-            outputs.append(output)
+            outputs.append(output.cpu())
+            del batch, grain, gray, output
```

## Testing notes

Verified by inspection against the streaming pattern in `ColorMatchToReference` immediately below in the same file. Math/diff is a strict reduction in GPU residency vs the current implementation. Happy to add empirical before/after VRAM numbers from a 700-frame test run if useful for review — just let me know.

Closes #25.