### PR TITLE
fix: read SRT files from the same dir they are saved to

### DIFF
--- a/GeneralVideoNodes.py
+++ b/GeneralVideoNodes.py
@@ -2996,7 +2996,7 @@ class VRGDG_LatestSRTAutoLoader:
     @staticmethod
     def _get_srt_dir():
         node_dir = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(node_dir, "srt_files")
+        return os.path.join(node_dir, "SRT_Files")
 
     @classmethod
     def _get_latest_srt_info(cls):


### PR DESCRIPTION
### Summary

`VRGDG_LatestSRTAutoLoader._get_srt_dir()` reads from a `srt_files` directory, but SRT files are written to `SRT_Files` (the save path at `GeneralVideoNodes.py:2712`, matching the `# ... inside /SRT_Files` comment). On case-sensitive filesystems (Linux, macOS) `srt_files` and `SRT_Files` are different directories, so the auto-loader never finds the saved files and raises `SRT folder does not exist`. On Windows the casing happens to match so it works by accident — which is why this only affects Linux/macOS users.

Reported in #85, where the user worked around it by copying `SRT_Files` → `srt_files` by hand.

### Fix

Point the read path at the same directory the write path uses (`SRT_Files`). One line.

Closes #85