### PR TITLE
Allow disabled multi cycling picker count

### DIFF
--- a/VRGDG_GeneralNodes.py
+++ b/VRGDG_GeneralNodes.py
@@ -2810,10 +2810,10 @@ Peaceful""",
             "picker_count": (
                 "INT",
                 {
-                    "default": 2,
-                    "min": 1,
+                    "default": 0,
+                    "min": 0,
                     "max": cls.MAX_PICKERS,
-                    "tooltip": "How many independent cycling text pickers to use. Extra picker sections are hidden in the UI.",
+                    "tooltip": "How many independent cycling text pickers to use. Set 0 to disable advanced prompt details.",
                 },
             ),
             "joiner": (


### PR DESCRIPTION
## Summary

Updates only `VRGDG_MultiCyclingTextPicker` so its `picker_count` input contract matches the current working-copy logic and PromptCreator UI behavior.

## Root Cause

The UI can intentionally send `picker_count = 0` when advanced prompt details are disabled, but PROD still declared `picker_count` with `min: 1`, so ComfyUI rejected the prompt during validation before the node could run.

## Validation

- Confirmed diff is limited to `VRGDG_GeneralNodes.py`
- Confirmed change is only the picker node `picker_count` default/min/tooltip metadata
- Ran `python -B -m py_compile VRGDG_GeneralNodes.py`