### PR TITLE
Polish Builder navigation and status layout

### DIFF
--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -40,7 +40,7 @@ If this guide or the LTX 2.3 Video Builder helps you, you can support VR Game De
 - [LLM Runner](#llm-runner)
 - [Batch Buttons and Full Builds](#batch-buttons-and-full-builds)
 - [Post Process](#post-process)
-- [Prompt Creator Panel](#prompt-creator-panel)
+- [Prompt Creator (Legacy)](#prompt-creator-legacy)
 - [Prompt Creator Import](#prompt-creator-import)
 - [Settings And Audio Notifications](#settings-and-audio-notifications)
 - [Required Custom Nodes](#required-custom-nodes)
@@ -2068,7 +2068,6 @@ The `Menu` contains batch tools that can work across many scenes.
 | `Image Slideshow Preview` | Builds a preview from the current scene images, their timeline durations, and the matching global-audio range without rendering scene videos |
 | `Build Full Video` | Runs the larger pipeline from prompts/images/videos through final stitch |
 | `Build Full FLF Video` | Runs the First/Last Frame endpoint, image-chain, prompt, render, final-frame extraction, and stitch stages |
-| `Remake Mode` | Helps rerun or rebuild outputs |
 | `Stop` | Stops the current workflow run |
 
 In `Reference to Video` mode, `LLM Video All` can use the Storyboard prompt writer when launched through the Wizard. In `Ingredients to Video` mode, make sure Ingredients sheets are mapped before running the batch prompt step.
@@ -2149,11 +2148,13 @@ To post-process a scene:
 6. Apply the chosen result, verify the correct history item is selected, and save the project.
 7. Test one scene before repeating the same treatment across the project.
 
-## Prompt Creator Panel
+## Prompt Creator (Legacy)
 
-The Prompt Creator is the companion UI for turning a song, lyrics, SRT timing, and user ideas into concept prompts and motion notes.
+Prompt Creator is the older, file-based planning workflow for turning a song, lyrics, SRT timing, and user ideas into concept prompts and motion notes. It remains available for older projects and users who specifically need its saved prompt-package workflow.
 
-Use Prompt Creator when you want the builder to start from a planned prompt package instead of writing every scene manually.
+For new projects, use Storyboard Builder. It is the newer workflow for keeping story direction, scene beats, references, image defaults, motion defaults, and generated prompts together in the same project.
+
+`New Project` now opens Video Builder directly. To use the older workflow, open `Prompt Creator (Legacy)` from the Builder tools. Read the warning and choose either `Continue to Prompt Creator` or `Continue to Video Builder`.
 
 Prompt Creator can create:
 
@@ -2246,7 +2247,7 @@ Useful buttons:
 
 | Button | What it does |
 | --- | --- |
-| `Prompt Creator` | Opens the Prompt Creator panel |
+| `Prompt Creator (Legacy)` | Shows the legacy-workflow warning before opening Prompt Creator |
 | `Import Data From Prompt Creator` | Copies Prompt Creator outputs into the current builder project |
 | `Send To Video Creator` | From Prompt Creator, saves/imports the current prompt creator project into Video Builder |
 | `Send To Prompt Creator` | From Video Builder, sends audio/SRT/lyrics back to Prompt Creator so you can create concept prompts |
@@ -2528,9 +2529,9 @@ Use this when you have a song and want better lip-sync behavior.
 12. Run `Gemma I2V All` or `Build Full Video`.
 13. Stitch or build the final video.
 
-### Prompt Creator Workflow
+### Legacy Prompt Creator Workflow
 
-Use this when Prompt Creator makes your concept prompts and motion notes.
+Use this only for an older Prompt Creator project or when you specifically need its file-based concept prompt and motion-note package.
 
 1. Open Prompt Creator.
 2. Add audio and full lyrics.
@@ -2552,16 +2553,14 @@ Use this when each scene needs a planned visual destination or continuous handof
 6. Use `Render All` after the endpoints are approved, or `Build Full FLF Video` to finish missing FLF dependencies and stitch automatically.
 7. Prefer resume choices until you intentionally want to replace completed work.
 
-### No Prompt Creator Workflow
+### Recommended Video Builder Workflow
 
-Use this when you want to work directly in Video Builder.
+Use this for new projects.
 
 1. Add audio.
-2. Use Lyric Mapping to create or fill scenes.
-3. Add Director Notes for still image direction.
-4. Add Video Notes for motion direction.
-5. Use Reference Builder if you need consistent characters or locations.
-6. Run Gemma prompts and generate media.
+2. Create or import the timeline scenes.
+3. Open Storyboard Builder to review or refine the shared story layer, story beats, references, image defaults, motion defaults, and individual scene cards.
+4. Run the image and video prompt tools, review the results, and generate media.
 
 ## Common Problems
 

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -42,7 +42,6 @@ import {
 
 const NODE_NAME = "VRGDG_MusicVideoBuilderUI";
 const BUILDER_UI_VERSION = "welcome-startup-2026-05-20";
-const V10_STATUS_DISMISS_KEY = "vrgdg:v10-update-status-dismissed";
 const HIDDEN_WIDGETS = new Set(["audio_path", "project_folder", "session_path", "srt_path"]);
 const DEFAULT_I2V_UNET = "LTX-2.3-22B-distilled-1.1-Q6_K.gguf";
 const DEFAULT_I2V_DIFFUSION_MODEL = "LTX_8bit\\ltx-2.3-22b-dev_transformer_only_int8_convrot.safetensors";
@@ -1845,7 +1844,7 @@ function openBuilder(node) {
     width: min(1800px, calc(100vw - 24px));
     height: min(920px, calc(100vh - 24px));
     display: grid;
-    grid-template-rows: auto auto minmax(0,1fr) minmax(230px, 34vh);
+    grid-template-rows: auto minmax(0,1fr) minmax(230px, 34vh);
     background: #18181b;
     color: #fafafa;
     border: 1px solid #3f3f46;
@@ -1857,7 +1856,7 @@ function openBuilder(node) {
     width: 100vw;
     height: 100vh;
     display: grid;
-    grid-template-rows: auto auto minmax(0,1fr) minmax(230px, 34vh);
+    grid-template-rows: auto minmax(0,1fr) minmax(230px, 34vh);
     background: #18181b;
     color: #fafafa;
     border: 0;
@@ -1885,7 +1884,6 @@ function openBuilder(node) {
   updateStatusClose.style.cssText = "width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;padding:0;border:1px solid rgba(255,255,255,.32);border-radius:5px;background:rgba(0,0,0,.18);color:inherit;font:700 18px/1 sans-serif;cursor:pointer;";
   updateStatusBanner.append(updateStatusDot, updateStatusText, updateStatusAction, updateStatusClose);
 
-  let updateStatusDismissToken = "";
   const setUpdateStatusAppearance = (kind, text, detail = "") => {
     const styles = {
       current: { background: "#14532d", border: "#22c55e", dot: "#86efac", shadow: "rgba(134,239,172,.22)" },
@@ -1905,9 +1903,6 @@ function openBuilder(node) {
 
   updateStatusClose.onclick = () => {
     updateStatusBanner.style.display = "none";
-    if (updateStatusDismissToken) {
-      try { localStorage.setItem(V10_STATUS_DISMISS_KEY, updateStatusDismissToken); } catch (_) { /* Storage may be disabled. */ }
-    }
   };
 
   const refreshV10UpdateStatus = async () => {
@@ -1924,14 +1919,6 @@ function openBuilder(node) {
       const behind = Math.max(0, Number(payload.behind || 0));
       const wrongBranch = Boolean(payload.expected_branch) && payload.branch !== payload.expected_branch;
       const isOutdated = Boolean(payload.outdated) || behind > 0 || wrongBranch;
-      updateStatusDismissToken = `${installed}:${latest}:${isOutdated ? "outdated" : "current"}`;
-      let dismissed = "";
-      try { dismissed = localStorage.getItem(V10_STATUS_DISMISS_KEY) || ""; } catch (_) { /* Storage may be disabled. */ }
-      if (dismissed === updateStatusDismissToken) {
-        updateStatusBanner.style.display = "none";
-        return;
-      }
-
       if (isOutdated) {
         const countText = `${behind} commit${behind === 1 ? "" : "s"} behind`;
         const reason = wrongBranch
@@ -1971,6 +1958,8 @@ function openBuilder(node) {
   pickAudioButton.textContent = "Choose Audio";
   pickSrtButton.textContent = "Choose SRT";
   const settingsButton = makeButton("Settings");
+  const reviewGuideButton = makeButton("Review Guide");
+  reviewGuideButton.title = "Open the LTX 2.3 Video Builder guide on GitHub.";
   const loadButton = makeButton("Load Audio", "primary");
   const loadSrtButton = makeButton("Load SRT", "primary");
   const menuButton = makeButton("Menu");
@@ -1995,7 +1984,7 @@ function openBuilder(node) {
     restoreBrowserAiDownloadsQuietly().catch(() => null);
     overlay.remove();
   };
-  const promptCreatorButton = makeButton("Prompt Creator");
+  const promptCreatorButton = makeButton("Prompt Creator (Legacy)");
   const autoLoadAllButton = makeButton("Import Data From Prompt Creator");
   const importSceneNotesButton = makeButton("Import Scene Notes JSON");
   const wizardButton = makeButton("Wizard", "primary");
@@ -2018,7 +2007,6 @@ function openBuilder(node) {
   const importImageFolderButton = makeButton("Fill Timeline Images From Folder", "primary");
   const fullBuildButton = makeButton("Build Full Video");
   const fullFLFBuildButton = makeButton("Build Full FLF Video");
-  const remakeModeButton = makeButton("Remake Mode");
   const stopWorkflowButton = makeButton("Stop");
   const downloadModelsButton = makeButton("Download Models");
   const buyMeACoffeeButton = makeBuyMeACoffeeButton();
@@ -2044,7 +2032,7 @@ function openBuilder(node) {
     button.style.justifyContent = "flex-start";
   };
   menuDropdown.append(buyMeACoffeeButton);
-  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton, remakeModeButton]) {
+  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, reviewGuideButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton]) {
     styleMenuItem(button);
     menuDropdown.append(button);
   }
@@ -2157,7 +2145,7 @@ function openBuilder(node) {
   let beatCalibrationDraft = null;
   toolsPane.append(
     toolIntro,
-    makeToolRow(promptCreatorButton, "Open Prompt Creator to build source text, SRT timing, concept prompts, and context files."),
+    makeToolRow(promptCreatorButton, "Legacy workflow. Storyboard Builder is the newer, recommended way to plan story beats, references, defaults, and scene prompts."),
     makeToolRow(sendToPromptCreatorButton, "Send this Video Builder timeline back into Prompt Creator as an editable draft."),
     makeToolRow(autoLoadAllButton, "Import the latest Prompt Creator outputs into this project, including timing and prompt data."),
     makeToolRow(importSceneNotesButton, "Load a scene-notes JSON file and map its notes onto the current scenes."),
@@ -4610,7 +4598,10 @@ function openBuilder(node) {
   sceneAudio.preload = "metadata";
   updateGlobalAudioMuteButton();
 
-  shell.append(updateStatusBanner, topbar, main, timeline);
+  const shellHeader = document.createElement("div");
+  shellHeader.style.cssText = "display:flex;flex-direction:column;min-width:0;min-height:0;";
+  shellHeader.append(updateStatusBanner, topbar);
+  shell.append(shellHeader, main, timeline);
   overlay.append(shell);
   document.body.append(overlay);
   refreshV10UpdateStatus();
@@ -29827,11 +29818,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const choice = await showWelcomeProjectModal([], projectsLoader);
     if (!choice) return false;
     if (choice.action === "new") {
-      const mode = await window.VRGDGMusicVideoPromptCreator?.chooseNewProjectMode?.();
-      if (!mode) return false;
-      const created = await newProject();
-      if (created && mode === "prompt_creator") openPromptCreatorPanel();
-      return Boolean(created);
+      return Boolean(await newProject());
     }
     if (choice.action === "load" && choice.project_folder) {
       return await loadSessionFromProject(choice.project_folder);
@@ -38439,24 +38426,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     input.click();
   }
 
-  function showRemakeModeComingSoon() {
-    const backdrop = document.createElement("div");
-    backdrop.style.cssText = "position:fixed;inset:0;z-index:100006;background:rgba(0,0,0,.58);display:flex;align-items:center;justify-content:center;";
-    const box = document.createElement("div");
-    box.style.cssText = "width:min(420px,calc(100vw - 40px));border:1px solid #155e75;border-radius:8px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
-    const title = document.createElement("div");
-    title.textContent = "Remake Mode";
-    title.style.cssText = "font-size:16px;font-weight:900;color:#cffafe;";
-    const body = document.createElement("div");
-    body.textContent = "Coming soon. This will let you select scenes and remake images, videos, or both.";
-    body.style.cssText = "font-size:13px;color:#d4d4d8;line-height:1.45;";
-    const close = makeButton("Close");
-    close.onclick = () => backdrop.remove();
-    box.append(title, body, close);
-    backdrop.append(box);
-    document.body.append(backdrop);
-  }
-
   function confirmLongBatchAction({ title, lines = [], confirmLabel = "Continue" } = {}) {
     return new Promise((resolve) => {
       const backdrop = document.createElement("div");
@@ -42700,6 +42669,52 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       });
     });
   }
+
+  function showLegacyPromptCreatorNotice() {
+    return new Promise((resolve) => {
+      const backdrop = document.createElement("div");
+      backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:20px;";
+      const box = document.createElement("div");
+      box.style.cssText = "width:min(620px,calc(100vw - 40px));border:1px solid #b45309;border-radius:10px;background:#111827;color:#f8fafc;box-shadow:0 24px 80px rgba(0,0,0,.6);padding:18px;display:flex;flex-direction:column;gap:13px;";
+      const heading = document.createElement("div");
+      heading.textContent = "Prompt Creator (Legacy)";
+      heading.style.cssText = "font-size:19px;font-weight:900;color:#fde68a;";
+      const note = document.createElement("div");
+      note.innerHTML = [
+        "<strong>Prompt Creator is the older planning workflow.</strong>",
+        "For new projects, use Storyboard Builder. It is the newer workflow for keeping story direction, scene beats, references, image defaults, motion defaults, and prompts together in the same project.",
+        "Continue only if you need an older Prompt Creator project or its file-based prompt workflow.",
+      ].map((line) => `<div style="margin-top:7px;">${line}</div>`).join("");
+      note.style.cssText = "font-size:13px;color:#e5e7eb;line-height:1.5;";
+      const actions = document.createElement("div");
+      actions.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-top:3px;";
+      const continueLegacy = makeButton("Continue to Prompt Creator");
+      const continueBuilder = makeButton("Continue to Video Builder", "primary");
+      const finish = (value) => {
+        backdrop.remove();
+        resolve(value);
+      };
+      continueLegacy.onclick = () => finish("prompt_creator");
+      continueBuilder.onclick = () => finish("video_builder");
+      backdrop.addEventListener("click", (event) => {
+        if (event.target === backdrop) finish("video_builder");
+      });
+      backdrop.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") finish("video_builder");
+      });
+      actions.append(continueLegacy, continueBuilder);
+      box.append(heading, note, actions);
+      backdrop.append(box);
+      document.body.append(backdrop);
+      backdrop.tabIndex = -1;
+      backdrop.focus();
+    });
+  }
+
+  async function confirmOpenLegacyPromptCreator() {
+    const choice = await showLegacyPromptCreatorNotice();
+    if (choice === "prompt_creator") openPromptCreatorPanel();
+  }
   browserAiSendButton.onclick = () => {
     const now = Date.now();
     if (browserAiSendButton.disabled || now - browserAiLastSendStartedAt < 750) return;
@@ -43158,11 +43173,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     loadAudio();
   };
   settingsButton.onclick = openSettingsModal;
+  reviewGuideButton.onclick = () => {
+    menuDropdown.style.display = "none";
+    window.open(
+      "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  };
   newProjectButton.onclick = async () => {
-    const mode = await window.VRGDGMusicVideoPromptCreator?.chooseNewProjectMode?.();
-    if (!mode) return;
-    const created = await newProject();
-    if (created && mode === "prompt_creator") openPromptCreatorPanel();
+    await newProject();
   };
   saveProjectAsButton.onclick = saveProjectAs;
   branchProjectButton.onclick = branchProject;
@@ -43182,7 +43202,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   loadSrtButton.onclick = loadSrt;
   loadSessionButton.onclick = loadSession;
   loadLastProjectButton.onclick = loadLastProject;
-  promptCreatorButton.onclick = openPromptCreatorPanel;
+  promptCreatorButton.onclick = confirmOpenLegacyPromptCreator;
   wizardButton.onclick = openWizardFromBuilder;
   storyboardBuilderButton.onclick = openStoryboardBuilderFromProject;
   fluxReferenceBuilderButton.onclick = openReferenceBuilderTargetChooser;
@@ -43206,7 +43226,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   editI2VPromptButton.onclick = editCurrentVideoPromptWithGemma;
   fullBuildButton.onclick = confirmAndRunFullBuild;
   fullFLFBuildButton.onclick = confirmAndRunFullFLFBuild;
-  remakeModeButton.onclick = showRemakeModeComingSoon;
   stopWorkflowButton.onclick = stopCurrentWorkflow;
   downloadModelsButton.onclick = showModelDownloadModal;
   fullscreenButton.onclick = () => applyBuilderFullscreen(!builderFullscreen);

--- a/web/VRGDG_MusicVideoPromptCreatorUI.js
+++ b/web/VRGDG_MusicVideoPromptCreatorUI.js
@@ -598,37 +598,6 @@ function buildPayload(controls, modelSelect) {
   };
 }
 
-function createModeChoiceModal() {
-  return new Promise((resolve) => {
-    const backdrop = document.createElement("div");
-    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.68);display:flex;align-items:center;justify-content:center;";
-    const box = document.createElement("div");
-    box.style.cssText = "width:min(560px,calc(100vw - 40px));border:1px solid #155e75;border-radius:9px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
-    const heading = document.createElement("div");
-    heading.textContent = "Start New Project";
-    heading.style.cssText = "font-size:18px;font-weight:900;color:#cffafe;";
-    const note = document.createElement("div");
-    note.textContent = "Choose where you want to begin. Prompt Creator builds the SRT, lyric segments, concept prompts, and context files. Video Creation opens the editor directly.";
-    note.style.cssText = "font-size:13px;color:#d4d4d8;line-height:1.45;";
-    const actions = document.createElement("div");
-    actions.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:8px;";
-    const promptCreator = makeButton("Start Prompt Creator", "primary");
-    const videoCreator = makeButton("Start Video Creation");
-    const cancel = makeButton("Cancel");
-    const finish = (value) => {
-      backdrop.remove();
-      resolve(value);
-    };
-    promptCreator.onclick = () => finish("prompt_creator");
-    videoCreator.onclick = () => finish("video_creator");
-    cancel.onclick = () => finish("");
-    actions.append(promptCreator, videoCreator);
-    box.append(heading, note, actions, cancel);
-    backdrop.append(box);
-    document.body.append(backdrop);
-  });
-}
-
 function showPromptCreatorDraftProjectModal(projects = []) {
   return new Promise((resolve) => {
     const backdrop = document.createElement("div");
@@ -734,7 +703,7 @@ function openPromptCreator(options = {}) {
   const topbar = document.createElement("div");
   topbar.style.cssText = "display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1px solid #364152;background:#20242a;";
   const title = document.createElement("div");
-  title.textContent = "Prompt Creator";
+  title.textContent = "Prompt Creator (Legacy)";
   title.style.cssText = "font-size:16px;font-weight:900;color:#cffafe;margin-right:auto;";
   const backButton = makeButton("Back To Video Creator");
   const loadDraftButton = makeButton("Load Project Draft");
@@ -2009,5 +1978,4 @@ function openPromptCreator(options = {}) {
 
 window.VRGDGMusicVideoPromptCreator = {
   open: openPromptCreator,
-  chooseNewProjectMode: createModeChoiceModal,
 };


### PR DESCRIPTION
## What changed

- Marks Prompt Creator as a legacy workflow and recommends Storyboard Builder for new planning work.
- Removes Prompt Creator from the new-project choice and adds a clear legacy confirmation dialog.
- Adds a **Review Guide** menu item that opens the public LTX 2.3 Video Builder guide.
- Removes the obsolete **Remake Mode** menu entry and popup.
- Fixes the update-status banner by grouping it with the toolbar in the original three-row Builder layout.
- Makes the banner close button dismiss only the current Builder window instead of hiding the status across future openings.
- Updates the public guide wording to match the revised interface.

## Why

These changes simplify the recommended project workflow, remove obsolete navigation, provide direct guide access, and prevent the update banner from stretching the toolbar and reducing the usable workspace.

## Validation

- Both modified JavaScript modules passed Node module syntax checks.
- `git diff --check` passed.
- Obsolete Prompt Creator chooser, Remake Mode menu, and persistent banner-dismiss references are absent.
- A headless Chromium layout check measured the combined header at 92px, with 460px remaining for the main workspace and 367px for the timeline in the normal 1920×1080 layout.