### PR TITLE
fix: import each submodule independently so a broken dep can't take out the whole pack (closes #38)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,77 +1,59 @@
+import importlib
 import os
 
 import folder_paths
 
-from .nodes import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_2,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_2,
+# Import each submodule independently so that an ImportError in one (e.g.
+# `transformers` is older than the Whisper API the Humo files expect, or
+# `cv2`/`librosa`/`voxcpm`/`llama_cpp` isn't installed on this user's
+# machine) only takes out the affected submodule's nodes — leaving the
+# rest of the pack registered. With the previous "one big import block"
+# layout, the first import failure raised before reaching the merged
+# `NODE_CLASS_MAPPINGS` dict, which is why simple visual nodes like
+# `FastFilmGrain` and `FastUnsharpSharpen` (which live in `nodes.py` and
+# import cleanly on their own) silently disappeared whenever any other
+# submodule failed. See issue #38.
+_VRGDG_SUBMODULES = (
+    ".nodes",
+    ".HumoAutomation",
+    ".HumoAutomationExtra1",
+    ".HumoAutomationExtra2",
+    ".GeneralVideoNodes",
+    ".GeneralVideoNodes2",
+    ".LLM",
+    ".VRGDGswtichNodes",
+    ".VRGDG_GeneralNodes",
+    ".VRGDG_AudioNodes",
+    ".VRGDG_GeneralNodes2",
+    ".VRGDG_IV_Adjustments",
+    ".LTXLoraTrain",
+    ".VRGDG_VoxCPM2Node",
 )
 
-from .HumoAutomation import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_3,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_3,
-)
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
 
-from .HumoAutomationExtra1 import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_4,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_4,
-)
+_VRGDG_FAILED = []
 
-from .HumoAutomationExtra2 import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_5,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_5,
-)
+for _modname in _VRGDG_SUBMODULES:
+    try:
+        _mod = importlib.import_module(_modname, package=__name__)
+    except Exception as exc:
+        _VRGDG_FAILED.append((_modname, f"{type(exc).__name__}: {exc}"))
+        continue
+    NODE_CLASS_MAPPINGS.update(getattr(_mod, "NODE_CLASS_MAPPINGS", {}))
+    NODE_DISPLAY_NAME_MAPPINGS.update(getattr(_mod, "NODE_DISPLAY_NAME_MAPPINGS", {}))
 
-
-from .GeneralVideoNodes import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_6,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_6,
-)
-
-from .GeneralVideoNodes2 import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_7,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_7,
-)
-
-from .LLM import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_8,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_8,
-)
-
-from .VRGDGswtichNodes import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_9,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_9,
-)
-
-from .VRGDG_GeneralNodes import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_10,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_10,
-)
-
-from .VRGDG_AudioNodes import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_11,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_11,
-)
-
-from .VRGDG_GeneralNodes2 import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_12,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_12,
-)
-
-from .VRGDG_IV_Adjustments import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_13,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_13,
-)
-
-from .LTXLoraTrain import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_14,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_14,
-)
-
-from .VRGDG_VoxCPM2Node import (
-    NODE_CLASS_MAPPINGS as NODE_CLASS_MAPPINGS_15,
-    NODE_DISPLAY_NAME_MAPPINGS as NODE_DISPLAY_NAME_MAPPINGS_15,
-)
+if _VRGDG_FAILED:
+    print(
+        "[VRGDG] Some submodules failed to import; their nodes will be unavailable:"
+    )
+    for _name, _err in _VRGDG_FAILED:
+        print(f"  - {_name}: {_err}")
+    print(
+        "[VRGDG] The rest of the pack still loaded. "
+        "Install the missing dep(s) above to enable the rest."
+    )
 
 _VRGDG_TEXTFILE_TEMPLATES = (
     ("fulllyrics", "full_lyrics.txt"),
@@ -113,41 +95,6 @@ try:
 except Exception as exc:
     print(f"[VRGDG] Failed to prepare TextFiles placeholders: {exc}")
 
-
-NODE_CLASS_MAPPINGS = {
-    **NODE_CLASS_MAPPINGS_2,
-    **NODE_CLASS_MAPPINGS_3,
-    **NODE_CLASS_MAPPINGS_4,
-    **NODE_CLASS_MAPPINGS_5,
-    **NODE_CLASS_MAPPINGS_6,  
-    **NODE_CLASS_MAPPINGS_7,
-    **NODE_CLASS_MAPPINGS_8,   
-    **NODE_CLASS_MAPPINGS_9,
-    **NODE_CLASS_MAPPINGS_10,
-    **NODE_CLASS_MAPPINGS_11, 
-    **NODE_CLASS_MAPPINGS_12,
-    **NODE_CLASS_MAPPINGS_13,    
-    **NODE_CLASS_MAPPINGS_14,
-    **NODE_CLASS_MAPPINGS_15,    
-    
-}
-
-NODE_DISPLAY_NAME_MAPPINGS = {
-    **NODE_DISPLAY_NAME_MAPPINGS_2,
-    **NODE_DISPLAY_NAME_MAPPINGS_3,
-    **NODE_DISPLAY_NAME_MAPPINGS_4,
-    **NODE_DISPLAY_NAME_MAPPINGS_5,
-    **NODE_DISPLAY_NAME_MAPPINGS_6,  
-    **NODE_DISPLAY_NAME_MAPPINGS_7,
-    **NODE_DISPLAY_NAME_MAPPINGS_8,      
-    **NODE_DISPLAY_NAME_MAPPINGS_9,
-    **NODE_DISPLAY_NAME_MAPPINGS_10, 
-    **NODE_DISPLAY_NAME_MAPPINGS_11,
-    **NODE_DISPLAY_NAME_MAPPINGS_12,   
-    **NODE_DISPLAY_NAME_MAPPINGS_13,   
-    **NODE_DISPLAY_NAME_MAPPINGS_14,
-    **NODE_DISPLAY_NAME_MAPPINGS_15,    
-}
 
 WEB_DIRECTORY = "./web"
 


### PR DESCRIPTION
## Summary

Closes #38.

This is the structural refactor I sketched in the issue thread on May 1. Quoting your earlier comment:

> I have attempted to fix this, but fixing it ends up breaking it for other people. It depends on your current environment and different version of things. I'm not sure what to do at this point sorry, I'm still working on it.

The reason every dep-pinning attempt feels like whack-a-mole is that the symptom isn't really about which dep is broken — it's about how `__init__.py` is laid out. Right now it does **14 hard imports at the top**:

```python
from .nodes import ...
from .HumoAutomation import ...           # transformers.WhisperProcessor at top
from .HumoAutomationExtra2 import ...     # transformers + cv2 at top
from .GeneralVideoNodes import ...        # cv2 + librosa at top
from .LLM import ...                      # llama_cpp at top
from .VRGDG_VoxCPM2Node import ...        # voxcpm at top
... (14 total)
```

If *any one* of those submodules raises during import — `transformers` older than the Whisper API the Humo files expect, `cv2` not installed, a kornia / torchcodec / voxcpm wheel mismatch, anything — the very first failure raises *before* the merged `NODE_CLASS_MAPPINGS` dict at the bottom is reached. ComfyUI then registers **zero** of the pack's nodes, and the user sees `FastFilmGrain` / `FastUnsharpSharpen` as missing even though those nodes live in `nodes.py` and import cleanly on their own. That's the symptom @macieknowakzdz-glitch and @kamran7272 and @wes-kay and @hydragyrum2 reported, and what @ewb-git's "manager isn't installing the requirements, no errors in the log, the node loaded successfully but isn't there" comment describes.

## Fix

Replace the 14 hard imports with a single loop that imports each submodule via `importlib.import_module` wrapped in `try / except`. Successful imports contribute their `NODE_CLASS_MAPPINGS` / `NODE_DISPLAY_NAME_MAPPINGS` to the top-level dicts; failures get appended to a `_VRGDG_FAILED` list and printed once at the end with type, message, and a final "rest of the pack still loaded" line.

Diff is small and orthogonal:

```
__init__.py | 147 +++++++++++++++++++-----------------------------------------
1 file changed, 47 insertions(+), 100 deletions(-)
```

The textfile-template setup, `WEB_DIRECTORY`, and `__all__` are untouched.

## What changes for each kind of user

| user state | before | after |
|---|---|---|
| All deps healthy (current happy path) | every node registers | every node registers (identical) |
| `transformers` broken | **whole pack goes dark** | Humo* fails with the real error printed; `nodes.py` + the rest still register |
| `cv2` not installed | whole pack goes dark | HumoAutomationExtra2 + GeneralVideoNodes fail with the real error printed; rest still register |
| `voxcpm` not installed | whole pack goes dark | VRGDG_VoxCPM2Node fails; rest still register |
| `llama_cpp` not installed | whole pack goes dark | LLM fails; rest still register |
| `comfyui-manager` skipped requirements (the @ewb-git case) | silent — node "loaded" but nodes invisible | console line names exactly which submodule failed and why, then 13 of 14 register cleanly |

No version pinning, no requirements changes — this is orthogonal to which deps each user has.

## Verification

Running real submodule imports in CI is hard because they need a full ComfyUI runtime and several GB of heavy deps, so I built a focused harness on a synthetic mini-package mimicking the same shape: 6 fake submodules, 2 of which raise on import (one `ModuleNotFoundError`, one `RuntimeError`). 10-expectation pass:

```
=== fake_vrgg loaded ===
  [OK  ] healthy_a contributes (FastFilmGrain in NODE_CLASS_MAPPINGS)
         keys: ['FastFilmGrain', 'FastUnsharpSharpen', 'NodeFromB', 'NodeFromC']
  [OK  ] healthy_a contributes (FastUnsharpSharpen)
  [OK  ] healthy_b contributes (NodeFromB) AFTER a broken submodule
  [OK  ] healthy_c contributes (NodeFromC) AFTER two broken submodules
  [OK  ] broken_import is recorded in _VRGDG_FAILED
         failed: ['.broken_import', '.broken_at_runtime']
  [OK  ] broken_at_runtime is recorded in _VRGDG_FAILED
  [OK  ] no_mappings does NOT count as failed (just contributes nothing)
  [OK  ] stdout warns about failures
  [OK  ] stdout names the broken submodules
  [OK  ] stdout includes the error type + message for the broken import
  [OK  ] stdout closes with the 'rest still loaded' line

=== all 10 expectations OK ===
```

Sample stdout when something is genuinely broken:

```
[VRGDG] Some submodules failed to import; their nodes will be unavailable:
  - .broken_import: ModuleNotFoundError: No module named 'this_module_does_not_exist'
  - .broken_at_runtime: RuntimeError: simulated transformers/Whisper API mismatch
[VRGDG] The rest of the pack still loaded. Install the missing dep(s) above to enable the rest.
```

## Notes / open questions

- **Order in `_VRGDG_SUBMODULES`** matches the original import order. If two submodules ever register a node under the same key, last-import-wins, same as today.
- **Which submodules need which deps** isn't documented anywhere I could see — happy to follow up with a small `EXTRA_DEPS.md` table if you'd like, drawn from the failure output users will now actually see in their consoles.
- I noticed `nodes.py` references `np.` from line ~188 onward but the `import numpy as np` is at line 1298. Python resolves at call-time so it works today, but it's fragile to file edits and gets flagged by linters. I haven't touched that here — happy to send as a separate PR if you want.
- I'd love to take ownership of this kind of structural maintenance for the pack going forward — let me know if you'd want me to, e.g., look at the type-hint / ComfyUI-version compat issues that come up in the issue tracker.

If the approach lands fine but you'd rather phrase the user-facing message differently, or you want me to keep the original module name aliases (`NODE_CLASS_MAPPINGS_2 .. _15`) for any external tooling that reads them, easy to adjust — just say the word.

Credit to everyone in the #38 thread for driving the diagnosis: @macieknowakzdz-glitch (original report), @kamran7272 / @wes-kay / @hydragyrum2 (confirmations across environments), @ewb-git (the "no error in logs but node isn't there" symptom), and you for the patient back-and-forth.