### PR TITLE
[codex] Add optional LoRA workflow controls

### DIFF
--- a/VRGDG_GeneralNodes2.py
+++ b/VRGDG_GeneralNodes2.py
@@ -6,6 +6,7 @@ import threading
 import torch
 import time
 
+import comfy
 import folder_paths
 from aiohttp import web
 from nodes import PreviewImage
@@ -664,6 +665,147 @@ class VRGDG_ImageIndex0HUMOEDIT:
         return (empty_image,)
 
 
+class VRGDG_OptionalMultiLoraModelOnly:
+    MAX_LORA_SLOTS = 20
+    NONE_LORA = "[none]"
+
+    def __init__(self):
+        self._loaded_loras = {}
+
+    @staticmethod
+    def _lora_stem(lora_name):
+        if not lora_name:
+            return ""
+        return os.path.splitext(os.path.basename(str(lora_name)))[0]
+
+    @classmethod
+    def _lora_choices(cls):
+        loras = folder_paths.get_filename_list("loras")
+        return [cls.NONE_LORA] + [name for name in loras if str(name or "").strip() != cls.NONE_LORA]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        lora_choices = cls._lora_choices()
+        required = {
+            "model": ("MODEL",),
+            "use_custom_loras": (
+                "BOOLEAN",
+                {
+                    "default": False,
+                    "tooltip": "Off passes the model through unchanged and ignores all LoRA slots.",
+                },
+            ),
+            "lora_count": (
+                "INT",
+                {
+                    "default": 0,
+                    "min": 0,
+                    "max": cls.MAX_LORA_SLOTS,
+                    "step": 1,
+                    "tooltip": "How many LoRA slots to show and apply. Zero applies none.",
+                },
+            ),
+            "ltx_two_pass_mode": (
+                "BOOLEAN",
+                {
+                    "default": True,
+                    "tooltip": "When enabled, first_pass_model uses half strength and second_pass_model uses full strength.",
+                },
+            ),
+        }
+
+        for i in range(1, cls.MAX_LORA_SLOTS + 1):
+            required[f"lora_{i}"] = (
+                lora_choices,
+                {
+                    "default": cls.NONE_LORA,
+                    "tooltip": "Choose [none] to leave this slot unused.",
+                },
+            )
+            required[f"strength_{i}"] = (
+                "FLOAT",
+                {
+                    "default": 1.0,
+                    "min": -100.0,
+                    "max": 100.0,
+                    "step": 0.01,
+                    "tooltip": "Full-strength value. In LTX two-pass mode, first pass uses half of this.",
+                },
+            )
+
+        return {"required": required}
+
+    RETURN_TYPES = ("MODEL", "MODEL", "STRING")
+    RETURN_NAMES = ("first_pass_model", "second_pass_model", "lora_names")
+    FUNCTION = "apply_loras"
+    CATEGORY = "VRGDG/Loaders"
+    DESCRIPTION = "Safely applies optional model-only LoRAs. Defaults to [none], so shared workflows do not warn about missing LoRA files."
+
+    def _is_none_lora(self, lora_name):
+        value = str(lora_name or "").strip()
+        return not value or value == self.NONE_LORA
+
+    @staticmethod
+    def _as_bool(value):
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+        return bool(value)
+
+    def _get_lora_data(self, lora_name):
+        lora_path = folder_paths.get_full_path_or_raise("loras", lora_name)
+        if lora_path not in self._loaded_loras:
+            self._loaded_loras[lora_path] = comfy.utils.load_torch_file(lora_path, safe_load=True)
+        return self._loaded_loras[lora_path]
+
+    def _collect_lora_specs(self, lora_count, kwargs):
+        try:
+            count = int(lora_count)
+        except Exception:
+            count = 0
+        count = max(0, min(self.MAX_LORA_SLOTS, count))
+
+        specs = []
+        for slot in range(1, count + 1):
+            lora_name = kwargs.get(f"lora_{slot}", self.NONE_LORA)
+            if self._is_none_lora(lora_name):
+                continue
+
+            try:
+                strength = float(kwargs.get(f"strength_{slot}", 1.0))
+            except Exception:
+                strength = 1.0
+            if strength == 0:
+                continue
+
+            specs.append((str(lora_name), strength))
+        return specs
+
+    def _apply_specs(self, model, specs, multiplier):
+        output_model = model
+        for lora_name, strength in specs:
+            effective_strength = float(strength) * float(multiplier)
+            if effective_strength == 0:
+                continue
+            lora = self._get_lora_data(lora_name)
+            output_model, _ = comfy.sd.load_lora_for_models(output_model, None, lora, effective_strength, 0)
+        return output_model
+
+    def apply_loras(self, model, use_custom_loras=False, lora_count=0, ltx_two_pass_mode=True, **kwargs):
+        if not self._as_bool(use_custom_loras):
+            return (model, model, "")
+
+        specs = self._collect_lora_specs(lora_count, kwargs)
+        if not specs:
+            return (model, model, "")
+
+        first_multiplier = 0.5 if self._as_bool(ltx_two_pass_mode) else 1.0
+        second_multiplier = 1.0
+        first_pass_model = self._apply_specs(model, specs, first_multiplier)
+        second_pass_model = self._apply_specs(model, specs, second_multiplier)
+        lora_names = ", ".join(self._lora_stem(name) for name, _ in specs)
+        return (first_pass_model, second_pass_model, lora_names)
+
+
 class VRGDG_NoteBox:
     RETURN_TYPES = ()
     FUNCTION = "run"
@@ -1313,6 +1455,24 @@ class VRGDG_PromptMapJsonFixer:
         return {
             "required": {
                 "text": ("STRING", {"multiline": True, "default": ""}),
+                "use_srt_file": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "When enabled, count scene entries in the connected SRT file/text and require it to match the prompt count.",
+                    },
+                ),
+            },
+            "optional": {
+                "srt_file": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": False,
+                        "forceInput": True,
+                        "tooltip": "Connect an SRT file path, or raw SRT text. Ignored when Use SRT File is off.",
+                    },
+                ),
             }
         }
 
@@ -1414,7 +1574,35 @@ class VRGDG_PromptMapJsonFixer:
         }
         return normalized
 
-    def fix_json(self, text):
+    def _read_srt_source(self, srt_file):
+        value = str(srt_file or "").strip().strip("\"'")
+        if not value:
+            raise ValueError("VRGDG_PromptMapJsonFixer: Use SRT File is enabled, but no SRT file/text was connected.")
+
+        if os.path.isfile(value):
+            with open(value, "r", encoding="utf-8-sig") as file_obj:
+                return file_obj.read(), value
+
+        if "-->" in value:
+            return value, "connected SRT text"
+
+        raise ValueError(
+            "VRGDG_PromptMapJsonFixer: connected SRT value is not an existing file path and does not look like SRT text."
+        )
+
+    def _count_srt_scenes(self, srt_file):
+        srt_text, source_label = self._read_srt_source(srt_file)
+        timestamp_lines = re.findall(
+            r"(?m)^\s*\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}\s*-->\s*\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}.*$",
+            str(srt_text or ""),
+        )
+        if not timestamp_lines:
+            raise ValueError(
+                f"VRGDG_PromptMapJsonFixer: no SRT timestamp lines were found in {source_label}."
+            )
+        return len(timestamp_lines), source_label
+
+    def fix_json(self, text, use_srt_file=False, srt_file=""):
         original = str(text or "")
         cleaned = self._basic_cleanup(original)
         sliced = self._extract_json_slice(cleaned)
@@ -1433,6 +1621,15 @@ class VRGDG_PromptMapJsonFixer:
 
         normalized = self._build_output(prompts)
         prompt_count = len(normalized)
+
+        if bool(use_srt_file):
+            srt_scene_count, source_label = self._count_srt_scenes(srt_file)
+            if prompt_count != srt_scene_count:
+                raise ValueError(
+                    "VRGDG_PromptMapJsonFixer: prompt count does not match SRT scene count. "
+                    f"Prompts: {prompt_count}, SRT scenes: {srt_scene_count}. Source: {source_label}."
+                )
+            notes.append(f"SRT scene count matched prompt count ({prompt_count})")
 
         fixed_text = json.dumps(normalized, indent=2, ensure_ascii=False)
         was_fixed = fixed_text.strip() != cleaned.strip()
@@ -1943,6 +2140,7 @@ NODE_CLASS_MAPPINGS = {
     "VRGDG_BoxIT": VRGDG_BoxIT,
     "VRGDG_IntToFloat": VRGDG_IntToFloat,
     "VRGDG_ImageIndex0HUMOEDIT": VRGDG_ImageIndex0HUMOEDIT,
+    "VRGDG_OptionalMultiLoraModelOnly": VRGDG_OptionalMultiLoraModelOnly,
     "VRGDG_NoteBox": VRGDG_NoteBox,
     "VRGDG_SetMuteStateMulti": VRGDG_SetMuteStateMulti,
     "VRGDG_SetGroupStateMulti": VRGDG_SetGroupStateMulti,
@@ -1970,6 +2168,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VRGDG_BoxIT": "VRGDG_BoxIT",
     "VRGDG_IntToFloat": "VRGDG_IntToFloat",
     "VRGDG_ImageIndex0HUMOEDIT": "VRGDG_ImageIndex0HUMOEDIT",
+    "VRGDG_OptionalMultiLoraModelOnly": "VRGDG Optional Multi LoRA Model Only",
     "VRGDG_NoteBox": "VRGDG_NoteBox",
     "VRGDG_SetMuteStateMulti": "VRGDG_SetMuteStateMulti",
     "VRGDG_SetGroupStateMulti": "VRGDG_SetGroupStateMulti",

--- a/web/VRGDG_LoraSwitchMulti_dynamic.js
+++ b/web/VRGDG_LoraSwitchMulti_dynamic.js
@@ -1,0 +1,151 @@
+import { app } from "../../../scripts/app.js";
+
+const NODE_NAMES = new Set([
+  "VRGDG_OptionalMultiLoraModelOnly",
+]);
+const OPTIONAL_MODEL_ONLY_NODE = "VRGDG_OptionalMultiLoraModelOnly";
+const MAX_LORA_SLOTS = 20;
+const OPTIONAL_OUTPUTS = [
+  ["first_pass_model", "MODEL"],
+  ["second_pass_model", "MODEL"],
+  ["lora_names", "STRING"],
+];
+
+function getWidget(node, name) {
+  return (node.widgets || []).find((w) => w.name === name);
+}
+
+function asBoolean(value) {
+  if (typeof value === "boolean") return value;
+  const text = String(value ?? "").trim().toLowerCase();
+  return text === "true" || text === "1" || text === "yes" || text === "on";
+}
+
+function setWidgetVisible(widget, visible) {
+  if (!widget) return;
+  if (!Object.prototype.hasOwnProperty.call(widget, "__vrgdgOriginalType")) {
+    widget.__vrgdgOriginalType = widget.type;
+    widget.__vrgdgOriginalComputeSize = widget.computeSize;
+  }
+
+  widget.hidden = !visible;
+  widget.serialize = true;
+
+  if (visible) {
+    widget.type = widget.__vrgdgOriginalType;
+    if (widget.__vrgdgOriginalComputeSize) {
+      widget.computeSize = widget.__vrgdgOriginalComputeSize;
+    } else {
+      delete widget.computeSize;
+    }
+  } else {
+    widget.type = widget.__vrgdgOriginalType;
+    widget.computeSize = () => [0, -4];
+  }
+}
+
+function isOptionalModelOnlyNode(node) {
+  return node?.comfyClass === OPTIONAL_MODEL_ONLY_NODE || node?.type === OPTIONAL_MODEL_ONLY_NODE;
+}
+
+function normalizeOptionalOutputs(node) {
+  if (!isOptionalModelOnlyNode(node) || !Array.isArray(node.outputs)) return;
+
+  while (node.outputs.length > OPTIONAL_OUTPUTS.length) {
+    if (typeof node.removeOutput === "function") {
+      node.removeOutput(node.outputs.length - 1);
+    } else {
+      node.outputs.pop();
+    }
+  }
+
+  for (let i = 0; i < OPTIONAL_OUTPUTS.length; i++) {
+    const [name, type] = OPTIONAL_OUTPUTS[i];
+    if (!node.outputs[i] && typeof node.addOutput === "function") {
+      node.addOutput(name, type);
+    }
+    if (node.outputs[i]) {
+      node.outputs[i].name = name;
+      node.outputs[i].localized_name = name;
+      node.outputs[i].type = type;
+    }
+  }
+}
+
+function refreshWidgets(node) {
+  const countWidget = getWidget(node, "lora_count");
+  if (!countWidget) return;
+
+  normalizeOptionalOutputs(node);
+
+  const isOptionalNode = isOptionalModelOnlyNode(node);
+  const useCustomWidget = getWidget(node, "use_custom_loras");
+  const useCustom = !isOptionalNode || asBoolean(useCustomWidget?.value);
+  const minCount = isOptionalNode ? 0 : 1;
+  const fallbackCount = isOptionalNode ? 0 : 4;
+  const count = useCustom
+    ? Math.max(minCount, Math.min(MAX_LORA_SLOTS, Number(countWidget.value ?? fallbackCount)))
+    : 0;
+
+  setWidgetVisible(countWidget, useCustom);
+  setWidgetVisible(getWidget(node, "ltx_two_pass_mode"), useCustom);
+
+  for (let i = 1; i <= MAX_LORA_SLOTS; i++) {
+    const visible = useCustom && i <= count;
+    setWidgetVisible(getWidget(node, `lora_${i}`), visible);
+    setWidgetVisible(getWidget(node, `strength_${i}`), visible);
+  }
+
+  node.setSize([node.size[0], node.computeSize()[1]]);
+  app.graph.setDirtyCanvas(true, true);
+}
+
+function bindCountChange(node) {
+  const countWidget = getWidget(node, "lora_count");
+  const useCustomWidget = getWidget(node, "use_custom_loras");
+
+  if (countWidget && !countWidget.__vrgdgLoraSwitchBound) {
+    const oldCallback = countWidget.callback;
+    countWidget.callback = function () {
+      if (oldCallback) oldCallback.apply(this, arguments);
+      refreshWidgets(node);
+    };
+
+    countWidget.__vrgdgLoraSwitchBound = true;
+  }
+
+  if (useCustomWidget && !useCustomWidget.__vrgdgLoraSwitchBound) {
+    const oldCallback = useCustomWidget.callback;
+    useCustomWidget.callback = function () {
+      if (oldCallback) oldCallback.apply(this, arguments);
+      refreshWidgets(node);
+    };
+
+    useCustomWidget.__vrgdgLoraSwitchBound = true;
+  }
+}
+
+app.registerExtension({
+  name: "vrgdg.optional_lora_model_only.dynamic",
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (!NODE_NAMES.has(nodeData.name)) return;
+
+    const origOnNodeCreated = nodeType.prototype.onNodeCreated;
+    const origOnConfigure = nodeType.prototype.onConfigure;
+
+    nodeType.prototype.onNodeCreated = function () {
+      const r = origOnNodeCreated?.apply(this, arguments);
+      bindCountChange(this);
+      setTimeout(() => refreshWidgets(this), 0);
+      return r;
+    };
+
+    nodeType.prototype.onConfigure = function () {
+      const r = origOnConfigure?.apply(this, arguments);
+      bindCountChange(this);
+      refreshWidgets(this);
+      return r;
+    };
+  },
+});

--- a/web/VRGDG_PromptCreatorUI_V2.js
+++ b/web/VRGDG_PromptCreatorUI_V2.js
@@ -5,6 +5,10 @@ const NODE_NAME = "VRGDG_PromptCreatorUI_V2";
 const PART2_NODE_NAME = "VRGDG_Part2WorkflowUI";
 const MODAL_ID = "vrgdg-prompt-creator-ui-v2-modal";
 const PART2_MODAL_ID = "vrgdg-prompt-creator-part2-ui-modal";
+const PART2_DRAFT_STORAGE_KEY = "vrgdg.part2.workflow.ui.draft.v1";
+const PART2_OPTIONAL_LORA_NODE_NAME = "VRGDG_OptionalMultiLoraModelOnly";
+const PART2_MAX_LORA_SLOTS = 20;
+const PART2_Z_IMAGE_LORA_INNER_NODE_ID = 847;
 const BANNER_URL = new URL("./ChatGPT Image May 5, 2026, 08_07_18 PM.png?v=20260505_2020_refresh", import.meta.url).href;
 const PART2_BANNER_URL = new URL("./ChatGPT Image May 5, 2026, 08_07_18 PM-002.png?v=20260505_224432", import.meta.url).href;
 const LYRIC_CREATOR_GPT_URL = "https://chatgpt.com/g/g-69979b391cc88191ae4fe298b59c236e-ai-lyric-creator";
@@ -20,18 +24,28 @@ const PART2_NODE_IDS = {
   camera: 830,
   promptJson: 543,
   zImageModels: 797,
+  optionalLoras: 842,
 };
 const PART2_MODEL_FIELDS = [
-  { nodeId: 271, key: "unet_name", label: "LTX GGUF model" },
-  { nodeId: 271, key: "vae_name", label: "Video VAE" },
-  { nodeId: 271, key: "clip_name1", label: "Gemma Clip Model" },
-  { nodeId: 271, key: "clip_name2", label: "Text Projecton clip model" },
-  { nodeId: 271, key: "model_name", label: "Latent Upscaler" },
-  { nodeId: 271, key: "vae_name_1", label: "Audio VAE" },
-  { nodeId: 797, key: "lora_name", label: "Z-Image Lora" },
-  { nodeId: 797, key: "unet_name", label: "Z-Image Turbo Model" },
-  { nodeId: 797, key: "clip_name", label: "Z-Image Clip" },
-  { nodeId: 797, key: "vae_name", label: "Z-Image VAE" },
+  { nodeId: 271, key: "unet_name", label: "LTX GGUF model", downloadUrl: "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF/tree/main" },
+  { nodeId: 271, key: "vae_name", label: "Video VAE", downloadUrl: "https://huggingface.co/Kijai/LTX2.3_comfy/tree/main/vae" },
+  { nodeId: 271, key: "clip_name1", label: "Gemma Clip Model", downloadUrl: "https://huggingface.co/Sikaworld1990/gemma-3-12b-it-abliterated-sikaworld-high-fidelity-edition-Ltx-2/resolve/main/gemma-3-12b-it-abliterated-sikaworld-high-fidelity-edition.safetensors" },
+  { nodeId: 271, key: "clip_name2", label: "Text Projection clip model", downloadUrl: "https://huggingface.co/Kijai/LTX2.3_comfy/tree/main/text_encoders" },
+  { nodeId: 271, key: "model_name", label: "Latent Upscaler", downloadUrl: "https://huggingface.co/prince-canuma/LTX-2.3-distilled/resolve/main/ltx-2.3-spatial-upscaler-x2-1.1.safetensors" },
+  { nodeId: 271, key: "vae_name_1", label: "Audio VAE", downloadUrl: "https://huggingface.co/Kijai/LTX2.3_comfy/tree/main/vae" },
+  { nodeId: 797, key: "unet_name", label: "Z-Image Turbo Model", downloadUrl: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors" },
+  { nodeId: 797, key: "clip_name", label: "Z-Image Clip", downloadUrl: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors" },
+  { nodeId: 797, key: "vae_name", label: "Z-Image VAE", downloadUrl: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors" },
+];
+const PART2_LLM_DOWNLOADS = [
+  {
+    label: "Download GGUF",
+    url: "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2/resolve/main/supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf",
+  },
+  {
+    label: "Download mmproj",
+    url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-BF16.gguf",
+  },
 ];
 const PART2_SETTING_FIELDS = [
   { key: "value", label: "Frames Per Second", type: "number", step: "1", note: "Must match the FPS used in the Part 1 workflow." },
@@ -240,6 +254,36 @@ function createButton(label, styles = "") {
     ${styles}
   `;
   return button;
+}
+
+function createLlmDownloadButtons() {
+  const buttons = document.createElement("div");
+  buttons.style.cssText = "display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end;";
+
+  for (const item of PART2_LLM_DOWNLOADS) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = item.label;
+    button.style.cssText = `
+      border: 1px solid #2563eb;
+      background: #1d4ed8;
+      color: white;
+      border-radius: 6px;
+      padding: 5px 8px;
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 700;
+      white-space: nowrap;
+    `;
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      window.open(item.url, "_blank", "noopener,noreferrer");
+    });
+    buttons.appendChild(button);
+  }
+
+  return buttons;
 }
 
 function createPathHint() {
@@ -577,7 +621,15 @@ function ensureModal() {
       line-height: 1.35;
     `;
 
-    fieldWrap.append(fieldLabel, input, fieldNote);
+    if (field.key === "model_file") {
+      const labelRow = document.createElement("div");
+      labelRow.style.cssText = "display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px;";
+      fieldLabel.style.marginBottom = "0";
+      labelRow.append(fieldLabel, createLlmDownloadButtons());
+      fieldWrap.append(labelRow, input, fieldNote);
+    } else {
+      fieldWrap.append(fieldLabel, input, fieldNote);
+    }
     if (field.headerControl) {
       fieldWrap.style.minWidth = "320px";
       subgraphTitleActions.appendChild(fieldWrap);
@@ -910,6 +962,40 @@ function getPart2Node(nodeId) {
   return app.graph?.getNodeById?.(nodeId) || null;
 }
 
+function getPart2NodeByType(typeName) {
+  const nodes = app.graph?._nodes || [];
+  return nodes.find((node) => node?.comfyClass === typeName || node?.type === typeName) || null;
+}
+
+function getPart2OptionalLoraNode() {
+  const nodeById = getPart2Node(PART2_NODE_IDS.optionalLoras);
+  if (nodeById?.comfyClass === PART2_OPTIONAL_LORA_NODE_NAME || nodeById?.type === PART2_OPTIONAL_LORA_NODE_NAME) {
+    return nodeById;
+  }
+  return getPart2NodeByType(PART2_OPTIONAL_LORA_NODE_NAME);
+}
+
+function getSubgraphNodes(subgraph) {
+  if (Array.isArray(subgraph?.nodes)) return subgraph.nodes;
+  if (Array.isArray(subgraph?._nodes)) return subgraph._nodes;
+  return [];
+}
+
+function getPart2ZImageOptionalLoraNode() {
+  const zNode = getPart2Node(PART2_NODE_IDS.zImageModels);
+  const subNodes = getSubgraphNodes(zNode?.subgraph);
+  return (
+    subNodes.find((node) => Number(node?.id) === PART2_Z_IMAGE_LORA_INNER_NODE_ID) ||
+    subNodes.find((node) => node?.comfyClass === PART2_OPTIONAL_LORA_NODE_NAME || node?.type === PART2_OPTIONAL_LORA_NODE_NAME) ||
+    null
+  );
+}
+
+function getPart2ZImageUseLoraProxyValue() {
+  const value = getPart2WidgetValue(PART2_NODE_IDS.zImageModels, "use_custom_loras", 6);
+  return String(value ?? false).toLowerCase() === "true";
+}
+
 function getPart2Widget(node, name, fallbackIndex = -1) {
   if (!node) return null;
   const widgets = node.widgets || [];
@@ -965,6 +1051,18 @@ function fillSelectOptions(select, options, currentValue) {
   select.value = String(currentValue ?? "");
 }
 
+function setSelectValueAllowingDraft(select, value) {
+  const text = String(value ?? "");
+  const hasOption = Array.from(select.options || []).some((option) => option.value === text);
+  if (text && !hasOption) {
+    const option = document.createElement("option");
+    option.value = text;
+    option.textContent = text;
+    select.appendChild(option);
+  }
+  select.value = text;
+}
+
 function createPart2Field(labelText, control, noteText = "") {
   const wrapper = document.createElement("label");
   wrapper.style.cssText = "display: block; font-size: 12px; color: #cbd5e1;";
@@ -983,6 +1081,71 @@ function createPart2Field(labelText, control, noteText = "") {
   `;
 
   wrapper.append(label, control, note);
+  return wrapper;
+}
+
+function createPart2ModelField(field, control) {
+  if (!field.downloadUrl) {
+    return createPart2Field(field.label, control);
+  }
+
+  const wrapper = document.createElement("label");
+  wrapper.style.cssText = "display: block; font-size: 12px; color: #cbd5e1;";
+
+  const labelRow = document.createElement("div");
+  labelRow.style.cssText = "display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px;";
+
+  const label = document.createElement("div");
+  label.textContent = field.label;
+  label.style.cssText = "font-weight: 700;";
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "Download Model";
+  button.style.cssText = `
+    border: 1px solid #2563eb;
+    background: #1d4ed8;
+    color: white;
+    border-radius: 6px;
+    padding: 5px 8px;
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+  `;
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    window.open(field.downloadUrl, "_blank", "noopener,noreferrer");
+  });
+
+  labelRow.append(label, button);
+  wrapper.append(labelRow, control);
+  return wrapper;
+}
+
+function createPart2LlmField(control) {
+  const wrapper = document.createElement("label");
+  wrapper.style.cssText = "display: block; font-size: 12px; color: #cbd5e1;";
+
+  const labelRow = document.createElement("div");
+  labelRow.style.cssText = "display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px;";
+
+  const label = document.createElement("div");
+  label.textContent = "SuperGemma LLM Model";
+  label.style.cssText = "font-weight: 700;";
+
+  const note = document.createElement("div");
+  note.textContent = "Download both files for the Gemma LLM Node.";
+  note.style.cssText = `
+    margin-top: 5px;
+    color: #94a3b8;
+    font-size: 11px;
+    line-height: 1.35;
+  `;
+
+  labelRow.append(label, createLlmDownloadButtons());
+  wrapper.append(labelRow, control, note);
   return wrapper;
 }
 
@@ -1105,6 +1268,19 @@ function ensurePart2Modal() {
     modelSelects: {},
     settings: {},
     useSrt: null,
+    lora: {
+      useCustom: null,
+      count: null,
+      twoPass: null,
+      slots: [],
+      section: null,
+    },
+    zImageLora: {
+      useCustom: null,
+      count: null,
+      slots: [],
+      section: null,
+    },
     cameraItems: null,
     cameraMode: null,
     promptJson: null,
@@ -1118,13 +1294,107 @@ function ensurePart2Modal() {
   for (const field of PART2_MODEL_FIELDS) {
     const select = stylePart2Input(document.createElement("select"));
     controls.modelSelects[`${field.nodeId}:${field.key}`] = select;
-    modelGrid.appendChild(createPart2Field(field.label, select));
+    modelGrid.appendChild(createPart2ModelField(field, select));
   }
 
   const llmSelect = stylePart2Input(document.createElement("select"));
   controls.modelSelects["llm"] = llmSelect;
-  modelGrid.appendChild(createPart2Field("LLM Model (Nodes 811 and 805)", llmSelect, "Updates both LLM nodes."));
+  modelGrid.appendChild(createPart2LlmField(llmSelect));
   modelSection.appendChild(modelGrid);
+
+  const loraSection = createPart2Section(
+    "LTX Optional LoRAs",
+    "Pick optional model-only LoRAs once. Image/style LoRAs can sometimes slow down or stiffen motion during the first video pass, so the workflow can use half strength while motion is being created, then full strength during the upscale/refine pass."
+  );
+  controls.lora.section = loraSection;
+  const loraGrid = document.createElement("div");
+  loraGrid.style.cssText = "display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px;";
+
+  const loraUseSelect = stylePart2Input(document.createElement("select"));
+  for (const [value, label] of [["false", "OFF"], ["true", "ON"]]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    loraUseSelect.appendChild(option);
+  }
+  controls.lora.useCustom = loraUseSelect;
+  loraGrid.appendChild(createPart2Field("Use Custom LoRAs", loraUseSelect, "OFF leaves both first and second pass models unchanged."));
+
+  const loraCountInput = stylePart2Input(document.createElement("input"));
+  loraCountInput.type = "number";
+  loraCountInput.min = "0";
+  loraCountInput.max = String(PART2_MAX_LORA_SLOTS);
+  loraCountInput.step = "1";
+  controls.lora.count = loraCountInput;
+  loraGrid.appendChild(createPart2Field("LoRA Count", loraCountInput, "How many LoRA slots to show and apply."));
+
+  const loraTwoPassSelect = stylePart2Input(document.createElement("select"));
+  for (const [value, label] of [["true", "ON"], ["false", "OFF"]]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    loraTwoPassSelect.appendChild(option);
+  }
+  controls.lora.twoPass = loraTwoPassSelect;
+  loraGrid.appendChild(createPart2Field("LTX Two Pass Strength", loraTwoPassSelect, "ON uses half of each selected LoRA strength on first pass to preserve motion, then the full selected strength on the upscale pass. OFF uses the selected strength on both passes."));
+
+  for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+    const select = stylePart2Input(document.createElement("select"));
+    const strength = stylePart2Input(document.createElement("input"));
+    strength.type = "number";
+    strength.step = "0.01";
+    strength.min = "-100";
+    strength.max = "100";
+
+    const loraWrapper = createPart2Field(`LoRA ${i}`, select);
+    const strengthWrapper = createPart2Field(`Strength ${i}`, strength, "Selected/full strength for the upscale pass. First pass uses half of this value when two-pass strength is ON.");
+    controls.lora.slots.push({ select, strength, loraWrapper, strengthWrapper });
+    loraGrid.append(loraWrapper, strengthWrapper);
+  }
+
+  loraSection.appendChild(loraGrid);
+
+  const zImageLoraSection = createPart2Section(
+    "Z-Image Optional LoRA",
+    "Optional LoRA for the Z-Image still-image branch. This does not use two-pass strength; selected LoRAs apply at the strength you enter."
+  );
+  controls.zImageLora.section = zImageLoraSection;
+  const zImageLoraGrid = document.createElement("div");
+  zImageLoraGrid.style.cssText = "display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px;";
+
+  const zImageLoraUseSelect = stylePart2Input(document.createElement("select"));
+  for (const [value, label] of [["false", "OFF"], ["true", "ON"]]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    zImageLoraUseSelect.appendChild(option);
+  }
+  controls.zImageLora.useCustom = zImageLoraUseSelect;
+  zImageLoraGrid.appendChild(createPart2Field("Use Z-Image LoRAs", zImageLoraUseSelect, "OFF leaves the Z-Image model unchanged."));
+
+  const zImageLoraCountInput = stylePart2Input(document.createElement("input"));
+  zImageLoraCountInput.type = "number";
+  zImageLoraCountInput.min = "0";
+  zImageLoraCountInput.max = String(PART2_MAX_LORA_SLOTS);
+  zImageLoraCountInput.step = "1";
+  controls.zImageLora.count = zImageLoraCountInput;
+  zImageLoraGrid.appendChild(createPart2Field("Z-Image LoRA Count", zImageLoraCountInput, "How many Z-Image LoRA slots to show and apply."));
+
+  for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+    const select = stylePart2Input(document.createElement("select"));
+    const strength = stylePart2Input(document.createElement("input"));
+    strength.type = "number";
+    strength.step = "0.01";
+    strength.min = "-100";
+    strength.max = "100";
+
+    const loraWrapper = createPart2Field(`Z-Image LoRA ${i}`, select);
+    const strengthWrapper = createPart2Field(`Z-Image Strength ${i}`, strength, "Applied at this exact strength.");
+    controls.zImageLora.slots.push({ select, strength, loraWrapper, strengthWrapper });
+    zImageLoraGrid.append(loraWrapper, strengthWrapper);
+  }
+
+  zImageLoraSection.appendChild(zImageLoraGrid);
 
   const settingsSection = createPart2Section("Main Settings", "FPS should match the FPS used in Part 1.");
   const settingsGrid = document.createElement("div");
@@ -1199,7 +1469,7 @@ function ensurePart2Modal() {
   );
   actions.append(applyButton);
 
-  panel.append(banner, titleRow, modelSection, settingsSection, cameraSection, promptSection, status, actions);
+  panel.append(banner, titleRow, modelSection, loraSection, zImageLoraSection, settingsSection, cameraSection, promptSection, status, actions);
   overlay.appendChild(panel);
   document.body.appendChild(overlay);
 
@@ -1208,7 +1478,116 @@ function ensurePart2Modal() {
     status.style.color = isError ? "#fca5a5" : "#cbd5e1";
   }
 
+  let suppressDraftSave = false;
+
+  function collectPart2Draft() {
+    const draft = {
+      modelSelects: {},
+      settings: {},
+      useSrt: controls.useSrt.value,
+      cameraItems: controls.cameraItems.value,
+      cameraMode: controls.cameraMode.value,
+      promptJson: controls.promptJson.value,
+      lora: {
+        useCustom: controls.lora.useCustom.value,
+        count: controls.lora.count.value,
+        twoPass: controls.lora.twoPass.value,
+        slots: controls.lora.slots.map((slot) => ({
+          lora: slot.select.value,
+          strength: slot.strength.value,
+        })),
+      },
+      zImageLora: {
+        useCustom: controls.zImageLora.useCustom.value,
+        count: controls.zImageLora.count.value,
+        slots: controls.zImageLora.slots.map((slot) => ({
+          lora: slot.select.value,
+          strength: slot.strength.value,
+        })),
+      },
+    };
+
+    for (const [key, select] of Object.entries(controls.modelSelects)) {
+      draft.modelSelects[key] = select.value;
+    }
+    for (const [key, input] of Object.entries(controls.settings)) {
+      draft.settings[key] = input.value;
+    }
+    return draft;
+  }
+
+  function savePart2Draft() {
+    if (suppressDraftSave) return;
+    try {
+      localStorage.setItem(PART2_DRAFT_STORAGE_KEY, JSON.stringify(collectPart2Draft()));
+    } catch (error) {
+      // Browser storage can be disabled; form still works normally.
+    }
+  }
+
+  function loadPart2Draft() {
+    try {
+      const raw = localStorage.getItem(PART2_DRAFT_STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function clearPart2Draft() {
+    try {
+      localStorage.removeItem(PART2_DRAFT_STORAGE_KEY);
+    } catch (error) {
+      // ignore
+    }
+  }
+
+  function applyPart2Draft(draft) {
+    if (!draft || typeof draft !== "object") return false;
+    suppressDraftSave = true;
+
+    for (const [key, value] of Object.entries(draft.modelSelects || {})) {
+      if (controls.modelSelects[key]) setSelectValueAllowingDraft(controls.modelSelects[key], value);
+    }
+    for (const [key, value] of Object.entries(draft.settings || {})) {
+      if (controls.settings[key]) controls.settings[key].value = String(value ?? "");
+    }
+
+    if (draft.useSrt !== undefined) controls.useSrt.value = String(draft.useSrt);
+    if (draft.cameraItems !== undefined) controls.cameraItems.value = String(draft.cameraItems);
+    if (draft.cameraMode !== undefined) controls.cameraMode.value = String(draft.cameraMode);
+    if (draft.promptJson !== undefined) controls.promptJson.value = String(draft.promptJson);
+
+    if (draft.lora) {
+      controls.lora.useCustom.value = String(draft.lora.useCustom ?? "false");
+      controls.lora.count.value = String(draft.lora.count ?? "0");
+      controls.lora.twoPass.value = String(draft.lora.twoPass ?? "true");
+      for (let i = 0; i < controls.lora.slots.length; i++) {
+        const slotDraft = draft.lora.slots?.[i] || {};
+        if (slotDraft.lora !== undefined) setSelectValueAllowingDraft(controls.lora.slots[i].select, slotDraft.lora);
+        if (slotDraft.strength !== undefined) controls.lora.slots[i].strength.value = String(slotDraft.strength);
+      }
+      updateLoraVisibility();
+    }
+
+    if (draft.zImageLora) {
+      controls.zImageLora.useCustom.value = String(draft.zImageLora.useCustom ?? "false");
+      controls.zImageLora.count.value = String(draft.zImageLora.count ?? "0");
+      for (let i = 0; i < controls.zImageLora.slots.length; i++) {
+        const slotDraft = draft.zImageLora.slots?.[i] || {};
+        if (slotDraft.lora !== undefined) setSelectValueAllowingDraft(controls.zImageLora.slots[i].select, slotDraft.lora);
+        if (slotDraft.strength !== undefined) controls.zImageLora.slots[i].strength.value = String(slotDraft.strength);
+      }
+      updateZImageLoraVisibility();
+    }
+
+    updateFixedDurationVisibility();
+    suppressDraftSave = false;
+    return true;
+  }
+
   function closeModal() {
+    savePart2Draft();
     overlay.style.display = "none";
     setStatus("");
   }
@@ -1220,25 +1599,213 @@ function ensurePart2Modal() {
     }
   }
 
+  function updateLoraVisibility() {
+    const useLoras = String(controls.lora.useCustom.value || "false").toLowerCase() === "true";
+    const rawCount = Number(controls.lora.count.value || 0);
+    const count = useLoras ? Math.max(0, Math.min(PART2_MAX_LORA_SLOTS, Number.isFinite(rawCount) ? rawCount : 0)) : 0;
+
+    controls.lora.count.parentElement.style.display = useLoras ? "block" : "none";
+    controls.lora.twoPass.parentElement.style.display = useLoras ? "block" : "none";
+
+    for (let i = 0; i < controls.lora.slots.length; i++) {
+      const visible = useLoras && i < count;
+      controls.lora.slots[i].loraWrapper.style.display = visible ? "block" : "none";
+      controls.lora.slots[i].strengthWrapper.style.display = visible ? "block" : "none";
+    }
+  }
+
+  function updateZImageLoraVisibility() {
+    const useLoras = String(controls.zImageLora.useCustom.value || "false").toLowerCase() === "true";
+    const rawCount = Number(controls.zImageLora.count.value || 0);
+    const count = useLoras ? Math.max(0, Math.min(PART2_MAX_LORA_SLOTS, Number.isFinite(rawCount) ? rawCount : 0)) : 0;
+
+    controls.zImageLora.count.parentElement.style.display = useLoras ? "block" : "none";
+
+    for (let i = 0; i < controls.zImageLora.slots.length; i++) {
+      const visible = useLoras && i < count;
+      controls.zImageLora.slots[i].loraWrapper.style.display = visible ? "block" : "none";
+      controls.zImageLora.slots[i].strengthWrapper.style.display = visible ? "block" : "none";
+    }
+  }
+
+  function getLoraWidgetFallbackIndex(name) {
+    if (name === "use_custom_loras") return 0;
+    if (name === "lora_count") return 1;
+    if (name === "ltx_two_pass_mode") return 2;
+    let match = /^lora_(\d+)$/.exec(String(name || ""));
+    if (match) return 3 + (Number(match[1]) - 1) * 2;
+    match = /^strength_(\d+)$/.exec(String(name || ""));
+    if (match) return 4 + (Number(match[1]) - 1) * 2;
+    return -1;
+  }
+
+  function getNodeWidgetValueFlexible(node, name, fallbackValue = "") {
+    const fallbackIndex = getLoraWidgetFallbackIndex(name);
+    const widget = getPart2Widget(node, name, fallbackIndex);
+    if (widget) return widget.value;
+    if (Array.isArray(node?.widgets_values) && fallbackIndex >= 0) return node.widgets_values[fallbackIndex];
+    return fallbackValue;
+  }
+
+  function refreshLoraControls(missing) {
+    const loraNode = getPart2OptionalLoraNode();
+    if (!loraNode) {
+      controls.lora.section.style.display = "none";
+      missing.push(PART2_OPTIONAL_LORA_NODE_NAME);
+      return;
+    }
+
+    controls.lora.section.style.display = "block";
+    const useWidget = getPart2Widget(loraNode, "use_custom_loras");
+    const countWidget = getPart2Widget(loraNode, "lora_count");
+    const twoPassWidget = getPart2Widget(loraNode, "ltx_two_pass_mode");
+
+    controls.lora.useCustom.value = String(useWidget?.value ?? false).toLowerCase() === "true" ? "true" : "false";
+    controls.lora.count.value = String(countWidget?.value ?? 0);
+    controls.lora.twoPass.value = String(twoPassWidget?.value ?? true).toLowerCase() === "false" ? "false" : "true";
+
+    if (!useWidget) missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.use_custom_loras`);
+    if (!countWidget) missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.lora_count`);
+    if (!twoPassWidget) missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.ltx_two_pass_mode`);
+
+    for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+      const slot = controls.lora.slots[i - 1];
+      const loraWidget = getPart2Widget(loraNode, `lora_${i}`);
+      const strengthWidget = getPart2Widget(loraNode, `strength_${i}`);
+      fillSelectOptions(slot.select, getPart2WidgetOptions(loraWidget), loraWidget?.value ?? "[none]");
+      slot.strength.value = String(strengthWidget?.value ?? 1);
+    }
+
+    updateLoraVisibility();
+  }
+
+  function setPart2NodeWidgetValue(node, name, value) {
+    if (!node) return false;
+    const fallbackIndex = getLoraWidgetFallbackIndex(name);
+    const widget = getPart2Widget(node, name, fallbackIndex);
+    if (widget) {
+      widget.value = value;
+      widget.callback?.(value, app.canvas, node, app.canvas?.graph_mouse);
+    }
+    if (Array.isArray(node.widgets_values)) {
+      const widgetIndex = (node.widgets || []).findIndex((item) => item?.name === name);
+      const resolvedIndex = widgetIndex >= 0 ? widgetIndex : fallbackIndex;
+      if (resolvedIndex >= 0) node.widgets_values[resolvedIndex] = value;
+    }
+    app.graph?.setDirtyCanvas?.(true, true);
+    return Boolean(widget) || fallbackIndex >= 0;
+  }
+
+  function applyLoraControls(missing) {
+    const loraNode = getPart2OptionalLoraNode();
+    if (!loraNode) {
+      missing.push(PART2_OPTIONAL_LORA_NODE_NAME);
+      return 0;
+    }
+
+    let updated = 0;
+    const useLoras = String(controls.lora.useCustom.value).toLowerCase() === "true";
+    const rawCount = Number(controls.lora.count.value || 0);
+    const count = Math.max(0, Math.min(PART2_MAX_LORA_SLOTS, Number.isFinite(rawCount) ? Math.round(rawCount) : 0));
+
+    if (setPart2NodeWidgetValue(loraNode, "use_custom_loras", useLoras)) updated += 1;
+    else missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.use_custom_loras`);
+    if (setPart2NodeWidgetValue(loraNode, "lora_count", count)) updated += 1;
+    else missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.lora_count`);
+    if (setPart2NodeWidgetValue(loraNode, "ltx_two_pass_mode", String(controls.lora.twoPass.value).toLowerCase() !== "false")) updated += 1;
+    else missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.ltx_two_pass_mode`);
+
+    for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+      const slot = controls.lora.slots[i - 1];
+      const selectedLora = i <= count && useLoras ? slot.select.value : "[none]";
+      const strengthValue = Number(slot.strength.value);
+      if (setPart2NodeWidgetValue(loraNode, `lora_${i}`, selectedLora || "[none]")) updated += 1;
+      else missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.lora_${i}`);
+      if (setPart2NodeWidgetValue(loraNode, `strength_${i}`, Number.isFinite(strengthValue) ? strengthValue : 1.0)) updated += 1;
+      else missing.push(`${PART2_OPTIONAL_LORA_NODE_NAME}.strength_${i}`);
+    }
+
+    updateLoraVisibility();
+    return updated;
+  }
+
+  function refreshZImageLoraControls(missing) {
+    const loraNode = getPart2ZImageOptionalLoraNode();
+    if (!loraNode) {
+      controls.zImageLora.section.style.display = "none";
+      missing.push("Z-Image optional LoRA node");
+      return;
+    }
+
+    controls.zImageLora.section.style.display = "block";
+    controls.zImageLora.useCustom.value = getPart2ZImageUseLoraProxyValue() ? "true" : "false";
+    controls.zImageLora.count.value = String(getNodeWidgetValueFlexible(loraNode, "lora_count", 0));
+
+    for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+      const slot = controls.zImageLora.slots[i - 1];
+      const loraWidget = getPart2Widget(loraNode, `lora_${i}`, getLoraWidgetFallbackIndex(`lora_${i}`));
+      const currentLora = getNodeWidgetValueFlexible(loraNode, `lora_${i}`, "[none]");
+      fillSelectOptions(slot.select, getPart2WidgetOptions(loraWidget), currentLora);
+      slot.strength.value = String(getNodeWidgetValueFlexible(loraNode, `strength_${i}`, 1));
+    }
+
+    updateZImageLoraVisibility();
+  }
+
+  function applyZImageLoraControls(missing) {
+    const loraNode = getPart2ZImageOptionalLoraNode();
+    if (!loraNode) {
+      missing.push("Z-Image optional LoRA node");
+      return 0;
+    }
+
+    let updated = 0;
+    const useLoras = String(controls.zImageLora.useCustom.value).toLowerCase() === "true";
+    const rawCount = Number(controls.zImageLora.count.value || 0);
+    const count = Math.max(0, Math.min(PART2_MAX_LORA_SLOTS, Number.isFinite(rawCount) ? Math.round(rawCount) : 0));
+
+    if (setPart2NodeWidgetValue(loraNode, "use_custom_loras", useLoras)) updated += 1;
+    else missing.push("Z-Image LoRA use_custom_loras");
+    if (setPart2WidgetValue(PART2_NODE_IDS.zImageModels, "use_custom_loras", useLoras, 6)) updated += 1;
+    else missing.push("Z-Image use custom LoRAs toggle");
+    if (setPart2NodeWidgetValue(loraNode, "lora_count", count)) updated += 1;
+    else missing.push("Z-Image LoRA lora_count");
+    setPart2NodeWidgetValue(loraNode, "ltx_two_pass_mode", false);
+
+    for (let i = 1; i <= PART2_MAX_LORA_SLOTS; i++) {
+      const slot = controls.zImageLora.slots[i - 1];
+      const selectedLora = i <= count && useLoras ? slot.select.value : "[none]";
+      const strengthValue = Number(slot.strength.value);
+      if (setPart2NodeWidgetValue(loraNode, `lora_${i}`, selectedLora || "[none]")) updated += 1;
+      else missing.push(`Z-Image LoRA lora_${i}`);
+      if (setPart2NodeWidgetValue(loraNode, `strength_${i}`, Number.isFinite(strengthValue) ? strengthValue : 1.0)) updated += 1;
+      else missing.push(`Z-Image LoRA strength_${i}`);
+    }
+
+    updateZImageLoraVisibility();
+    return updated;
+  }
+
   function refreshPart2Controls() {
     const missing = [];
+    suppressDraftSave = true;
 
     for (const field of PART2_MODEL_FIELDS) {
       const node = getPart2Node(field.nodeId);
       const widget = getPart2Widget(node, field.key);
       const current = getPart2WidgetValue(field.nodeId, field.key);
       fillSelectOptions(controls.modelSelects[`${field.nodeId}:${field.key}`], getPart2WidgetOptions(widget), current);
-      if (!node || !widget) missing.push(`node ${field.nodeId}.${field.key}`);
+      if (!node || !widget) missing.push(field.label);
     }
 
     const llmNode = getPart2Node(PART2_NODE_IDS.llmI2V);
     const llmWidget = getPart2Widget(llmNode, null, 0);
     fillSelectOptions(controls.modelSelects.llm, getPart2WidgetOptions(llmWidget), getPart2WidgetValue(PART2_NODE_IDS.llmI2V, null, 0));
-    if (!llmNode || !llmWidget) missing.push("node 811 LLM model");
+    if (!llmNode || !llmWidget) missing.push("SuperGemma LLM model");
 
     for (const field of PART2_SETTING_FIELDS) {
       controls.settings[field.key].value = String(getPart2WidgetValue(PART2_NODE_IDS.settings, field.key) ?? "");
-      if (!getPart2Widget(getPart2Node(PART2_NODE_IDS.settings), field.key)) missing.push(`node 736.${field.key}`);
+      if (!getPart2Widget(getPart2Node(PART2_NODE_IDS.settings), field.key)) missing.push(field.label);
     }
 
     controls.useSrt.value = String(getPart2WidgetValue(PART2_NODE_IDS.useSrtSwitch, "switch", 0)).toLowerCase() === "false" ? "false" : "true";
@@ -1246,6 +1813,20 @@ function ensurePart2Modal() {
     controls.cameraMode.value = String(getPart2WidgetValue(PART2_NODE_IDS.camera, "selection_mode", 3) || "index");
     controls.promptJson.value = String(getPart2WidgetValue(PART2_NODE_IDS.promptJson, null, 0) || "");
     updateFixedDurationVisibility();
+    refreshLoraControls(missing);
+    refreshZImageLoraControls(missing);
+    suppressDraftSave = false;
+
+    const draft = loadPart2Draft();
+    if (draft) {
+      applyPart2Draft(draft);
+      setStatus(
+        missing.length
+          ? `Restored unsaved UI draft.\nLoaded with missing widgets:\n${missing.join("\n")}`
+          : "Restored unsaved UI draft. Click Apply Part 2 Settings when ready."
+      );
+      return;
+    }
 
     setStatus(missing.length ? `Loaded with missing widgets:\n${missing.join("\n")}` : "");
   }
@@ -1256,36 +1837,39 @@ function ensurePart2Modal() {
 
     for (const field of PART2_MODEL_FIELDS) {
       if (setPart2WidgetValue(field.nodeId, field.key, controls.modelSelects[`${field.nodeId}:${field.key}`].value)) updated += 1;
-      else missing.push(`node ${field.nodeId}.${field.key}`);
+      else missing.push(field.label);
     }
 
     const llmValue = controls.modelSelects.llm.value;
     if (setPart2WidgetValue(PART2_NODE_IDS.llmI2V, null, llmValue, 0)) updated += 1;
-    else missing.push("node 811 LLM model");
+    else missing.push("SuperGemma LLM model");
     if (setPart2WidgetValue(PART2_NODE_IDS.llmT2I, null, llmValue, 0)) updated += 1;
-    else missing.push("node 805 LLM model");
+    else missing.push("SuperGemma LLM model for text-to-image");
 
     for (const field of PART2_SETTING_FIELDS) {
       const rawValue = controls.settings[field.key].value;
       const numberValue = Number(rawValue);
       const value = Number.isFinite(numberValue) ? numberValue : rawValue;
       if (setPart2WidgetValue(PART2_NODE_IDS.settings, field.key, value)) updated += 1;
-      else missing.push(`node 736.${field.key}`);
+      else missing.push(field.label);
     }
 
     const useSrt = String(controls.useSrt.value).toLowerCase() !== "false";
     if (setPart2WidgetValue(PART2_NODE_IDS.useSrtSwitch, "switch", useSrt, 0)) updated += 1;
-    else missing.push("node 837.switch");
+    else missing.push("Use SRT Duration toggle");
 
     if (setPart2WidgetValue(PART2_NODE_IDS.camera, "items", controls.cameraItems.value, 1)) updated += 1;
-    else missing.push("node 830.items");
+    else missing.push("Camera motion list");
     if (setPart2WidgetValue(PART2_NODE_IDS.camera, "selection_mode", controls.cameraMode.value, 3)) updated += 1;
-    else missing.push("node 830.selection_mode");
+    else missing.push("Camera motion mode");
 
     if (setPart2WidgetValue(PART2_NODE_IDS.promptJson, null, controls.promptJson.value, 0)) updated += 1;
-    else missing.push("node 543 prompt JSON");
+    else missing.push("Prompt JSON");
 
+    updated += applyLoraControls(missing);
+    updated += applyZImageLoraControls(missing);
     updateFixedDurationVisibility();
+    clearPart2Draft();
     setStatus(missing.length ? `Updated ${updated} settings.\nMissing:\n${missing.join("\n")}` : `Updated ${updated} Part 2 settings.`);
   }
 
@@ -1294,6 +1878,33 @@ function ensurePart2Modal() {
     if (event.target === overlay) closeModal();
   });
   controls.useSrt.addEventListener("change", updateFixedDurationVisibility);
+  controls.lora.useCustom.addEventListener("change", updateLoraVisibility);
+  controls.lora.count.addEventListener("input", updateLoraVisibility);
+  controls.lora.count.addEventListener("change", updateLoraVisibility);
+  controls.zImageLora.useCustom.addEventListener("change", updateZImageLoraVisibility);
+  controls.zImageLora.count.addEventListener("input", updateZImageLoraVisibility);
+  controls.zImageLora.count.addEventListener("change", updateZImageLoraVisibility);
+
+  const draftControls = [
+    ...Object.values(controls.modelSelects),
+    ...Object.values(controls.settings),
+    controls.useSrt,
+    controls.cameraItems,
+    controls.cameraMode,
+    controls.promptJson,
+    controls.lora.useCustom,
+    controls.lora.count,
+    controls.lora.twoPass,
+    controls.zImageLora.useCustom,
+    controls.zImageLora.count,
+  ];
+  for (const slot of controls.lora.slots) draftControls.push(slot.select, slot.strength);
+  for (const slot of controls.zImageLora.slots) draftControls.push(slot.select, slot.strength);
+  for (const control of draftControls) {
+    control?.addEventListener?.("input", savePart2Draft);
+    control?.addEventListener?.("change", savePart2Draft);
+  }
+
   applyButton.addEventListener("click", applyPart2Settings);
   topApplyButton.addEventListener("click", applyPart2Settings);
 


### PR DESCRIPTION
## Summary

- Adds an optional model-only multi-LoRA loader with a safe `[none]` default, dynamic LoRA slots, first/second pass outputs, and LTX two-pass strength handling.
- Adds browser-side widget cleanup for the optional LoRA node so disabled LoRAs do not show stale slots or extra outputs.
- Updates Prompt Creator UI V2 and Part 2 UI with model download buttons, LLM GGUF/mmproj buttons, optional LTX/Z-Image LoRA controls, draft saving while the modal is closed, and user-facing missing-widget messages.
- Adds SRT scene-count validation to the Prompt Map JSON Fixer when `use_srt_file` is enabled.

## Why

Shared workflows need optional LoRA nodes that do not warn or fail when users do not have a default LoRA installed. Part 2 also needs UI controls that can drive both top-level LTX LoRAs and the Z-Image LoRA node inside the subgraph, while preserving motion by using reduced first-pass strength when enabled.

## Validation

- `Z:\ComfyUI\ComfyUI_windows_portable\python_embeded\python.exe -B -m py_compile VRGDG_GeneralNodes2.py`
- `Get-Content -Path web\VRGDG_PromptCreatorUI_V2.js | node --input-type=module --check`
- `Get-Content -Path web\VRGDG_LoraSwitchMulti_dynamic.js | node --input-type=module --check`
- `git diff --check`