### PR TITLE
[codex] Add Step 1 prompt paste button

### DIFF
--- a/VRGDG_GeneralNodes2.py
+++ b/VRGDG_GeneralNodes2.py
@@ -159,6 +159,18 @@ def _get_test_popup_text_path(field_name):
     return os.path.normpath(os.path.join(folder_paths.get_output_directory(), *parts))
 
 
+def _get_part2_concept_prompts_path():
+    return os.path.normpath(
+        os.path.join(
+            folder_paths.get_output_directory(),
+            "VRGDG_TEMP",
+            "TextFiles",
+            "ConceptPrompts",
+            "ConceptPrompts.txt",
+        )
+    )
+
+
 def _ensure_test_save_route_registered():
     global _VRGDG_TEST_SAVE_ROUTE_REGISTERED
     if _VRGDG_TEST_SAVE_ROUTE_REGISTERED:
@@ -179,8 +191,37 @@ def _ensure_test_save_route_registered():
                 "ok": True,
                 "audio_dir": _get_test_popup_audio_dir(),
                 "text_targets": text_targets,
+                "concept_prompts_path": _get_part2_concept_prompts_path(),
             }
         )
+
+    @server_instance.routes.get("/vrgdg/part2/load_concept_prompts")
+    async def vrgdg_part2_load_concept_prompts(request):
+        target_path = _get_part2_concept_prompts_path()
+        if not os.path.isfile(target_path):
+            return web.json_response(
+                {
+                    "ok": False,
+                    "error": "ConceptPrompts.txt was not found. Run Step 1 first or paste the prompt JSON manually.",
+                    "path": target_path,
+                },
+                status=404,
+            )
+
+        try:
+            with open(target_path, "r", encoding="utf-8-sig") as handle:
+                text = handle.read()
+        except Exception as exc:
+            return web.json_response(
+                {
+                    "ok": False,
+                    "error": f"Could not read ConceptPrompts.txt: {exc}",
+                    "path": target_path,
+                },
+                status=500,
+            )
+
+        return web.json_response({"ok": True, "text": text, "path": target_path})
 
     @server_instance.routes.post("/vrgdg/test_popup/save_text")
     async def vrgdg_test_popup_save_text(request):

--- a/web/VRGDG_PromptCreatorUI_V2.js
+++ b/web/VRGDG_PromptCreatorUI_V2.js
@@ -438,6 +438,15 @@ async function saveText(payload) {
   return data;
 }
 
+async function loadPart2ConceptPrompts() {
+  const response = await api.fetchApi("/vrgdg/part2/load_concept_prompts", { cache: "no-store" });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || !data?.ok) {
+    throw new Error(String(data?.error || `Concept prompts load failed (${response.status})`));
+  }
+  return data;
+}
+
 function ensureModal() {
   let overlay = document.getElementById(MODAL_ID);
   if (overlay) return overlay;
@@ -1449,7 +1458,22 @@ function ensurePart2Modal() {
   stylePart2Input(promptJson);
   promptJson.style.resize = "vertical";
   controls.promptJson = promptJson;
-  promptSection.appendChild(createPart2Field("Prompt JSON", promptJson, "This updates the Prompt Splitter node."));
+  const promptField = createPart2Field("Prompt JSON", promptJson, "This updates the Prompt Splitter node.");
+  const promptHeader = promptField.querySelector("div");
+  const pasteFromStep1Button = createButton(
+    "Paste From Step 1",
+    "border: 1px solid #2563eb; background: #1d4ed8; color: white; padding: 6px 9px; font-size: 11px; font-weight: 700;"
+  );
+  if (promptHeader) {
+    promptHeader.style.display = "flex";
+    promptHeader.style.alignItems = "center";
+    promptHeader.style.justifyContent = "space-between";
+    promptHeader.style.gap = "8px";
+    promptHeader.appendChild(pasteFromStep1Button);
+  } else {
+    promptField.insertBefore(pasteFromStep1Button, promptJson);
+  }
+  promptSection.appendChild(promptField);
 
   const status = document.createElement("div");
   status.style.cssText = `
@@ -1786,6 +1810,24 @@ function ensurePart2Modal() {
     return updated;
   }
 
+  async function pastePromptJsonFromStep1() {
+    pasteFromStep1Button.disabled = true;
+    const previousText = pasteFromStep1Button.textContent;
+    pasteFromStep1Button.textContent = "Loading...";
+    try {
+      const data = await loadPart2ConceptPrompts();
+      controls.promptJson.value = String(data.text ?? "");
+      controls.promptJson.dispatchEvent(new Event("input", { bubbles: true }));
+      savePart2Draft();
+      setStatus("Loaded prompt JSON from Step 1. Click Apply Part 2 Settings when ready.");
+    } catch (error) {
+      setStatus(error?.message || "Could not load prompt JSON from Step 1.", true);
+    } finally {
+      pasteFromStep1Button.disabled = false;
+      pasteFromStep1Button.textContent = previousText;
+    }
+  }
+
   function refreshPart2Controls() {
     const missing = [];
     suppressDraftSave = true;
@@ -1884,6 +1926,7 @@ function ensurePart2Modal() {
   controls.zImageLora.useCustom.addEventListener("change", updateZImageLoraVisibility);
   controls.zImageLora.count.addEventListener("input", updateZImageLoraVisibility);
   controls.zImageLora.count.addEventListener("change", updateZImageLoraVisibility);
+  pasteFromStep1Button.addEventListener("click", pastePromptJsonFromStep1);
 
   const draftControls = [
     ...Object.values(controls.modelSelects),


### PR DESCRIPTION
## Summary

- Adds a Part 2 backend endpoint that reads `ConceptPrompts.txt` from the user's ComfyUI output folder at `VRGDG_TEMP/TextFiles/ConceptPrompts/ConceptPrompts.txt`.
- Adds a `Paste From Step 1` button beside the Part 2 Prompt JSON field.
- When clicked, the button overwrites the Prompt JSON textarea with the saved Step 1 prompts and updates the Part 2 UI draft so the text is preserved until Apply is clicked.

## Why

Part 2 users can now load the prompt JSON generated by Step 1 without manually opening and pasting the text file.

## Validation

- `Z:\ComfyUI\ComfyUI_windows_portable\python_embeded\python.exe -B -m py_compile VRGDG_GeneralNodes2.py`
- `Get-Content -Path web\VRGDG_PromptCreatorUI_V2.js | node --input-type=module --check`
- `git diff --check`