### PR TITLE
[codex] Add Whisper and opening scene fallbacks

### DIFF
--- a/GeneralVideoNodes.py
+++ b/GeneralVideoNodes.py
@@ -2445,6 +2445,49 @@ class BeatSceneDurationNode:
             ms = int((seconds - int(seconds)) * 1000)
             return f"{h:02}:{m:02}:{s:02},{ms:03}"
 
+        def to_seconds(timestamp):
+            h, m, rest = timestamp.split(":")
+            s, ms = rest.split(",")
+            return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000.0
+
+        def merge_short_first_scene_if_needed(lines, min_first_duration=1.5):
+            # Short-first-scene guard:
+            # Some beat maps can still create an opening cut that is only a few
+            # frames long. Keep this as a final, isolated SRT cleanup so it can
+            # be removed easily if we ever want to revert this behavior.
+            blocks = []
+            for block in "\n".join(lines).strip().split("\n\n"):
+                block_lines = [line.strip() for line in block.splitlines() if line.strip()]
+                if len(block_lines) < 2 or "-->" not in block_lines[1]:
+                    continue
+                start_txt, end_txt = [part.strip() for part in block_lines[1].split("-->")]
+                blocks.append({
+                    "start": to_seconds(start_txt),
+                    "end": to_seconds(end_txt),
+                })
+
+            if len(blocks) < 2:
+                return lines
+
+            first_duration = blocks[0]["end"] - blocks[0]["start"]
+            if first_duration >= float(min_first_duration):
+                return lines
+
+            print(
+                "[BeatSceneDurationNode] Merging short first scene into scene 2: "
+                f"duration={first_duration:.3f}s, threshold={float(min_first_duration):.3f}s"
+            )
+            blocks[1]["start"] = blocks[0]["start"]
+            blocks = blocks[1:]
+
+            rebuilt = []
+            for idx, block in enumerate(blocks, 1):
+                rebuilt.append(str(idx))
+                rebuilt.append(f"{format_time(block['start'])} --> {format_time(block['end'])}")
+                rebuilt.append(f"SCENE {idx}")
+                rebuilt.append("")
+            return rebuilt
+
         srt_lines = []
         current_time = 0.0
         scene_index = 1
@@ -2659,6 +2702,9 @@ class BeatSceneDurationNode:
 
 
         ###############
+        srt_lines = merge_short_first_scene_if_needed(srt_lines)
+        scene_index = len([line for line in srt_lines if line.strip().isdigit()]) + 1
+
         # Save next to THIS custom node file, inside /SRT_Files
         node_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/HumoAutomationExtra2.py
+++ b/HumoAutomationExtra2.py
@@ -42,9 +42,33 @@ def _is_whisper_dtype_mismatch_error(exc):
     )
 
 
+def _is_whisper_mel_length_error(exc):
+    message = str(exc).lower()
+    return (
+        "whisper expects the mel input features to be of length 3000" in message
+        and "found" in message
+    )
+
+
+def _whisper_pad_input_features(input_features, target_length=3000):
+    current_length = input_features.shape[-1]
+    if current_length == target_length:
+        return input_features
+    if current_length > target_length:
+        return input_features[..., :target_length].contiguous()
+    return torch.nn.functional.pad(input_features, (0, target_length - current_length))
+
+
 def _whisper_generate_with_dtype_fallback(model, input_features, fallback_device, **kwargs):
     try:
         return model.generate(input_features, **kwargs)
+    except ValueError as exc:
+        if not _is_whisper_mel_length_error(exc):
+            raise
+
+        print("[Whisper] Retrying with mel input features padded to length 3000.")
+        padded_features = _whisper_pad_input_features(input_features)
+        return model.generate(padded_features, **kwargs)
     except RuntimeError as exc:
         if not _is_whisper_dtype_mismatch_error(exc):
             raise


### PR DESCRIPTION
## Summary

Adds two narrow fallback fixes:

- Pads Whisper mel input features to length 3000 only when Transformers raises that exact mel-length error.
- Merges scene 1 into scene 2 when `BeatSceneDurationNode` produces a first scene shorter than 1.5 seconds.

## Root Cause

Short audio segments can produce shorter mel input features, such as length 750. Whisper generation expects length 3000 and raises before transcription completes, which can leave downstream prompt/SRT counts mismatched.

Some beat maps can also produce an opening SRT cut that is only a few frames long. The new scene guard runs as an isolated final SRT cleanup so it can be removed easily if this behavior needs to be reverted.

## Change

When the exact Whisper ValueError appears, the node pads or truncates the mel feature dimension to 3000 and retries generation once. Other ValueErrors and the existing dtype fallback behavior are unchanged.

When `BeatSceneDurationNode` finishes building its SRT, it checks only the first scene. If scene 1 is shorter than 1.5 seconds and scene 2 exists, it merges scene 1 into scene 2 and renumbers the SRT.

## Validation

- `python -B -m py_compile HumoAutomationExtra2.py`
- `python -B -m py_compile GeneralVideoNodes.py HumoAutomationExtra2.py`
- `git diff --check`