### PR TITLE
Add V9 dev branch switcher node

### DIFF
--- a/VRGDG_TryV9Dev.py
+++ b/VRGDG_TryV9Dev.py
@@ -1,0 +1,84 @@
+import asyncio
+import os
+import subprocess
+
+from aiohttp import web
+from server import PromptServer
+
+
+V9_BRANCH = "dev/music-video-builder-ui-test-v9"
+_NODE_DIR = os.path.dirname(os.path.abspath(__file__))
+_ROUTES_REGISTERED = False
+
+
+def _run_git(*args):
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=_NODE_DIR,
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=300,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("Git was not found. Install Git, then try again.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Git timed out. Check your internet connection and try again.") from exc
+
+    output = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
+    if result.returncode != 0:
+        command = "git " + " ".join(args)
+        raise RuntimeError(f"{command} failed:\n{output or 'Git returned an unknown error.'}")
+    return output
+
+
+def _switch_to_v9():
+    if not os.path.isdir(os.path.join(_NODE_DIR, ".git")):
+        raise RuntimeError("This installation is not a Git checkout, so Git cannot switch branches.")
+
+    logs = []
+    for args in (("fetch", "origin"), ("switch", V9_BRANCH), ("pull",)):
+        logs.append({"command": "git " + " ".join(args), "output": _run_git(*args)})
+
+    branch = _run_git("branch", "--show-current").strip()
+    if branch != V9_BRANCH:
+        raise RuntimeError(f"Git finished on '{branch or '(detached HEAD)'}' instead of '{V9_BRANCH}'.")
+    return {"branch": branch, "logs": logs}
+
+
+def _register_routes():
+    global _ROUTES_REGISTERED
+    if _ROUTES_REGISTERED:
+        return
+
+    @PromptServer.instance.routes.post("/vrgdg/try_v9_dev")
+    async def vrgdg_try_v9_dev(request):
+        try:
+            result = await asyncio.to_thread(_switch_to_v9)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        return web.json_response({"ok": True, **result})
+
+    _ROUTES_REGISTERED = True
+
+
+class VRGDG_TryV9Dev:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("instructions",)
+    FUNCTION = "instructions"
+    CATEGORY = "VRGDG/Update"
+
+    def instructions(self):
+        return ("Use the button on this node to switch this installation from main to the V9 development branch.",)
+
+
+_register_routes()
+
+NODE_CLASS_MAPPINGS = {"VRGDG_TryV9Dev": VRGDG_TryV9Dev}
+NODE_DISPLAY_NAME_MAPPINGS = {"VRGDG_TryV9Dev": "VRGDG - Try V9 Dev"}

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ _VRGDG_SUBMODULES = (
     ".LTXLoraTrain",
     ".VRGDG_VoxCPM2Node",
     ".VRGDG_LTXICIngredientsGrid",
+    ".VRGDG_TryV9Dev",
 )
 
 _VRGDG_OPTIONAL_SUBMODULES = (

--- a/web/VRGDG_TryV9Dev.js
+++ b/web/VRGDG_TryV9Dev.js
@@ -1,0 +1,63 @@
+import { app } from "../../../scripts/app.js";
+import { api } from "../../../scripts/api.js";
+
+const NODE_NAME = "VRGDG_TryV9Dev";
+
+app.registerExtension({
+  name: "vrgdg.TryV9Dev",
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_NAME) return;
+
+    const originalCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      originalCreated?.apply(this, arguments);
+      this.setSize([380, 180]);
+
+      const status = this.addWidget("text", "status", "Ready to switch this installation to V9 Dev.", () => {}, {
+        multiline: true,
+      });
+      status.disabled = true;
+      status.serialize = false;
+
+      this.addWidget("button", "What does this do?", null, () => {
+        window.alert(
+          "This switches the existing comfyui-vrgamedevgirl folder from the main branch to V9 Dev.\n\n" +
+          "It runs:\n" +
+          "git fetch origin\n" +
+          "git switch dev/music-video-builder-ui-test-v9\n" +
+          "git pull\n\n" +
+          "It does not install a second copy, run git reset, run git clean, or delete files you created. Git stops if switching would overwrite conflicting work."
+        );
+      });
+
+      const updateButton = this.addWidget("button", "Switch to V9 Dev", null, async () => {
+        if (!window.confirm(
+          "Switch this VRGDG installation from main to V9 Dev?\n\n" +
+          "This runs the same fetch, switch, and pull commands as the manual instructions. Continue?"
+        )) return;
+
+        updateButton.disabled = true;
+        status.value = "Fetching and switching to V9 Dev...";
+        this.setDirtyCanvas(true, true);
+        try {
+          const response = await api.fetchApi("/vrgdg/try_v9_dev", { method: "POST" });
+          let payload = {};
+          try { payload = await response.json(); } catch (_) { payload = {}; }
+          if (!response.ok || !payload.ok) {
+            throw new Error(payload.error || `Update failed (HTTP ${response.status}).`);
+          }
+          status.value = "V9 Dev installed. Fully restart ComfyUI and hard-refresh the browser.";
+          window.alert(
+            "Switched to V9 Dev successfully.\n\nFully stop and restart ComfyUI, then hard-refresh the browser page."
+          );
+        } catch (error) {
+          status.value = `Switch did not complete: ${error?.message || error}`;
+          window.alert(`Switch to V9 Dev did not complete:\n\n${error?.message || error}`);
+        } finally {
+          updateButton.disabled = false;
+          this.setDirtyCanvas(true, true);
+        }
+      });
+    };
+  },
+});


### PR DESCRIPTION
## What changed

- Adds a `VRGDG - Try V9 Dev` node to the main branch.
- Adds an on-node help button explaining the exact Git operations.
- Adds a confirmed `Switch to V9 Dev` action that runs `git fetch origin`, `git switch dev/music-video-builder-ui-test-v9`, and `git pull` in the installed custom-node directory.
- Shows Git errors in the node and instructs users to fully restart ComfyUI and hard-refresh after success.

## Why

This gives users on the normal main branch an opt-in, guided way to switch their existing installation to the V9 development branch without cloning a second copy or opening a terminal.

## Safety and impact

The action follows the documented manual Git workflow. It does not run `git reset` or `git clean`, does not delete untracked files, and does not touch other custom-node folders. Git stops normally if local work conflicts with the branch switch.

## Checks

- `python -B -m py_compile VRGDG_TryV9Dev.py __init__.py`
- JavaScript module syntax check with Node.js
- `git diff --check`
