### PR TITLE
Add optional update details and fix GGUF selection

### DIFF
--- a/VRGDG_UpdateRoutes.py
+++ b/VRGDG_UpdateRoutes.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import subprocess
 import sys
@@ -9,6 +10,7 @@ from server import PromptServer
 
 UPDATE_BRANCH = "main"
 _NODE_DIR = os.path.dirname(os.path.abspath(__file__))
+_RELEASE_NOTES_FILE = "update_notes.json"
 _ROUTES_REGISTERED = False
 
 
@@ -60,6 +62,103 @@ def _install_requirements(timeout=900):
     }
 
 
+def _load_release_notes(ref=""):
+    """Load notes from a fetched Git ref, falling back to the installed checkout."""
+    raw = ""
+    source = "local"
+    if ref:
+        try:
+            raw = _run_git("show", f"{ref}:{_RELEASE_NOTES_FILE}", timeout=20)
+            source = ref
+        except Exception:
+            raw = ""
+
+    if not raw:
+        notes_path = os.path.join(_NODE_DIR, _RELEASE_NOTES_FILE)
+        if not os.path.isfile(notes_path):
+            return {"schema_version": 1, "product": "LTX 2.3 Video Builder", "releases": []}, "none"
+        with open(notes_path, "r", encoding="utf-8") as handle:
+            raw = handle.read()
+
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{_RELEASE_NOTES_FILE} is not valid JSON: {exc}") from exc
+
+    if not isinstance(document, dict):
+        raise RuntimeError(f"{_RELEASE_NOTES_FILE} must contain a JSON object.")
+    releases = document.get("releases")
+    if not isinstance(releases, list):
+        document["releases"] = []
+    return document, source
+
+
+def _git_is_ancestor(commit, ref):
+    commit = str(commit or "").strip()
+    ref = str(ref or "").strip()
+    if not commit or not ref:
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", commit, ref],
+            cwd=_NODE_DIR, capture_output=True, text=True,
+            errors="replace", timeout=20, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _git_commit_tree(commit):
+    """Return the tree ID for a commit, or an empty string if it is unavailable."""
+    commit = str(commit or "").strip()
+    if not commit:
+        return ""
+    try:
+        return _run_git("rev-parse", f"{commit}^{{tree}}", timeout=20).strip()
+    except Exception:
+        return ""
+
+
+def _git_history_contains_tree(commit, ref):
+    """Recognize equivalent content when a PR was squash-merged to another commit ID."""
+    target_tree = _git_commit_tree(commit)
+    ref = str(ref or "").strip()
+    if not target_tree or not ref:
+        return False
+    try:
+        history_trees = _run_git("log", "--format=%T", ref, timeout=30).splitlines()
+    except Exception:
+        return False
+    return target_tree in {tree.strip() for tree in history_trees if tree.strip()}
+
+
+def _git_contains_release(commit, ref):
+    return _git_is_ancestor(commit, ref) or _git_history_contains_tree(commit, ref)
+
+
+def _release_note_status(document, local_commit, latest_commit):
+    available_release_ids = []
+    current_release_id = ""
+    for release in document.get("releases", []):
+        if not isinstance(release, dict):
+            continue
+        release_id = str(release.get("id") or "").strip()
+        commit = str(release.get("commit") or "").strip()
+        if not release_id or not commit:
+            continue
+        installed = _git_contains_release(commit, local_commit)
+        published = _git_contains_release(commit, latest_commit)
+        if not current_release_id and installed:
+            current_release_id = release_id
+        if published and not installed:
+            available_release_ids.append(release_id)
+    return {
+        "available_release_ids": available_release_ids,
+        "current_release_id": current_release_id,
+    }
+
+
 def _update_to_main():
     if not os.path.isdir(os.path.join(_NODE_DIR, ".git")):
         raise RuntimeError("This installation is not a Git checkout, so the normal Git update commands cannot run.")
@@ -99,6 +198,7 @@ def _update_to_main():
         except Exception as exc:
             requirements_error = str(exc)
 
+    release_notes, release_notes_source = _load_release_notes()
     return {
         "branch": branch,
         "directory": _NODE_DIR,
@@ -109,6 +209,8 @@ def _update_to_main():
         "requirements_error": requirements_error,
         "requirements_command": requirements_command,
         "restart_required": True,
+        "release_notes": release_notes,
+        "release_notes_source": release_notes_source,
         "logs": logs,
     }
 
@@ -126,6 +228,9 @@ def _main_status():
     behind = int(_run_git("rev-list", "--count", f"HEAD..{remote_ref}").strip() or "0")
     ahead = int(_run_git("rev-list", "--count", f"{remote_ref}..HEAD").strip() or "0")
     tracked_changes = bool(_run_git("status", "--porcelain", "--untracked-files=no").strip())
+    release_notes, release_notes_source = _load_release_notes(remote_ref)
+    release_status = _release_note_status(release_notes, local_commit, latest_commit)
+    latest_content_installed = _git_contains_release(latest_commit, local_commit)
 
     return {
         "branch": branch,
@@ -134,8 +239,12 @@ def _main_status():
         "latest_commit": latest_commit,
         "behind": behind,
         "ahead": ahead,
-        "outdated": behind > 0 or branch != UPDATE_BRANCH,
+        "outdated": behind > 0 and not latest_content_installed,
+        "latest_content_installed": latest_content_installed,
         "tracked_changes": tracked_changes,
+        "release_notes": release_notes,
+        "release_notes_source": release_notes_source,
+        **release_status,
     }
 
 

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -373,17 +373,19 @@ def _patch_ltx_video_model_loader(prompt, payload):
     if not diffusion_name:
         diffusion_name = gguf_name
     switch_id = _optional_api_node_id_by_class(prompt, "ComfySwitchNode", "Switch-use GGUF", fallback_ids=("955", "939", "959"))
+    gguf_loader_id = _optional_api_node_id_by_class(prompt, "UnetLoaderGGUF", fallback_ids=("271:215", "969"))
     diffusion_loader_id = _optional_api_node_id_by_class(prompt, "DiffusionModelLoaderKJ", fallback_ids=("956", "938", "958"))
     if switch_id:
         _set_optional_api_input(prompt, switch_id, "switch", use_gguf)
-    _set_optional_api_input(prompt, "271:215", "unet_name", gguf_name)
+    if gguf_loader_id:
+        _set_optional_api_input(prompt, gguf_loader_id, "unet_name", gguf_name)
     if diffusion_loader_id:
         _set_optional_api_input(prompt, diffusion_loader_id, "model_name", diffusion_name)
-    if switch_id and diffusion_loader_id:
+    if switch_id and gguf_loader_id and diffusion_loader_id:
         if use_gguf:
-            _collapse_ltx_video_model_switch(prompt, switch_id, "271:215", diffusion_loader_id)
+            _collapse_ltx_video_model_switch(prompt, switch_id, gguf_loader_id, diffusion_loader_id)
         else:
-            _collapse_ltx_video_model_switch(prompt, switch_id, diffusion_loader_id, "271:215")
+            _collapse_ltx_video_model_switch(prompt, switch_id, diffusion_loader_id, gguf_loader_id)
 
 
 def _load_workflow_template(path=None):

--- a/update_notes.json
+++ b/update_notes.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "product": "LTX 2.3 Video Builder",
+  "releases": [
+    {
+      "id": "2026-07-25-builder-navigation",
+      "version": "2026.07.25",
+      "date": "2026-07-25",
+      "title": "Builder navigation, update details, and reliability fixes",
+      "commit": "0d9f1c963e37eb7272910e41fd7b19dce7c6d513",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added Review Guide to the Builder menu for direct access to the public LTX 2.3 Video Builder guide.",
+            "Added a clear legacy notice before opening the older Prompt Creator workflow.",
+            "Added an optional What's New window so users can review release details from the status banner or Builder menu."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "New projects now open directly in Video Builder.",
+            "Prompt Creator is labeled as a legacy workflow, with Storyboard Builder recommended for new story planning."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Removed the obsolete Remake Mode menu item.",
+            "Fixed the update-status banner so it no longer stretches the toolbar or reduces the main workspace.",
+            "Fixed update detection for development builds whose changes were squash-merged to main.",
+            "Fixed ID-LoRA GGUF rendering so the unused safetensors loader is removed before ComfyUI validates the prompt."
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-07-25-guide-visuals",
+      "version": "2026.07.25-guide",
+      "date": "2026-07-25",
+      "title": "Expanded Storyboard and Browser AI guide",
+      "commit": "1554e8c757e8e045fc634c713d0e9e3e84a13e62",
+      "restart_required": false,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "Documentation",
+          "items": [
+            "Added Storyboard Builder screenshots for the main window, Story Layer, Image Prep defaults, and Video Prep defaults.",
+            "Added Browser AI screenshots for provider setup, manual mode, and Band Sequence groups."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -1874,6 +1874,8 @@ function openBuilder(node) {
   const updateStatusText = document.createElement("span");
   updateStatusText.style.cssText = "min-width:0;flex:1 1 auto;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
   updateStatusText.textContent = "LTX 2.3 Video Builder — Checking for updates…";
+  const updateWhatsNewAction = makeButton("What's New");
+  updateWhatsNewAction.style.cssText += "display:none;padding:4px 10px;min-height:24px;background:#164e63;border-color:#22d3ee;color:#ecfeff;font-size:11px;font-weight:900;";
   const updateStatusAction = makeButton("Update");
   updateStatusAction.style.cssText += "display:none;padding:4px 10px;min-height:24px;background:#7f1d1d;border-color:#f87171;color:#fff;font-size:11px;font-weight:900;";
   const updateStatusClose = document.createElement("button");
@@ -1882,8 +1884,9 @@ function openBuilder(node) {
   updateStatusClose.title = "Dismiss this version status";
   updateStatusClose.setAttribute("aria-label", "Dismiss LTX 2.3 Video Builder version status");
   updateStatusClose.style.cssText = "width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;padding:0;border:1px solid rgba(255,255,255,.32);border-radius:5px;background:rgba(0,0,0,.18);color:inherit;font:700 18px/1 sans-serif;cursor:pointer;";
-  updateStatusBanner.append(updateStatusDot, updateStatusText, updateStatusAction, updateStatusClose);
+  updateStatusBanner.append(updateStatusDot, updateStatusText, updateWhatsNewAction, updateStatusAction, updateStatusClose);
 
+  let updateStatusPayload = null;
   const setUpdateStatusAppearance = (kind, text, detail = "") => {
     const styles = {
       current: { background: "#14532d", border: "#22c55e", dot: "#86efac", shadow: "rgba(134,239,172,.22)" },
@@ -1899,13 +1902,144 @@ function openBuilder(node) {
     updateStatusText.textContent = text;
     updateStatusBanner.title = detail || text;
     updateStatusAction.style.display = kind === "outdated" ? "inline-flex" : "none";
+    const hasReleaseNotes = Array.isArray(updateStatusPayload?.release_notes?.releases)
+      && updateStatusPayload.release_notes.releases.length > 0;
+    updateWhatsNewAction.style.display = hasReleaseNotes ? "inline-flex" : "none";
+    updateWhatsNewAction.title = kind === "outdated"
+      ? "Review what will change before updating."
+      : "Review recently installed features and fixes.";
   };
+
+  const updateReleaseNotes = (payload = updateStatusPayload) => {
+    const releases = payload?.release_notes?.releases;
+    return Array.isArray(releases) ? releases.filter((release) => release && typeof release === "object") : [];
+  };
+
+  function openWhatsNewModal({ mode = "current" } = {}) {
+    const payload = updateStatusPayload || {};
+    const allReleases = updateReleaseNotes(payload);
+    const availableIds = new Set(
+      Array.isArray(payload.available_release_ids)
+        ? payload.available_release_ids.map((value) => String(value || ""))
+        : []
+    );
+    const currentReleaseId = String(payload.current_release_id || "");
+    let releases = allReleases;
+    if (mode === "available" && availableIds.size) {
+      releases = allReleases.filter((release) => availableIds.has(String(release.id || "")));
+    } else if (mode === "current" && currentReleaseId) {
+      releases = allReleases.filter((release) => String(release.id || "") === currentReleaseId);
+    }
+    if (!releases.length) releases = allReleases.slice(0, mode === "history" ? 8 : 3);
+
+    document.querySelector(".vrgdg-builder-whats-new")?.remove();
+    const backdrop = document.createElement("div");
+    backdrop.className = "vrgdg-builder-whats-new";
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100030;background:rgba(0,0,0,.74);display:flex;align-items:center;justify-content:center;padding:20px;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(760px,calc(100vw - 40px));max-height:min(820px,calc(100vh - 40px));border:1px solid #155e75;border-radius:11px;background:#0f172a;color:#f8fafc;box-shadow:0 26px 90px rgba(0,0,0,.65);display:flex;flex-direction:column;overflow:hidden;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:flex-start;gap:12px;padding:16px 18px;border-bottom:1px solid #164e63;background:#082f49;";
+    const headingWrap = document.createElement("div");
+    headingWrap.style.cssText = "min-width:0;flex:1 1 auto;";
+    const heading = document.createElement("div");
+    heading.textContent = "What's New in LTX 2.3 Video Builder";
+    heading.style.cssText = "font-size:19px;font-weight:950;color:#cffafe;";
+    const summary = document.createElement("div");
+    const installed = String(payload.installed_commit || "").slice(0, 7);
+    const latest = String(payload.latest_commit || "").slice(0, 7);
+    summary.textContent = payload.outdated
+      ? `Review the changes available before updating${latest ? ` to build ${latest}` : ""}.`
+      : `Recent changes in your installed build${installed ? ` ${installed}` : ""}.`;
+    summary.style.cssText = "margin-top:4px;font-size:12px;line-height:1.4;color:#bae6fd;";
+    headingWrap.append(heading, summary);
+    const closeTop = makeButton("Close");
+    header.append(headingWrap, closeTop);
+
+    const content = document.createElement("div");
+    content.style.cssText = "display:flex;flex-direction:column;gap:12px;padding:16px 18px;overflow:auto;min-height:0;";
+    if (!releases.length) {
+      const empty = document.createElement("div");
+      empty.textContent = "Release notes are not available for this build yet.";
+      empty.style.cssText = "border:1px dashed #475569;border-radius:8px;padding:18px;text-align:center;color:#94a3b8;font-size:13px;";
+      content.append(empty);
+    }
+
+    for (const release of releases) {
+      const card = document.createElement("section");
+      card.style.cssText = "border:1px solid #334155;border-radius:9px;background:#111827;padding:14px;display:flex;flex-direction:column;gap:10px;";
+      const releaseTitle = document.createElement("div");
+      releaseTitle.textContent = String(release.title || release.version || "Builder update");
+      releaseTitle.style.cssText = "font-size:16px;font-weight:900;color:#e0f2fe;";
+      const meta = document.createElement("div");
+      const metaParts = [
+        release.version ? `Version ${release.version}` : "",
+        release.date ? String(release.date) : "",
+        release.restart_required ? "ComfyUI restart required" : "",
+      ].filter(Boolean);
+      meta.textContent = metaParts.join(" · ");
+      meta.style.cssText = "font-size:11px;color:#67e8f9;";
+      card.append(releaseTitle, meta);
+
+      const sections = Array.isArray(release.sections) ? release.sections : [];
+      for (const section of sections) {
+        const sectionTitle = document.createElement("div");
+        sectionTitle.textContent = String(section?.title || "Changes");
+        sectionTitle.style.cssText = "margin-top:2px;font-size:12px;font-weight:900;color:#fef3c7;text-transform:uppercase;letter-spacing:.04em;";
+        const list = document.createElement("ul");
+        list.style.cssText = "margin:0;padding-left:20px;display:flex;flex-direction:column;gap:5px;color:#dbeafe;font-size:13px;line-height:1.45;";
+        for (const itemText of Array.isArray(section?.items) ? section.items : []) {
+          const item = document.createElement("li");
+          item.textContent = String(itemText || "");
+          list.append(item);
+        }
+        if (list.childElementCount) card.append(sectionTitle, list);
+      }
+
+      if (release.guide_url) {
+        const guideButton = makeButton("Open Related Guide");
+        guideButton.style.alignSelf = "flex-start";
+        guideButton.onclick = () => window.open(String(release.guide_url), "_blank", "noopener,noreferrer");
+        card.append(guideButton);
+      }
+      content.append(card);
+    }
+
+    const actions = document.createElement("div");
+    actions.style.cssText = "display:flex;justify-content:flex-end;gap:9px;padding:12px 18px;border-top:1px solid #334155;background:#111827;";
+    const close = makeButton("Close");
+    actions.append(close);
+    if (payload.outdated) {
+      const updateNow = makeButton("Update Now", "primary");
+      updateNow.onclick = () => {
+        backdrop.remove();
+        updateV10Button.click();
+      };
+      actions.append(updateNow);
+    }
+
+    const finish = () => backdrop.remove();
+    closeTop.onclick = finish;
+    close.onclick = finish;
+    backdrop.addEventListener("click", (event) => {
+      if (event.target === backdrop) finish();
+    });
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") finish();
+    });
+    box.append(header, content, actions);
+    backdrop.append(box);
+    document.body.append(backdrop);
+    backdrop.tabIndex = -1;
+    backdrop.focus();
+  }
 
   updateStatusClose.onclick = () => {
     updateStatusBanner.style.display = "none";
   };
 
   const refreshV10UpdateStatus = async () => {
+    updateStatusPayload = null;
     setUpdateStatusAppearance("checking", "LTX 2.3 Video Builder — Checking for updates…");
     try {
       const response = await api.fetchApi("/vrgdg/update/v10/status");
@@ -1913,12 +2047,13 @@ function openBuilder(node) {
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `Status check failed (HTTP ${response.status}).`);
       }
+      updateStatusPayload = payload;
 
       const installed = String(payload.installed_commit || "").slice(0, 7) || "unknown";
       const latest = String(payload.latest_commit || "").slice(0, 7) || "unknown";
       const behind = Math.max(0, Number(payload.behind || 0));
       const wrongBranch = Boolean(payload.expected_branch) && payload.branch !== payload.expected_branch;
-      const isOutdated = Boolean(payload.outdated) || behind > 0 || wrongBranch;
+      const isOutdated = Boolean(payload.outdated);
       if (isOutdated) {
         const countText = `${behind} commit${behind === 1 ? "" : "s"} behind`;
         const reason = wrongBranch
@@ -1930,9 +2065,10 @@ function openBuilder(node) {
           `This installation is not at the latest production version on main (${reason}). Click Update to run the safe updater.`
         );
       } else {
-        const localNote = Number(payload.ahead || 0) > 0
-          ? " · local build ahead"
-          : payload.tracked_changes ? " · modified locally" : "";
+        const localNotes = [];
+        if (wrongBranch || Number(payload.ahead || 0) > 0) localNotes.push("local development build");
+        if (payload.tracked_changes) localNotes.push("modified locally");
+        const localNote = localNotes.length ? ` · ${localNotes.join(" · ")}` : "";
         setUpdateStatusAppearance(
           "current",
           `LTX 2.3 Video Builder build ${installed} — Up to date${localNote}`,
@@ -1940,6 +2076,7 @@ function openBuilder(node) {
         );
       }
     } catch (error) {
+      updateStatusPayload = null;
       setUpdateStatusAppearance(
         "unavailable",
         "LTX 2.3 Video Builder — Could not check for updates",
@@ -1960,6 +2097,8 @@ function openBuilder(node) {
   const settingsButton = makeButton("Settings");
   const reviewGuideButton = makeButton("Review Guide");
   reviewGuideButton.title = "Open the LTX 2.3 Video Builder guide on GitHub.";
+  const whatsNewMenuButton = makeButton("What's New");
+  whatsNewMenuButton.title = "Review recent LTX 2.3 Video Builder features, improvements, and fixes.";
   const loadButton = makeButton("Load Audio", "primary");
   const loadSrtButton = makeButton("Load SRT", "primary");
   const menuButton = makeButton("Menu");
@@ -2032,7 +2171,7 @@ function openBuilder(node) {
     button.style.justifyContent = "flex-start";
   };
   menuDropdown.append(buyMeACoffeeButton);
-  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, reviewGuideButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton]) {
+  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, reviewGuideButton, whatsNewMenuButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton]) {
     styleMenuItem(button);
     menuDropdown.append(button);
   }
@@ -43143,7 +43282,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           ? "Updated Python requirements were installed successfully."
           : "No requirements.txt changes were detected, so dependency installation was skipped.";
       window.alert(
-        `${requirementsNote}\n\nRESTART REQUIRED: Fully stop and restart ComfyUI, then hard-refresh the browser page so the new Python and JavaScript files load.`
+        `${requirementsNote}\n\nRESTART REQUIRED: Fully stop and restart ComfyUI, then hard-refresh the browser page so the new Python and JavaScript files load.\n\nAfter restarting, you can optionally open What's New from the status banner or Builder menu.`
       );
     } catch (error) {
       window.alert(`Update did not complete:\n\n${error?.message || error}`);
@@ -43153,6 +43292,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
   };
   updateStatusAction.onclick = () => updateV10Button.click();
+  updateWhatsNewAction.onclick = () => {
+    openWhatsNewModal({ mode: updateStatusPayload?.outdated ? "available" : "current" });
+  };
   menuDropdown.addEventListener("click", (event) => {
     if (event.target === autoSaveControl.input || autoSaveControl.wrapper.contains(event.target)) return;
     menuDropdown.style.display = "none";
@@ -43181,6 +43323,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       "noopener,noreferrer"
     );
   };
+  whatsNewMenuButton.onclick = () => openWhatsNewModal({ mode: "history" });
   newProjectButton.onclick = async () => {
     await newProject();
   };


### PR DESCRIPTION
## What changed

- adds structured LTX 2.3 Video Builder release notes and an optional **What's New** window accessible from the update banner and Builder menu
- keeps the window user-invoked instead of opening it automatically
- recognizes squash-equivalent Git content so local development builds are not falsely marked outdated
- selects the actual `UnetLoaderGGUF` node in each LTX workflow and removes the unused safetensors branch before prompt validation

## Why

The updater previously treated a squash-merged development commit as missing even when its content was already present. In ID-LoRA mode, the GGUF checkbox could still leave node `971` (`DiffusionModelLoaderKJ`) in the API prompt because loader selection relied on a hardcoded node ID, causing validation to fail when the unused safetensors model was not installed.

## User impact

Users can review update details when they choose, local development builds report their status correctly, and ID-LoRA rendering works with GGUF selected without requiring the unrelated safetensors model.

## Validation

- `python -B -m py_compile VRGDG_UpdateRoutes.py VRGDG_WorkflowRunnerNodes.py`
- Builder JavaScript module syntax check with Node
- `update_notes.json` JSON parse validation
- `git diff --check`
- in-memory ID-LoRA API-template validation for both GGUF and safetensors branches