### PR TITLE
[codex] Add multi string concat dynamic UI

### DIFF
--- a/web/VRGDG_MultiStringConcat_dynamic.js
+++ b/web/VRGDG_MultiStringConcat_dynamic.js
@@ -1,0 +1,79 @@
+import { app } from "../../../scripts/app.js";
+
+const NODE_NAME = "VRGDG_MultiStringConcat";
+const MAX_STRING_SLOTS = 20;
+
+function getWidget(node, name) {
+  return (node.widgets || []).find((w) => w.name === name);
+}
+
+function setWidgetVisible(widget, visible) {
+  if (!widget) return;
+  if (!Object.prototype.hasOwnProperty.call(widget, "__vrgdgOriginalType")) {
+    widget.__vrgdgOriginalType = widget.type;
+    widget.__vrgdgOriginalComputeSize = widget.computeSize;
+  }
+
+  if (visible) {
+    widget.type = widget.__vrgdgOriginalType;
+    if (widget.__vrgdgOriginalComputeSize) {
+      widget.computeSize = widget.__vrgdgOriginalComputeSize;
+    } else {
+      delete widget.computeSize;
+    }
+  } else {
+    widget.type = "hidden";
+    widget.computeSize = () => [0, -4];
+  }
+}
+
+function refreshWidgets(node) {
+  const countWidget = getWidget(node, "string_count");
+  if (!countWidget) return;
+
+  const count = Math.max(1, Math.min(MAX_STRING_SLOTS, Number(countWidget.value ?? 2)));
+  for (let i = 1; i <= MAX_STRING_SLOTS; i++) {
+    setWidgetVisible(getWidget(node, `string_${i}`), i <= count);
+  }
+
+  node.setSize([node.size[0], node.computeSize()[1]]);
+  app.graph.setDirtyCanvas(true, true);
+}
+
+function bindCountChange(node) {
+  const countWidget = getWidget(node, "string_count");
+  if (!countWidget || countWidget.__vrgdgMultiStringConcatBound) return;
+
+  const oldCallback = countWidget.callback;
+  countWidget.callback = function () {
+    if (oldCallback) oldCallback.apply(this, arguments);
+    refreshWidgets(node);
+  };
+
+  countWidget.__vrgdgMultiStringConcatBound = true;
+}
+
+app.registerExtension({
+  name: "vrgdg." + NODE_NAME + ".dynamic",
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_NAME) return;
+
+    const origOnNodeCreated = nodeType.prototype.onNodeCreated;
+    const origOnConfigure = nodeType.prototype.onConfigure;
+
+    nodeType.prototype.onNodeCreated = function () {
+      const r = origOnNodeCreated?.apply(this, arguments);
+      bindCountChange(this);
+      setTimeout(() => refreshWidgets(this), 0);
+      return r;
+    };
+
+    nodeType.prototype.onConfigure = function () {
+      const r = origOnConfigure?.apply(this, arguments);
+      bindCountChange(this);
+      refreshWidgets(this);
+      return r;
+    };
+  },
+});


### PR DESCRIPTION
## What changed

Added `web/VRGDG_MultiStringConcat_dynamic.js` so the `VRGDG_MultiStringConcat` node updates its visible string widgets based on `string_count`.

## Why

The Python node defines all 20 possible string inputs so workflows can save and load them, but the frontend JavaScript is responsible for hiding unused widgets. PROD was missing this JS file, so users saw every string input even when `string_count` was set lower.

## Impact

Users should now see only the active string inputs for the selected count, and the node resizes after creation, configuration, or count changes.

## Validation

- Compared the new PROD JS with the existing DEV JS.
- Ran `python -B -m py_compile VRGDG_GeneralNodes2.py`.