### PR TITLE
Add video comparison and improve Builder reliability

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -8525,6 +8525,11 @@ def _prepare_scene_audio_mix(payload):
     if not isinstance(segments, list) or not segments:
         raise ValueError("No scenes were provided for scene audio mix.")
     allow_missing_scene_audio = bool(payload.get("allow_missing_scene_audio", False))
+    global_audio_path = os.path.abspath(
+        str(payload.get("global_audio_path", "") or "").strip().strip('"')
+    )
+    if not os.path.isfile(global_audio_path):
+        global_audio_path = ""
 
     ffmpeg_path = _find_ffmpeg_path()
     folder = _scene_audio_mix_folder(project_folder)
@@ -8542,10 +8547,21 @@ def _prepare_scene_audio_mix(payload):
             continue
         path = str(segment.get("custom_audio_path", "") or "").strip().strip('"')
         if not path:
+            start = max(0.0, float(segment.get("start", 0) or 0))
+            end = max(start + 0.05, float(segment.get("end", start + 4) or start + 4))
+            duration = max(0.05, end - start)
+            if global_audio_path:
+                timeline_items.append({
+                    "index": index,
+                    "path": global_audio_path,
+                    "start": start,
+                    "end": end,
+                    "duration": duration,
+                    "source_start": start,
+                    "silent": False,
+                })
+                continue
             if allow_missing_scene_audio:
-                start = max(0.0, float(segment.get("start", 0) or 0))
-                end = max(start + 0.05, float(segment.get("end", start + 4) or start + 4))
-                duration = max(0.05, end - start)
                 timeline_items.append({
                     "index": index,
                     "path": "",

--- a/VRGDG_VideoCompareNode.py
+++ b/VRGDG_VideoCompareNode.py
@@ -1,0 +1,144 @@
+import os
+
+import folder_paths
+
+
+_VIDEO_EXTENSIONS = {".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v"}
+
+
+def _video_path_candidates(value):
+    candidates = []
+    if isinstance(value, str):
+        candidates.append(value)
+    elif isinstance(value, dict):
+        for key in ("fullpath", "path", "video_path", "filename"):
+            item = value.get(key)
+            if isinstance(item, str):
+                candidates.append(item)
+        for key in ("files", "filenames", "videos", "gifs"):
+            candidates.extend(_video_path_candidates(value.get(key)))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            candidates.extend(_video_path_candidates(item))
+    return candidates
+
+
+def _resolve_video_path(value, label):
+    roots = [
+        "",
+        folder_paths.get_output_directory(),
+        folder_paths.get_temp_directory(),
+        folder_paths.get_input_directory(),
+    ]
+    candidates = _video_path_candidates(value)
+    for raw_path in reversed(candidates):
+        text = str(raw_path or "").strip().strip('"')
+        if not text or os.path.splitext(text)[1].lower() not in _VIDEO_EXTENSIONS:
+            continue
+        for root in roots:
+            path = text if not root or os.path.isabs(text) else os.path.join(root, text)
+            path = os.path.normpath(os.path.abspath(path))
+            if os.path.isfile(path):
+                return path
+    raise ValueError(
+        f"{label} video was not found. Connect the Filenames output from a "
+        "Video Combine node that has already created a video."
+    )
+
+
+class VRGDG_VideoCompareSlider:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "before_video": (
+                    "VHS_FILENAMES",
+                    {"tooltip": "Connect the Filenames output for the original/before video."},
+                ),
+                "after_video": (
+                    "VHS_FILENAMES",
+                    {"tooltip": "Connect the Filenames output for the processed/after video."},
+                ),
+                "slider_position": (
+                    "FLOAT",
+                    {
+                        "default": 0.5,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "Starting position of the before/after wipe.",
+                    },
+                ),
+                "before_label": (
+                    "STRING",
+                    {"default": "Before", "tooltip": "Label shown over the original video."},
+                ),
+                "after_label": (
+                    "STRING",
+                    {"default": "After", "tooltip": "Label shown over the processed video."},
+                ),
+                "show_labels": ("BOOLEAN", {"default": True}),
+                "loop": ("BOOLEAN", {"default": True}),
+                "muted": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Mute playback. When unmuted, audio comes from the before video.",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("VHS_FILENAMES", "VHS_FILENAMES")
+    RETURN_NAMES = ("before_video", "after_video")
+    FUNCTION = "compare"
+    OUTPUT_NODE = True
+    CATEGORY = "VRGDG/Image"
+
+    def compare(
+        self,
+        before_video,
+        after_video,
+        slider_position,
+        before_label,
+        after_label,
+        show_labels,
+        loop,
+        muted,
+    ):
+        before_path = _resolve_video_path(before_video, "Before")
+        after_path = _resolve_video_path(after_video, "After")
+        return {
+            "ui": {
+                "compare_videos": [
+                    {
+                        "compare_role": "before",
+                        "path": before_path,
+                        "name": os.path.basename(before_path),
+                    },
+                    {
+                        "compare_role": "after",
+                        "path": after_path,
+                        "name": os.path.basename(after_path),
+                    },
+                ],
+                "compare_video_settings": {
+                    "slider_position": float(slider_position),
+                    "before_label": str(before_label or "Before"),
+                    "after_label": str(after_label or "After"),
+                    "show_labels": bool(show_labels),
+                    "loop": bool(loop),
+                    "muted": bool(muted),
+                },
+            },
+            "result": (before_video, after_video),
+        }
+
+
+NODE_CLASS_MAPPINGS = {
+    "VRGDG_VideoCompareSlider": VRGDG_VideoCompareSlider,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VRGDG_VideoCompareSlider": "VRGDG Video Compare Slider",
+}

--- a/VRGDG_VideoEditorNodes.py
+++ b/VRGDG_VideoEditorNodes.py
@@ -775,7 +775,10 @@ def _ensure_video_editor_routes():
             return web.json_response({"ok": False, "error": "Image file was not found."}, status=404)
         if os.path.splitext(image_path)[1].lower() not in {".png", ".jpg", ".jpeg", ".webp"}:
             return web.json_response({"ok": False, "error": "Unsupported image file type."}, status=400)
-        return web.FileResponse(image_path)
+        response = web.FileResponse(image_path)
+        if str(request.query.get("thumbv", "") or "").strip():
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
 
     _VRGDG_VIDEO_EDITOR_ROUTES_REGISTERED = True
 

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ _VRGDG_SUBMODULES = (
     ".VRGDG_StartImageStoryboard",
     ".VRGDG_MusicVideoPromptCreatorNodes",
     ".VRGDG_ImageCompareNode",
+    ".VRGDG_VideoCompareNode",
     ".VRGDG_ImagePasteBack",
     ".VRGDG_StandaloneFaceFixNodes",
     ".VRGDG_VideoEnhanceNodes",

--- a/nodes.py
+++ b/nodes.py
@@ -137,7 +137,7 @@ class FastUnsharpSharpen:
                     {
                         "default": 0.5,
                         "min": 0.0,
-                        "max": 2.0,
+                        "max": 10.0,
                         "step": 0.01,
                     },
                 ),

--- a/tests/test_builder_history_memory.py
+++ b/tests/test_builder_history_memory.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+VIDEO_EDITOR_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "VRGDG_VideoEditorNodes.py"
+).read_text(encoding="utf-8")
+
+
+class BuilderHistoryMemoryTests(unittest.TestCase):
+    def test_history_snapshots_deduplicate_embedded_media(self):
+        self.assertIn("HISTORY_BLOB_TOKEN_PREFIX", SOURCE)
+        self.assertIn("historySnapshotReplacer", SOURCE)
+        self.assertIn("JSON.parse(snapshot, historySnapshotReviver)", SOURCE)
+        self.assertIn("pruneHistoryBlobCache();", SOURCE)
+
+    def test_inspector_text_edits_use_one_history_checkpoint_per_focus(self):
+        self.assertIn('control.addEventListener("focus", pushHistory);', SOURCE)
+        self.assertIn(
+            'control.addEventListener("input", () => updateActiveFromInputs({ skipHistory: true }));',
+            SOURCE,
+        )
+        self.assertIn(
+            'control.addEventListener("change", () => updateActiveFromInputs({ skipHistory: true }));',
+            SOURCE,
+        )
+
+    def test_scene_thumbnails_keep_stable_urls_across_renders(self):
+        self.assertIn("function makeEditorThumbnailUrl(path)", SOURCE)
+        self.assertIn("EDITOR_THUMBNAIL_SESSION_VERSION", SOURCE)
+        self.assertIn("refreshEditorThumbnailUrl(imagePath);", SOURCE)
+        self.assertIn("makeEditorThumbnailUrl(previewThumbPath)", SOURCE)
+        self.assertIn("makeEditorThumbnailUrl(imagePath)", SOURCE)
+        self.assertIn('request.query.get("thumbv"', VIDEO_EDITOR_SOURCE)
+        self.assertIn('"Cache-Control"] = "public, max-age=31536000, immutable"', VIDEO_EDITOR_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_hybrid_audio.py
+++ b/tests/test_builder_hybrid_audio.py
@@ -1,0 +1,113 @@
+import ast
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_SOURCE = ROOT / "VRGDG_MusicVideoBuilderNodes.py"
+UI_SOURCE = ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js"
+
+
+class _CompletedProcess:
+    returncode = 0
+    stderr = ""
+    stdout = ""
+
+
+class _RecordingSubprocess:
+    def __init__(self):
+        self.commands = []
+
+    def run(self, command, **_kwargs):
+        self.commands.append(command)
+        output_path = Path(command[-1])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.touch()
+        return _CompletedProcess()
+
+
+def load_scene_audio_mixer(recording_subprocess):
+    tree = ast.parse(NODE_SOURCE.read_text(encoding="utf-8"), filename=str(NODE_SOURCE))
+    names = {"_concat_file_path", "_scene_audio_mix_folder", "_prepare_scene_audio_mix"}
+    helpers = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    namespace = {
+        "os": os,
+        "shutil": shutil,
+        "subprocess": recording_subprocess,
+        "_find_ffmpeg_path": lambda: "ffmpeg",
+        "_srt_path": lambda folder: os.path.join(folder, "builder_segments.srt"),
+        "_segments_to_srt": lambda _segments: "",
+        "_read_audio_peaks": lambda _path, _count: {"duration": 8.0, "peaks": []},
+        "_estimate_beats_from_audio": lambda *_args, **_kwargs: ([], 0.0),
+    }
+    exec(compile(ast.Module(body=helpers, type_ignores=[]), str(NODE_SOURCE), "exec"), namespace)
+    return namespace["_prepare_scene_audio_mix"]
+
+
+class BuilderHybridAudioTests(unittest.TestCase):
+    def test_global_audio_fills_scenes_without_custom_override(self):
+        recorder = _RecordingSubprocess()
+        prepare_mix = load_scene_audio_mixer(recorder)
+        with tempfile.TemporaryDirectory() as folder:
+            global_audio = Path(folder) / "song.wav"
+            silent_override = Path(folder) / "silent_scene.wav"
+            global_audio.touch()
+            silent_override.touch()
+
+            result = prepare_mix({
+                "project_folder": folder,
+                "global_audio_path": str(global_audio),
+                "segments": [
+                    {"start": 0, "end": 4, "custom_audio_path": ""},
+                    {
+                        "start": 4,
+                        "end": 8,
+                        "custom_audio_path": str(silent_override),
+                        "custom_audio_duration": 4,
+                    },
+                ],
+            })
+
+        trim_commands = [command for command in recorder.commands if "-ss" in command]
+        self.assertEqual(len(trim_commands), 2)
+        self.assertEqual(Path(trim_commands[0][trim_commands[0].index("-i") + 1]), global_audio)
+        self.assertEqual(trim_commands[0][trim_commands[0].index("-ss") + 1], "0.000000")
+        self.assertEqual(Path(trim_commands[1][trim_commands[1].index("-i") + 1]), silent_override)
+        self.assertTrue(result["used_scene_audio"])
+
+    def test_ui_preserves_global_audio_and_prioritizes_it_for_stitch(self):
+        source = UI_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("global_audio_path: currentProjectAudioPath()", source)
+        self.assertIn(
+            "const sceneAudioMode = !embeddedSceneAudioMode && !globalAudioPath && usingSceneAudioMode();",
+            source,
+        )
+        self.assertIn('audio_path: embeddedSceneAudioMode ? "" : globalAudioPath', source)
+
+        prepare_start = source.index("async function prepareSceneAudioMix(")
+        prepare_end = source.index("async function renderSceneVideoWithProgress(", prepare_start)
+        prepare_source = source[prepare_start:prepare_end]
+        self.assertNotIn("audioInput.value = data.audio_path", prepare_source)
+
+    def test_loaded_global_audio_controls_timeline_playback_and_waveform(self):
+        source = UI_SOURCE.read_text(encoding="utf-8")
+        self.assertIn(
+            "return !currentProjectAudioPath() && (usingSceneAudioMode() || usingRenderedSceneAudioMode());",
+            source,
+        )
+        self.assertIn(
+            "const peaks = currentProjectAudioPath() && state.peaks.length ? state.peaks : [0];",
+            source,
+        )
+        self.assertGreaterEqual(source.count("activateGlobalTimelineAudioPlayback(0);"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_menu_scroll.py
+++ b/tests/test_builder_menu_scroll.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+
+BUILDER_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+class BuilderMenuScrollTests(unittest.TestCase):
+    def test_main_menu_is_limited_to_the_viewport_and_scrollable(self):
+        self.assertIn("max-height:min(760px,calc(100vh - 88px))", BUILDER_SOURCE)
+        self.assertIn("overflow-y:auto", BUILDER_SOURCE)
+        self.assertIn("scrollbar-gutter:stable", BUILDER_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storyboard_subject_picker.py
+++ b/tests/test_storyboard_subject_picker.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STORYBOARD_SOURCE = (
+    ROOT / "web" / "VRGDG_StoryboardBuilderUI.js"
+).read_text(encoding="utf-8")
+BUILDER_SOURCE = (
+    ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+class StoryboardSubjectPickerTests(unittest.TestCase):
+    def test_subject_button_opens_multi_subject_picker(self):
+        self.assertIn("const openStoryboardSubjectPicker = (scene) =>", STORYBOARD_SOURCE)
+        self.assertIn("const selected = new Set(", STORYBOARD_SOURCE)
+        self.assertIn("scene.subject_refs = selectedSubjects;", STORYBOARD_SOURCE)
+        self.assertIn(
+            'openStoryboardSubjectPicker(scene)',
+            STORYBOARD_SOURCE,
+        )
+
+    def test_imported_references_merge_with_existing_references(self):
+        self.assertIn(
+            "if (incomingRefs.subjects.length) {",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "if (incomingRefs.locations.length && !refs.locations_cleared) {",
+            BUILDER_SOURCE,
+        )
+        self.assertNotIn(
+            "if (incomingRefs.subjects.length && !(refs.subjects || []).length) {",
+            BUILDER_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unsharp_strength.py
+++ b/tests/test_unsharp_strength.py
@@ -1,0 +1,18 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = (Path(__file__).resolve().parents[1] / "nodes.py").read_text(encoding="utf-8")
+
+
+class FastUnsharpStrengthTests(unittest.TestCase):
+    def test_strength_widget_supports_values_up_to_ten(self):
+        start = SOURCE.index("class FastUnsharpSharpen:")
+        end = SOURCE.index("class FastLaplacianSharpen:", start)
+        unsharp_source = SOURCE[start:end]
+        self.assertIn('"max": 10.0', unsharp_source)
+        self.assertNotIn('"max": 2.0', unsharp_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_video_compare_slider.py
+++ b/tests/test_video_compare_slider.py
@@ -1,0 +1,72 @@
+import ast
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_SOURCE = ROOT / "VRGDG_VideoCompareNode.py"
+UI_SOURCE = ROOT / "web" / "VRGDG_VideoCompare.js"
+INIT_SOURCE = ROOT / "__init__.py"
+
+
+class _FolderPaths:
+    def __init__(self, root):
+        self.root = root
+
+    def get_output_directory(self):
+        return self.root
+
+    def get_temp_directory(self):
+        return self.root
+
+    def get_input_directory(self):
+        return self.root
+
+
+def load_video_path_resolver(root):
+    tree = ast.parse(NODE_SOURCE.read_text(encoding="utf-8"), filename=str(NODE_SOURCE))
+    names = {"_video_path_candidates", "_resolve_video_path"}
+    helpers = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    namespace = {
+        "os": os,
+        "folder_paths": _FolderPaths(root),
+        "_VIDEO_EXTENSIONS": {".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v"},
+    }
+    exec(compile(ast.Module(body=helpers, type_ignores=[]), str(NODE_SOURCE), "exec"), namespace)
+    return namespace["_resolve_video_path"]
+
+
+class VideoCompareSliderTests(unittest.TestCase):
+    def test_vhs_output_resolves_the_final_video_file(self):
+        with tempfile.TemporaryDirectory() as folder:
+            metadata = Path(folder) / "preview.png"
+            silent_video = Path(folder) / "preview.mp4"
+            audio_video = Path(folder) / "preview-audio.mp4"
+            for path in (metadata, silent_video, audio_video):
+                path.touch()
+            resolve = load_video_path_resolver(folder)
+            result = resolve((True, [str(metadata), str(silent_video), str(audio_video)]), "Before")
+            self.assertEqual(Path(result), audio_video)
+
+    def test_node_and_frontend_are_registered(self):
+        node_source = NODE_SOURCE.read_text(encoding="utf-8")
+        ui_source = UI_SOURCE.read_text(encoding="utf-8")
+        init_source = INIT_SOURCE.read_text(encoding="utf-8")
+
+        self.assertIn('"VRGDG_VideoCompareSlider": VRGDG_VideoCompareSlider', node_source)
+        self.assertIn('".VRGDG_VideoCompareNode"', init_source)
+        self.assertIn('const NODE_NAME = "VRGDG_VideoCompareSlider"', ui_source)
+        self.assertIn('this.addDOMWidget("video_compare"', ui_source)
+        self.assertIn("afterClip.style.clipPath", ui_source)
+        self.assertIn("Promise.all([beforeVideo.play(), afterVideo.play()])", ui_source)
+        self.assertIn("requestAnimationFrame(animationSync)", ui_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,41 @@
   "product": "LTX 2.3 Video Builder",
   "releases": [
     {
+      "id": "2026-07-30-video-compare-builder-reliability",
+      "version": "2026.07.30",
+      "date": "2026-07-30",
+      "title": "Video comparison, global audio, and Builder performance",
+      "commit": "91d025e0439e566ed3989604f3619471bf36f7e5",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added VRGDG Video Compare Slider with synchronized before-and-after playback, a draggable comparison divider, timeline scrubbing, looping, labels, and optional audio.",
+            "Added a visual Storyboard subject picker for assigning one or more existing Reference Builder subjects to a scene or uploading a new subject."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Increased Fast Unsharp Sharpen strength from a maximum of 2.0 to 10.0.",
+            "Improved Video Builder undo memory by deduplicating embedded media and recording inspector text edits once per edit session.",
+            "Added stable, versioned thumbnail URLs and immutable caching so scene thumbnails are not downloaded again on every render.",
+            "Storyboard imports now merge incoming subjects and locations with existing references instead of ignoring new references when mappings already exist."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Global audio now remains the preferred final soundtrack and fills scenes without custom audio during scene-audio preparation and stitching.",
+            "Loading or restoring global audio now correctly restores timeline playback and the visible waveform instead of remaining on silent scene audio.",
+            "The Video Builder menu now stays inside the viewport and scrolls so every menu action remains accessible."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-07-28-builder-lyric-timing",
       "version": "2026.07.28",
       "date": "2026-07-28",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -1403,6 +1403,27 @@ function makeEditorImageUrl(path) {
   return `/vrgdg/video_editor/image?path=${encodeURIComponent(path)}&rand=${Date.now()}`;
 }
 
+const EDITOR_THUMBNAIL_SESSION_VERSION = Date.now();
+let editorThumbnailRefreshCounter = 0;
+const editorThumbnailVersionByPath = new Map();
+
+function editorThumbnailPathKey(path) {
+  return String(path || "").trim().replace(/\//g, "\\").toLowerCase();
+}
+
+function refreshEditorThumbnailUrl(path) {
+  const key = editorThumbnailPathKey(path);
+  if (!key) return;
+  editorThumbnailRefreshCounter += 1;
+  editorThumbnailVersionByPath.set(key, `${Date.now()}_${editorThumbnailRefreshCounter}`);
+}
+
+function makeEditorThumbnailUrl(path) {
+  const key = editorThumbnailPathKey(path);
+  const version = editorThumbnailVersionByPath.get(key) || EDITOR_THUMBNAIL_SESSION_VERSION;
+  return `/vrgdg/video_editor/image?path=${encodeURIComponent(path)}&thumbv=${encodeURIComponent(version)}`;
+}
+
 function makeEditorVideoUrl(path) {
   return `/vrgdg/video_editor/video?path=${encodeURIComponent(path)}&rand=${Date.now()}`;
 }
@@ -2172,7 +2193,7 @@ function openBuilder(node) {
   stopWorkflowButton.style.borderColor = "#7f1d1d";
   stopWorkflowButton.style.color = "#fee2e2";
   const menuDropdown = document.createElement("div");
-  menuDropdown.style.cssText = "display:none;position:absolute;left:12px;top:52px;z-index:20;min-width:260px;border:1px solid #3f3f46;border-radius:8px;background:#18181b;box-shadow:0 18px 60px rgba(0,0,0,.55);padding:8px;gap:6px;flex-direction:column;";
+  menuDropdown.style.cssText = "display:none;position:absolute;left:12px;top:52px;z-index:20;min-width:260px;max-height:min(760px,calc(100vh - 88px));overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;scrollbar-gutter:stable;box-sizing:border-box;border:1px solid #3f3f46;border-radius:8px;background:#18181b;box-shadow:0 18px 60px rgba(0,0,0,.55);padding:8px;gap:6px;flex-direction:column;";
   const styleMenuItem = (button) => {
     button.style.width = "100%";
     button.style.textAlign = "left";
@@ -5118,6 +5139,7 @@ function openBuilder(node) {
   const state = {
     duration: 0,
     audioDuration: 0,
+    audioPath: String(audioInput.value || ""),
     peaks: [],
     beats: [],
     detectedTempoBpm: 0,
@@ -7344,6 +7366,7 @@ function openBuilder(node) {
     const customAudioPath = String(segment.custom_audio_path || "").trim();
     if (customAudioPath) return customAudioPath;
     if (usingRenderedSceneAudioMode()) return String(selectedSegmentVideoPath(segment) || "").trim();
+    if (usingSceneAudioMode()) return currentProjectAudioPath();
     return "";
   }
 
@@ -7354,7 +7377,9 @@ function openBuilder(node) {
 
   function timelineAudioSourceStartForSegment(segment) {
     if (!segment) return 0;
-    return String(segment.custom_audio_path || "").trim() ? audioSourceStart(segment) : 0;
+    return String(segment.custom_audio_path || "").trim()
+      ? audioSourceStart(segment)
+      : Math.max(0, Number(segment.start || 0));
   }
 
   function timelineAudioDurationForSegment(segment) {
@@ -7482,7 +7507,10 @@ function openBuilder(node) {
   function activateSegmentVideoPath(segment, videoPath, thumbnailPath = "") {
     if (!segment || !String(videoPath || "").trim()) return;
     segment.video_path = String(videoPath || "").trim();
-    if (String(thumbnailPath || "").trim()) segment.video_thumbnail_path = String(thumbnailPath || "").trim();
+    if (String(thumbnailPath || "").trim()) {
+      segment.video_thumbnail_path = String(thumbnailPath || "").trim();
+      refreshEditorThumbnailUrl(segment.video_thumbnail_path);
+    }
     normalizeSegmentVideoHistory(segment);
     const selectedIndex = segment.video_history.findIndex((item) => mediaPathKey(item) === mediaPathKey(segment.video_path));
     if (selectedIndex >= 0) segment.video_history_index = selectedIndex;
@@ -7509,7 +7537,7 @@ function openBuilder(node) {
   }
 
   function playbackDuration() {
-    if (!usingSceneAudioMode() && !usingRenderedSceneAudioMode() && currentProjectAudioPath()) {
+    if (currentProjectAudioPath()) {
       const audioEnd = loadedGlobalAudioDuration();
       if (audioEnd > 0) return audioEnd;
     }
@@ -7695,12 +7723,30 @@ function openBuilder(node) {
   }
 
   function currentGlobalTime() {
-    if (!state.sceneSelectionUsesGlobalAudio && (usingSceneAudioMode() || usingRenderedSceneAudioMode() || (sceneAudio.src && !sceneAudio.paused))) return Number(state.sceneAudioGlobalTime || 0);
+    if (usingSceneAudioPlaybackMode() && (!state.sceneSelectionUsesGlobalAudio || (sceneAudio.src && !sceneAudio.paused))) {
+      return Number(state.sceneAudioGlobalTime || 0);
+    }
     return Number(audio.currentTime || 0);
   }
 
   function currentProjectAudioPath() {
     return String(audioInput.value || state.audioPath || "").trim();
+  }
+
+  function usingSceneAudioPlaybackMode() {
+    return !currentProjectAudioPath() && (usingSceneAudioMode() || usingRenderedSceneAudioMode());
+  }
+
+  function activateGlobalTimelineAudioPlayback(startTime = 0) {
+    const start = Math.max(0, Number(startTime || 0));
+    sceneAudio.pause();
+    sceneAudio.onloadedmetadata = null;
+    sceneAudio.removeAttribute("src");
+    sceneAudio.load();
+    state.sceneAudioSegmentId = "";
+    state.sceneAudioGlobalTime = start;
+    state.sceneSelectionUsesGlobalAudio = true;
+    seekAudioWhenReady(start);
   }
 
   function audioSourceDurationForScene(segment) {
@@ -8501,6 +8547,45 @@ function openBuilder(node) {
     else segment.use_i2v_vision_reference = Boolean(enabled);
   }
 
+  const HISTORY_BLOB_TOKEN_PREFIX = "__VRGDG_HISTORY_BLOB__:";
+  let nextHistoryBlobToken = 1;
+  const historyBlobByToken = new Map();
+  const historyTokenByBlob = new Map();
+
+  function historySnapshotReplacer(key, value) {
+    if (typeof value !== "string") return value;
+    const isMediaDataUrl = /^data:(?:image|video|audio)\//i.test(value);
+    const isLargeDataField = value.length >= 65536 && (key === "data" || /(?:_data|Data)$/.test(key));
+    if (!isMediaDataUrl && !isLargeDataField) return value;
+    let token = historyTokenByBlob.get(value);
+    if (!token) {
+      token = `${HISTORY_BLOB_TOKEN_PREFIX}${nextHistoryBlobToken++}`;
+      historyTokenByBlob.set(value, token);
+      historyBlobByToken.set(token, value);
+    }
+    return token;
+  }
+
+  function historySnapshotReviver(_key, value) {
+    if (typeof value !== "string" || !value.startsWith(HISTORY_BLOB_TOKEN_PREFIX)) return value;
+    return historyBlobByToken.get(value) ?? value;
+  }
+
+  function pruneHistoryBlobCache() {
+    const snapshots = [...state.undoStack, ...state.redoStack];
+    for (const [token, blob] of historyBlobByToken.entries()) {
+      if (snapshots.some((snapshot) => snapshot.includes(token))) continue;
+      historyBlobByToken.delete(token);
+      historyTokenByBlob.delete(blob);
+    }
+  }
+
+  function clearHistoryBlobCache() {
+    historyBlobByToken.clear();
+    historyTokenByBlob.clear();
+    nextHistoryBlobToken = 1;
+  }
+
   function historySnapshot() {
     return JSON.stringify({
       segments: state.segments,
@@ -8569,11 +8654,11 @@ function openBuilder(node) {
       autoImg2ImgStartStep: normalizeAutoImg2ImgStartStep(state.autoImg2ImgStartStep),
       autoImg2ImgCreativity: normalizeAutoImg2ImgCreativity(state.autoImg2ImgCreativity),
       promptToolsHintPrefs: state.promptToolsHintPrefs,
-    });
+    }, historySnapshotReplacer);
   }
 
   function restoreHistorySnapshot(snapshot) {
-    const data = JSON.parse(snapshot);
+    const data = JSON.parse(snapshot, historySnapshotReviver);
     state.isRestoringHistory = true;
     state.segments = data.segments || [];
     state.overlaySegments = data.overlaySegments || data.overlay_segments || [];
@@ -8677,6 +8762,7 @@ function openBuilder(node) {
     state.undoStack.push(snapshot);
     if (state.undoStack.length > 50) state.undoStack.shift();
     state.redoStack = [];
+    pruneHistoryBlobCache();
     updateHistoryButtons();
   }
 
@@ -8687,6 +8773,7 @@ function openBuilder(node) {
     state.redoStack.push(current);
     if (state.redoStack.length > 50) state.redoStack.shift();
     restoreHistorySnapshot(previous);
+    pruneHistoryBlobCache();
     syncPromptJsonFromSegments("undo");
     syncI2VMotionJsonFromSegments("undo");
   }
@@ -8698,6 +8785,7 @@ function openBuilder(node) {
     state.undoStack.push(current);
     if (state.undoStack.length > 50) state.undoStack.shift();
     restoreHistorySnapshot(next);
+    pruneHistoryBlobCache();
     syncPromptJsonFromSegments("redo");
     syncI2VMotionJsonFromSegments("redo");
   }
@@ -11219,13 +11307,13 @@ function openBuilder(node) {
   function mediaThumbnailHtml(segment, height = 56) {
     const imagePath = selectedSegmentImageThumbnailPath(segment);
     if (imagePath) {
-      return `<img src="${escapeHtml(makeEditorImageUrl(imagePath))}" style="width:100%;height:${height}px;object-fit:cover;border-radius:4px;margin-top:6px;background:#050505;">`;
+      return `<img src="${escapeHtml(makeEditorThumbnailUrl(imagePath))}" style="width:100%;height:${height}px;object-fit:cover;border-radius:4px;margin-top:6px;background:#050505;">`;
     }
     const videoPath = selectedSegmentVideoPath(segment);
     if (!videoPath) return "";
     const thumbnailPath = selectedSegmentVideoThumbnailPath(segment);
     if (thumbnailPath) {
-      return `<img src="${escapeHtml(makeEditorImageUrl(thumbnailPath))}" title="${escapeHtml(videoPath)}" style="width:100%;height:${height}px;object-fit:cover;border-radius:4px;margin-top:6px;background:#050505;">`;
+      return `<img src="${escapeHtml(makeEditorThumbnailUrl(thumbnailPath))}" title="${escapeHtml(videoPath)}" style="width:100%;height:${height}px;object-fit:cover;border-radius:4px;margin-top:6px;background:#050505;">`;
     }
     return `<div title="${escapeHtml(videoPath)}" style="width:100%;height:${height}px;box-sizing:border-box;border:1px solid #155e75;border-radius:4px;margin-top:6px;background:#020617;display:flex;align-items:center;justify-content:center;color:#67e8f9;font-size:11px;font-weight:900;letter-spacing:0;">VIDEO</div>`;
   }
@@ -11233,7 +11321,7 @@ function openBuilder(node) {
   function timelineImageSourceUrl(image = {}) {
     const source = image && typeof image === "object" ? image : {};
     if (source.data) return String(source.data);
-    if (source.path) return makeEditorImageUrl(source.path);
+    if (source.path) return makeEditorThumbnailUrl(source.path);
     return "";
   }
 
@@ -11291,7 +11379,7 @@ function openBuilder(node) {
     const visual = document.createElement("span");
     visual.title = videoPath;
     if (thumbnailPath) {
-      const thumbnailUrl = makeEditorImageUrl(thumbnailPath).replace(/"/g, "%22");
+      const thumbnailUrl = makeEditorThumbnailUrl(thumbnailPath).replace(/"/g, "%22");
       visual.style.cssText = `position:absolute;inset:0;background:linear-gradient(rgba(0,0,0,.18),rgba(0,0,0,.18)),url("${thumbnailUrl}") center / auto 100% repeat-x;pointer-events:none;z-index:0;`;
     } else {
       visual.textContent = "VIDEO";
@@ -11734,7 +11822,7 @@ function openBuilder(node) {
     const maxTime = playbackDuration();
     const time = Math.max(0, Math.min(maxTime, Number(value || 0)));
     state.sceneAudioGlobalTime = time;
-    if (!state.sceneSelectionUsesGlobalAudio && (usingSceneAudioMode() || usingRenderedSceneAudioMode())) {
+    if (!state.sceneSelectionUsesGlobalAudio && usingSceneAudioPlaybackMode()) {
       const segment = timelineAudioSegmentAtTime(time) || playbackSegmentAtTime(time) || state.segments[state.segments.length - 1] || null;
       if (segment) state.activeId = segment.id;
       const sourcePath = timelineAudioPathForSegment(segment);
@@ -14524,7 +14612,7 @@ function openBuilder(node) {
     const waveBottom = timelineCanvas.height - 10;
     const waveHeight = Math.max(24, waveBottom - waveTop);
     const mid = waveTop + waveHeight / 2;
-    const peaks = state.peaks.length && !usingSceneAudioMode() ? state.peaks : [0];
+    const peaks = currentProjectAudioPath() && state.peaks.length ? state.peaks : [0];
     const gain = WAVEFORM_MODES[state.waveformMode]?.gain || 1;
     for (let x = 0; x < width; x++) {
       const index = Math.floor((x / width) * peaks.length);
@@ -14907,7 +14995,7 @@ function openBuilder(node) {
         || (videoMode === "rtv" && rtvReferenceBehaviorForSegment(segment) === "first_last_frame")
       );
       const previewThumbPath = selectedSegmentImageThumbnailPath(segment);
-      const thumb = !showFirstLastFrameThumb && previewThumbPath ? makeEditorImageUrl(previewThumbPath) : "";
+      const thumb = !showFirstLastFrameThumb && previewThumbPath ? makeEditorThumbnailUrl(previewThumbPath) : "";
       const hasVideoPreview = Boolean(selectedSegmentVideoPath(segment));
       const inserted = !isOverlay && state.srtMode && segment.source !== "srt";
       const lockedByVideo = hasLockedVideo(segment);
@@ -28575,6 +28663,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       audio.dataset.path = data.audio_path || audioInput.value;
       audio.src = audioUrl(audio.dataset.path);
       audio.load();
+      activateGlobalTimelineAudioPlayback(0);
       globalScrub.max = String(Math.max(0, state.duration));
       setWidgetValue(node, "audio_path", data.audio_path || audioInput.value);
       if (!state.segments.length) {
@@ -28669,6 +28758,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           audio.dataset.path = audioInput.value;
           audio.src = audioUrl(audioInput.value);
           audio.load();
+          activateGlobalTimelineAudioPlayback(0);
           setWidgetValue(node, "audio_path", audioInput.value);
           render();
           toast(`Loaded audio:\n${audioInput.value}`);
@@ -28722,6 +28812,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       audio.dataset.path = audioInput.value;
       audio.src = audioUrl(audioInput.value);
       audio.load();
+      activateGlobalTimelineAudioPlayback(0);
       globalScrub.max = String(Math.max(0, state.duration));
       setWidgetValue(node, "audio_path", audioInput.value);
       if (!state.segments.length) {
@@ -30089,6 +30180,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.videoModelMode = session.video_model_mode || state.videoModelMode || "i2v";
       state.i2vVideoSettings = cloneI2VVideoSettings(session.i2v_video_settings || state.i2vVideoSettings);
       state.promptToolsHintPrefs = session.prompt_tools_hint_prefs || state.promptToolsHintPrefs || {};
+      state.audioPath = String(session.audio_path || "");
       if (session.audio_path) {
         audioInput.value = session.audio_path;
         setWidgetValue(node, "audio_path", session.audio_path);
@@ -30111,9 +30203,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           audio.dataset.path = audioInput.value;
           audio.src = audioUrl(audioInput.value);
           audio.load();
+          activateGlobalTimelineAudioPlayback(0);
         } catch (error) {
           toast(`Loaded session, but audio waveform failed:\n${String(error?.message || error)}`, true);
         }
+      } else {
+        audioInput.value = "";
+        setWidgetValue(node, "audio_path", "");
+        audio.dataset.path = "";
+        audio.removeAttribute("src");
+        audio.load();
       }
       try {
         await recoverSceneVideosFromProject({ projectFolder: state.projectFolder, renderAfter: false });
@@ -30239,6 +30338,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         segment.image_history_index = segment.image_history.length - 1;
       }
       if (data.saved_path) {
+        refreshEditorThumbnailUrl(data.saved_path);
         segment.image_assignment_cleared = false;
         segment.preview_mode = "image";
         promoteChainedFLFSceneImageToEndFrame(segment);
@@ -30253,6 +30353,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   function addSceneImageHistoryPath(segment, imagePath) {
     ensureSegmentRuntimeFields(segment);
     if (!segment || !imagePath) return;
+    refreshEditorThumbnailUrl(imagePath);
     const existingIndex = segment.image_history.findIndex((item) => mediaPathKey(item) === mediaPathKey(imagePath));
     if (existingIndex >= 0) {
       segment.image_history_index = existingIndex;
@@ -33459,11 +33560,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }
         return Array.from(byKey.values());
       };
-      if (incomingRefs.subjects.length && !(refs.subjects || []).length) {
+      if (incomingRefs.subjects.length) {
         refs.subjects = mergeReferenceList(refs.subjects, incomingRefs.subjects);
         refs.subject_count = refs.subjects.length;
       }
-      if (incomingRefs.locations.length && !(refs.locations || []).length && !refs.locations_cleared) {
+      if (incomingRefs.locations.length && !refs.locations_cleared) {
         refs.locations = mergeReferenceList(refs.locations, incomingRefs.locations);
       }
       if (!refs.subject_scene_map || typeof refs.subject_scene_map !== "object") refs.subject_scene_map = {};
@@ -35033,11 +35134,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const embeddedSceneAudioMode = currentVideoMode() === "id_lora" || !!options.useEmbeddedSceneAudio;
     const sceneAudioMode = !embeddedSceneAudioMode && usingSceneAudioMode();
     if (!idLoraMode && !sceneAudioMode && !String(audioInput.value || "").trim()) missing.push("Audio file path is missing.");
-    if (!idLoraMode && sceneAudioMode) {
+    if (!idLoraMode && sceneAudioMode && !currentProjectAudioPath()) {
       const audioCheckScenes = sceneScope === "all" ? state.segments.map((segment, index) => ({ segment, index })) : batchTargetItems(sceneScope, { baseOnly: true });
       audioCheckScenes.forEach(({ segment, index }) => {
         if (!String(segment.custom_audio_path || "").trim()) {
-          missing.push(`${sceneDisplayName(segment, index)}: scene audio is missing.`);
+          missing.push(`${sceneDisplayName(segment, index)}: scene audio is missing and no global audio is available as a fallback.`);
         }
       });
     }
@@ -35168,22 +35269,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const data = await postJson("/vrgdg/music_builder/prepare_scene_audio_mix", {
       project_folder: projectInput.value,
       segments: state.segments,
+      global_audio_path: currentProjectAudioPath(),
       allow_missing_scene_audio: !!options.allowMissingSceneAudio,
     }, 180000);
-    if (data.audio_path) {
-      audioInput.value = data.audio_path;
-      setWidgetValue(node, "audio_path", data.audio_path);
-      audio.dataset.path = data.audio_path;
-      audio.src = audioUrl(data.audio_path);
-      audio.load();
-      state.duration = Math.max(state.duration || 0, Number(data.duration || 0));
-      state.audioDuration = Number(data.duration || 0);
-      enforceAudioTimelineEnd();
-      state.peaks = Array.isArray(data.peaks) ? data.peaks : state.peaks;
-      state.beats = Array.isArray(data.beats) ? data.beats : state.beats;
-      state.beatCalibration = null;
-      showBeatMarkersIfAvailable();
-    }
     if (data.srt_path) {
       state.srtPath = data.srt_path;
       srtInput.value = data.srt_path;
@@ -35536,8 +35624,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         source_start: Math.max(0, Number(segment.overlay_source_start || 0)),
         label: segment.label || `Insert ${index + 1}`,
       }));
+    const globalAudioPath = currentProjectAudioPath();
     const embeddedSceneAudioMode = currentVideoMode() === "id_lora" || !!options.useEmbeddedSceneAudio;
-    const sceneAudioMode = !embeddedSceneAudioMode && usingSceneAudioMode();
+    const sceneAudioMode = !embeddedSceneAudioMode && !globalAudioPath && usingSceneAudioMode();
     const audioPaths = sceneAudioMode ? baseSegments.map((segment) => String(segment.custom_audio_path || "").trim()) : [];
     const audioItems = sceneAudioMode ? baseSegments.map((segment) => ({
       path: String(segment.custom_audio_path || "").trim(),
@@ -35548,7 +35637,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     paths.forEach((path, index) => {
       if (!path) missing.push(`${sceneDisplayName(baseSegments[index], index)}: rendered scene video is missing.`);
       else if (!isLikelyVideoPath(path)) missing.push(`${sceneDisplayName(baseSegments[index], index)}: selected scene media is not a video:\n${path}`);
-      if (sceneAudioMode && !audioPaths[index]) missing.push(`${sceneDisplayName(baseSegments[index], index)}: scene audio is missing.`);
+      if (sceneAudioMode && !audioPaths[index]) {
+        missing.push(`${sceneDisplayName(baseSegments[index], index)}: scene audio is missing and no global audio is available as a fallback.`);
+      }
     });
     overlayItems.forEach((item) => {
       if (!isLikelyVideoPath(item.path)) missing.push(`${item.label || "Insert"}: selected insert media is not a video:\n${item.path}`);
@@ -35570,7 +35661,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     progress?.set(stitchAudioMessage, 94);
     const data = await postJson("/vrgdg/workflow_runner/stitch_scene_videos", {
       scene_paths: paths,
-      audio_path: embeddedSceneAudioMode ? "" : audioInput.value,
+      audio_path: embeddedSceneAudioMode ? "" : globalAudioPath,
       scene_audio_paths: audioPaths,
       scene_audio_items: audioItems,
       use_embedded_scene_audio: embeddedSceneAudioMode,
@@ -38503,6 +38594,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     };
     state.duration = 0;
     state.audioDuration = 0;
+    state.audioPath = "";
     state.peaks = [];
     state.beats = [];
     state.beatCalibration = null;
@@ -38576,6 +38668,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     useVrgdgTextContext.input.checked = true;
     state.undoStack = [];
     state.redoStack = [];
+    clearHistoryBlobCache();
     syncZImageSettingsPanel();
     syncFluxKleinPanel();
     syncErnieImagePanel();
@@ -42895,8 +42988,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   for (const control of [labelInput, startInput, endInput, notesInput, ernieNotesInput, krea2TwoPassNotesInput, i2vNotesInput, t2iPrompt, ernieT2IPrompt, krea2TwoPassT2IPrompt, i2vPrompt, zEnhanceGemmaNotes, zEnhancePromptPreview]) {
-    control.addEventListener("input", updateActiveFromInputs);
-    control.addEventListener("change", updateActiveFromInputs);
+    control.addEventListener("focus", pushHistory);
+    control.addEventListener("input", () => updateActiveFromInputs({ skipHistory: true }));
+    control.addEventListener("change", () => updateActiveFromInputs({ skipHistory: true }));
   }
   freezeTimingControl.input.addEventListener("change", () => {
     pushHistory();
@@ -44106,7 +44200,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       updateAudioScrubbers();
       return;
     }
-    if (!state.sceneSelectionUsesGlobalAudio && (usingSceneAudioMode() || usingRenderedSceneAudioMode())) {
+    if (!state.sceneSelectionUsesGlobalAudio && usingSceneAudioPlaybackMode()) {
       audio.pause();
       playSceneAudioFrom(currentGlobalTime());
       updatePlayPauseButton();

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -3585,6 +3585,120 @@ function openStoryboardBuilder(payload = {}) {
     return ref;
   };
 
+  const openStoryboardSubjectPicker = (scene) => {
+    if (!scene) return;
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100050;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:22px;";
+    const panel = document.createElement("div");
+    panel.style.cssText = "width:min(980px,calc(100vw - 44px));max-height:calc(100vh - 48px);overflow:auto;border:1px solid #155e75;border-radius:10px;background:#0b1220;color:#f8fafc;padding:14px;display:flex;flex-direction:column;gap:12px;box-shadow:0 24px 80px rgba(0,0,0,.62);";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:10px;";
+    const heading = document.createElement("div");
+    heading.textContent = `${scene.scene_number || 1}. ${scene.label || `Scene ${scene.scene_number || 1}`} — Characters Present`;
+    heading.style.cssText = "font-size:16px;font-weight:900;color:#cffafe;";
+    const close = makeButton("Cancel");
+    header.append(heading, close);
+
+    const choices = document.createElement("div");
+    choices.style.cssText = "display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:10px;";
+    const selected = new Set(
+      (Array.isArray(scene.subject_refs) ? scene.subject_refs : [])
+        .map((subject) => String(subject?.id || ""))
+        .filter(Boolean),
+    );
+    const availableSubjects = Array.isArray(state.referenceBuilder.subjects)
+      ? state.referenceBuilder.subjects
+      : [];
+
+    const renderChoices = () => {
+      choices.replaceChildren();
+      const clearSelection = document.createElement("button");
+      clearSelection.type = "button";
+      clearSelection.textContent = "Clear selection";
+      clearSelection.style.cssText = `min-height:132px;border:2px dashed ${selected.size ? "#475569" : "#22d3ee"};border-radius:8px;background:${selected.size ? "#111827" : "#083344"};color:#94a3b8;cursor:pointer;font-weight:900;`;
+      clearSelection.onclick = () => {
+        selected.clear();
+        renderChoices();
+      };
+      choices.append(clearSelection);
+
+      availableSubjects.forEach((subject) => {
+        const subjectId = String(subject.id || "");
+        if (!subjectId) return;
+        const active = selected.has(subjectId);
+        const card = document.createElement("button");
+        card.type = "button";
+        card.style.cssText = `min-height:132px;border:2px solid ${active ? "#22d3ee" : "#334155"};border-radius:8px;background:${active ? "#083344" : "#111827"};color:#f8fafc;padding:8px;display:flex;flex-direction:column;gap:7px;align-items:center;cursor:pointer;`;
+        const preview = document.createElement("div");
+        preview.style.cssText = "width:96px;height:72px;border:1px solid #155e75;border-radius:6px;background:#061620;overflow:hidden;display:flex;align-items:center;justify-content:center;flex:0 0 auto;";
+        const imageSource = storyboardReferenceImageSrc(subject.image || {});
+        if (imageSource) {
+          const image = document.createElement("img");
+          image.src = imageSource;
+          image.alt = subject.name || "Subject reference";
+          image.draggable = false;
+          image.style.cssText = "width:100%;height:100%;object-fit:cover;display:block;";
+          preview.append(image);
+        } else {
+          const empty = document.createElement("span");
+          empty.textContent = "No image";
+          empty.style.cssText = "font-size:11px;font-weight:900;color:#67e8f9;";
+          preview.append(empty);
+        }
+        const name = document.createElement("div");
+        name.textContent = subject.name || "Subject";
+        name.style.cssText = "font-size:12px;font-weight:900;text-align:center;line-height:1.25;";
+        card.append(preview, name);
+        card.onclick = () => {
+          if (selected.has(subjectId)) selected.delete(subjectId);
+          else selected.add(subjectId);
+          renderChoices();
+        };
+        choices.append(card);
+      });
+
+      if (!availableSubjects.length) {
+        const empty = document.createElement("div");
+        empty.textContent = "No subjects are in Reference Builder yet. Use Upload New Subject below to add the first one.";
+        empty.style.cssText = "grid-column:1/-1;border:1px dashed #334155;border-radius:8px;padding:18px;color:#94a3b8;text-align:center;font-size:12px;";
+        choices.append(empty);
+      }
+    };
+
+    const footer = document.createElement("div");
+    footer.style.cssText = "display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;";
+    const upload = makeButton("Upload New Subject");
+    const cancel = makeButton("Cancel");
+    const apply = makeButton("Apply Selection", "primary");
+    const dismiss = () => backdrop.remove();
+    close.onclick = dismiss;
+    cancel.onclick = dismiss;
+    upload.onclick = async () => {
+      dismiss();
+      await addStoryboardReferenceFromFile("subject", scene);
+    };
+    apply.onclick = () => {
+      const selectedSubjects = availableSubjects.filter((subject) => selected.has(String(subject.id || "")));
+      scene.subject_refs = selectedSubjects;
+      scene.subjects = storyboardSubjectNamesFromRefs(selectedSubjects);
+      if (selectedSubjects.length) scene.no_character_present = false;
+      syncReferenceMappingsToVideoCreator();
+      dismiss();
+      renderTable();
+      createToast(selectedSubjects.length
+        ? `${selectedSubjects.length} subject${selectedSubjects.length === 1 ? "" : "s"} mapped to ${scene.label || `Scene ${scene.scene_number}`}.`
+        : `Subject mapping cleared for ${scene.label || `Scene ${scene.scene_number}`}.`);
+    };
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) dismiss();
+    });
+    footer.append(upload, cancel, apply);
+    panel.append(header, choices, footer);
+    backdrop.append(panel);
+    document.body.append(backdrop);
+    renderChoices();
+  };
+
   const openSceneEditor = (scene) => {
     const isVideoPrepMode = state.mode === "image_to_video_prep";
     const isImagePrepMode = !isVideoPrepMode;
@@ -4224,7 +4338,7 @@ function openStoryboardBuilder(payload = {}) {
         </div>`;
       const status = `<span style="display:inline-flex;align-items:center;gap:6px;color:${meta.color};font-weight:900;"><span style="width:8px;height:8px;border-radius:999px;background:${meta.color};display:inline-block;"></span>${escapeHtml(meta.label)}</span>`;
       const miniRefButtonStyle = "margin-top:7px;border:1px dashed #155e75;border-radius:6px;background:#07111f;color:#a5f3fc;padding:5px 7px;font-size:11px;font-weight:900;cursor:pointer;";
-      const subjectCell = `<div>${subjectRefsHtml(scene)}</div><button data-action="load-subject-ref" title="Load a subject image for this scene" style="${miniRefButtonStyle}">+ Subject</button>`;
+      const subjectCell = `<div>${subjectRefsHtml(scene)}</div><button data-action="load-subject-ref" title="Choose subjects from Reference Builder or upload a new subject image" style="${miniRefButtonStyle}">+ Subject</button>`;
       const settingCell = `<div>${settingRefHtml(scene)}</div><button data-action="load-location-ref" title="Load a location image for this scene" style="${miniRefButtonStyle}">+ Location</button>`;
       const videoType = videoPromptTypeLabel(scene.video_prompt_type || "i2v");
       const shotCell = `<div style="display:flex;flex-direction:column;gap:4px;"><span style="align-self:flex-start;border:1px solid #155e75;border-radius:999px;background:#0f172a;color:#a5f3fc;font-size:11px;font-weight:900;padding:2px 7px;">${escapeHtml(videoType)}</span><strong style="color:#f8fafc;">${escapeHtml(scene.shot_type || "-")}</strong></div>`;
@@ -4256,7 +4370,7 @@ function openStoryboardBuilder(payload = {}) {
         `;
       }
       tr.querySelector('[data-action="edit"]')?.addEventListener("click", () => openSceneEditor(scene));
-      tr.querySelector('[data-action="load-subject-ref"]')?.addEventListener("click", () => addStoryboardReferenceFromFile("subject", scene));
+      tr.querySelector('[data-action="load-subject-ref"]')?.addEventListener("click", () => openStoryboardSubjectPicker(scene));
       tr.querySelector('[data-action="load-location-ref"]')?.addEventListener("click", () => addStoryboardReferenceFromFile("location", scene));
       tr.querySelector('[data-action="gemma"]')?.addEventListener("click", async () => {
         const runnerName = promptRunnerName();

--- a/web/VRGDG_VideoCompare.js
+++ b/web/VRGDG_VideoCompare.js
@@ -1,0 +1,484 @@
+import { app } from "../../../scripts/app.js";
+import { api } from "../../../scripts/api.js";
+
+const NODE_NAME = "VRGDG_VideoCompareSlider";
+const MIN_WIDTH = 560;
+const MIN_HEIGHT = 560;
+
+function getWidget(node, name) {
+  return node.widgets?.find((widget) => widget.name === name);
+}
+
+function widgetValue(node, name, fallback) {
+  return getWidget(node, name)?.value ?? fallback;
+}
+
+function setWidgetValue(node, name, value) {
+  const widget = getWidget(node, name);
+  if (!widget) return;
+  widget.value = value;
+  widget.callback?.(value);
+}
+
+function videoUrl(path) {
+  return api.apiURL(`/vrgdg/video_editor/video?path=${encodeURIComponent(path)}&v=${Date.now()}`);
+}
+
+function formatTime(value) {
+  const seconds = Math.max(0, Number(value || 0));
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds - minutes * 60;
+  return `${String(minutes).padStart(2, "0")}:${remainder.toFixed(2).padStart(5, "0")}`;
+}
+
+function createButton(label, title = "") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = label;
+  button.title = title;
+  button.style.cssText = [
+    "min-width:38px",
+    "height:30px",
+    "padding:4px 10px",
+    "border:1px solid #52525b",
+    "border-radius:5px",
+    "background:#27272a",
+    "color:#f4f4f5",
+    "font:700 12px Arial,sans-serif",
+    "cursor:pointer",
+  ].join(";");
+  return button;
+}
+
+function createCompareUI(node) {
+  const root = document.createElement("div");
+  root.style.cssText = [
+    "width:100%",
+    "height:430px",
+    "display:flex",
+    "flex-direction:column",
+    "gap:7px",
+    "box-sizing:border-box",
+    "padding:6px",
+    "background:#18181b",
+    "color:#f4f4f5",
+    "font-family:Arial,sans-serif",
+    "user-select:none",
+    "overflow:hidden",
+  ].join(";");
+
+  const stage = document.createElement("div");
+  stage.style.cssText = [
+    "position:relative",
+    "flex:1 1 auto",
+    "min-height:260px",
+    "overflow:hidden",
+    "border:1px solid #3f3f46",
+    "border-radius:7px",
+    "background:#050505",
+    "touch-action:none",
+    "cursor:ew-resize",
+  ].join(";");
+
+  const beforeVideo = document.createElement("video");
+  const afterVideo = document.createElement("video");
+  for (const video of [beforeVideo, afterVideo]) {
+    video.preload = "metadata";
+    video.playsInline = true;
+    video.disablePictureInPicture = true;
+    video.style.cssText = "position:absolute;inset:0;width:100%;height:100%;object-fit:contain;background:#050505;pointer-events:none;";
+  }
+  afterVideo.muted = true;
+
+  const afterClip = document.createElement("div");
+  afterClip.style.cssText = "position:absolute;inset:0;overflow:hidden;pointer-events:none;";
+  afterClip.append(afterVideo);
+
+  const divider = document.createElement("div");
+  divider.style.cssText = [
+    "position:absolute",
+    "top:0",
+    "bottom:0",
+    "width:2px",
+    "background:#fff",
+    "box-shadow:0 0 0 1px rgba(0,0,0,.7),0 0 14px rgba(255,255,255,.35)",
+    "transform:translateX(-1px)",
+    "pointer-events:none",
+  ].join(";");
+
+  const handle = document.createElement("div");
+  handle.textContent = "↔";
+  handle.style.cssText = [
+    "position:absolute",
+    "top:50%",
+    "width:34px",
+    "height:34px",
+    "display:flex",
+    "align-items:center",
+    "justify-content:center",
+    "border:1px solid rgba(0,0,0,.55)",
+    "border-radius:999px",
+    "background:rgba(255,255,255,.94)",
+    "color:#111",
+    "font:900 17px Arial,sans-serif",
+    "box-shadow:0 3px 14px rgba(0,0,0,.55)",
+    "transform:translate(-50%,-50%)",
+    "pointer-events:none",
+  ].join(";");
+
+  const beforeLabel = document.createElement("div");
+  const afterLabel = document.createElement("div");
+  for (const label of [beforeLabel, afterLabel]) {
+    label.style.cssText = [
+      "position:absolute",
+      "top:9px",
+      "padding:5px 8px",
+      "border-radius:5px",
+      "background:rgba(0,0,0,.68)",
+      "color:#fff",
+      "font:900 11px Arial,sans-serif",
+      "pointer-events:none",
+    ].join(";");
+  }
+  beforeLabel.style.left = "9px";
+  afterLabel.style.right = "9px";
+
+  const empty = document.createElement("div");
+  empty.textContent = "Run the node to load the before and after videos";
+  empty.style.cssText = [
+    "position:absolute",
+    "inset:0",
+    "display:flex",
+    "align-items:center",
+    "justify-content:center",
+    "padding:20px",
+    "color:#a1a1aa",
+    "font:700 12px Arial,sans-serif",
+    "text-align:center",
+    "pointer-events:none",
+  ].join(";");
+
+  stage.append(beforeVideo, afterClip, divider, handle, beforeLabel, afterLabel, empty);
+
+  const controls = document.createElement("div");
+  controls.style.cssText = "display:grid;grid-template-columns:auto auto minmax(80px,1fr) auto auto;gap:7px;align-items:center;";
+  const playButton = createButton("▶", "Play or pause both videos");
+  const restartButton = createButton("↺", "Restart both videos");
+  const scrubber = document.createElement("input");
+  scrubber.type = "range";
+  scrubber.min = "0";
+  scrubber.max = "0";
+  scrubber.step = "0.01";
+  scrubber.value = "0";
+  scrubber.style.cssText = "width:100%;accent-color:#22d3ee;cursor:pointer;";
+  const timeLabel = document.createElement("div");
+  timeLabel.textContent = "00:00.00 / 00:00.00";
+  timeLabel.style.cssText = "font:700 11px Arial,sans-serif;color:#67e8f9;white-space:nowrap;font-variant-numeric:tabular-nums;";
+  const muteButton = createButton("🔇", "Mute or unmute before-video audio");
+  controls.append(playButton, restartButton, scrubber, timeLabel, muteButton);
+
+  const wipeRow = document.createElement("div");
+  wipeRow.style.cssText = "display:grid;grid-template-columns:auto minmax(80px,1fr) auto;gap:8px;align-items:center;";
+  const wipeTitle = document.createElement("div");
+  wipeTitle.textContent = "Before / After";
+  wipeTitle.style.cssText = "font:800 11px Arial,sans-serif;color:#d4d4d8;white-space:nowrap;";
+  const wipeSlider = document.createElement("input");
+  wipeSlider.type = "range";
+  wipeSlider.min = "0";
+  wipeSlider.max = "1";
+  wipeSlider.step = "0.01";
+  wipeSlider.style.cssText = "width:100%;accent-color:#f4f4f5;cursor:ew-resize;";
+  const wipeValue = document.createElement("div");
+  wipeValue.style.cssText = "min-width:34px;text-align:right;font:700 11px Arial,sans-serif;color:#d4d4d8;";
+  wipeRow.append(wipeTitle, wipeSlider, wipeValue);
+  root.append(stage, controls, wipeRow);
+
+  let dragging = false;
+  let animationFrame = 0;
+  let commonDuration = 0;
+
+  function showLabels() {
+    const visible = !!widgetValue(node, "show_labels", true);
+    beforeLabel.textContent = String(widgetValue(node, "before_label", "Before") || "Before");
+    afterLabel.textContent = String(widgetValue(node, "after_label", "After") || "After");
+    beforeLabel.style.display = visible ? "" : "none";
+    afterLabel.style.display = visible ? "" : "none";
+  }
+
+  function setWipe(value, updateWidget = false) {
+    const position = Math.max(0, Math.min(1, Number(value ?? 0.5)));
+    const percent = position * 100;
+    afterClip.style.clipPath = `inset(0 0 0 ${percent}%)`;
+    divider.style.left = `${percent}%`;
+    handle.style.left = `${percent}%`;
+    wipeSlider.value = String(position);
+    wipeValue.textContent = `${Math.round(percent)}%`;
+    if (updateWidget) {
+      const rounded = Math.round(position * 100) / 100;
+      const widget = getWidget(node, "slider_position");
+      if (widget && Number(widget.value) !== rounded) {
+        widget.value = rounded;
+      }
+    }
+  }
+
+  function setWipeFromPointer(event) {
+    const rect = stage.getBoundingClientRect();
+    if (!rect.width) return;
+    setWipe((event.clientX - rect.left) / rect.width, true);
+  }
+
+  function calculateDuration() {
+    const durations = [Number(beforeVideo.duration), Number(afterVideo.duration)]
+      .filter((value) => Number.isFinite(value) && value > 0);
+    commonDuration = durations.length ? Math.min(...durations) : 0;
+    scrubber.max = String(commonDuration);
+    updateTime();
+  }
+
+  function updateTime() {
+    const current = Math.min(commonDuration || Number(beforeVideo.currentTime || 0), Number(beforeVideo.currentTime || 0));
+    if (document.activeElement !== scrubber) scrubber.value = String(Math.max(0, current));
+    timeLabel.textContent = `${formatTime(current)} / ${formatTime(commonDuration)}`;
+  }
+
+  function seekBoth(value) {
+    const target = Math.max(0, Math.min(commonDuration || Number(value || 0), Number(value || 0)));
+    try {
+      beforeVideo.currentTime = target;
+      afterVideo.currentTime = target;
+    } catch {
+      // Metadata may still be loading. The next scrub/play event retries.
+    }
+    updateTime();
+  }
+
+  function pauseBoth() {
+    beforeVideo.pause();
+    afterVideo.pause();
+    playButton.textContent = "▶";
+    if (animationFrame) cancelAnimationFrame(animationFrame);
+    animationFrame = 0;
+  }
+
+  function animationSync() {
+    if (beforeVideo.paused) {
+      animationFrame = 0;
+      return;
+    }
+    if (commonDuration > 0 && beforeVideo.currentTime >= commonDuration - 0.025) {
+      if (widgetValue(node, "loop", true)) {
+        seekBoth(0);
+      } else {
+        seekBoth(commonDuration);
+        pauseBoth();
+        return;
+      }
+    }
+    if (Math.abs(Number(afterVideo.currentTime || 0) - Number(beforeVideo.currentTime || 0)) > 0.08) {
+      try {
+        afterVideo.currentTime = beforeVideo.currentTime;
+      } catch {
+        // Retry on the next animation frame.
+      }
+    }
+    updateTime();
+    animationFrame = requestAnimationFrame(animationSync);
+  }
+
+  async function playBoth() {
+    if (!beforeVideo.src || !afterVideo.src) return;
+    if (commonDuration > 0 && beforeVideo.currentTime >= commonDuration - 0.025) seekBoth(0);
+    afterVideo.muted = true;
+    beforeVideo.muted = !!widgetValue(node, "muted", true);
+    try {
+      afterVideo.currentTime = beforeVideo.currentTime;
+      await Promise.all([beforeVideo.play(), afterVideo.play()]);
+      playButton.textContent = "Ⅱ";
+      if (!animationFrame) animationFrame = requestAnimationFrame(animationSync);
+    } catch (error) {
+      pauseBoth();
+      console.warn("[VRGDG Video Compare] Playback failed:", error);
+    }
+  }
+
+  function clearVideo(video) {
+    video.pause();
+    video.removeAttribute("src");
+    video.load();
+  }
+
+  function applyWidgets() {
+    setWipe(widgetValue(node, "slider_position", 0.5), false);
+    showLabels();
+    beforeVideo.muted = !!widgetValue(node, "muted", true);
+    muteButton.textContent = beforeVideo.muted ? "🔇" : "🔊";
+  }
+
+  stage.addEventListener("pointerdown", (event) => {
+    dragging = true;
+    stage.setPointerCapture?.(event.pointerId);
+    setWipeFromPointer(event);
+  });
+  stage.addEventListener("pointermove", (event) => {
+    if (dragging) setWipeFromPointer(event);
+  });
+  stage.addEventListener("pointerup", (event) => {
+    dragging = false;
+    stage.releasePointerCapture?.(event.pointerId);
+  });
+  stage.addEventListener("pointercancel", () => {
+    dragging = false;
+  });
+  wipeSlider.addEventListener("input", () => setWipe(wipeSlider.value, true));
+  scrubber.addEventListener("input", () => seekBoth(scrubber.value));
+  playButton.addEventListener("click", () => {
+    if (beforeVideo.paused) playBoth();
+    else pauseBoth();
+  });
+  restartButton.addEventListener("click", () => {
+    const wasPlaying = !beforeVideo.paused;
+    seekBoth(0);
+    if (wasPlaying) playBoth();
+  });
+  muteButton.addEventListener("click", () => {
+    const muted = !beforeVideo.muted;
+    beforeVideo.muted = muted;
+    setWidgetValue(node, "muted", muted);
+    muteButton.textContent = muted ? "🔇" : "🔊";
+  });
+  beforeVideo.addEventListener("loadedmetadata", calculateDuration);
+  afterVideo.addEventListener("loadedmetadata", calculateDuration);
+  beforeVideo.addEventListener("pause", () => {
+    if (!beforeVideo.ended) pauseBoth();
+  });
+  beforeVideo.addEventListener("ratechange", () => {
+    afterVideo.playbackRate = beforeVideo.playbackRate;
+  });
+  root.addEventListener("pointerdown", (event) => event.stopPropagation());
+  root.addEventListener("pointermove", (event) => event.stopPropagation());
+  root.addEventListener("pointerup", (event) => event.stopPropagation());
+  root.addEventListener("wheel", (event) => event.stopPropagation(), { passive: true });
+  root.addEventListener("contextmenu", (event) => event.stopPropagation());
+
+  applyWidgets();
+
+  return {
+    root,
+    applyWidgets,
+    load(items = [], settings = {}) {
+      pauseBoth();
+      const beforeInfo = items.find((item) => item?.compare_role === "before") || items[0];
+      const afterInfo = items.find((item) => item?.compare_role === "after") || items[1];
+      if (!beforeInfo?.path || !afterInfo?.path) return;
+      if (settings.slider_position !== undefined) setWidgetValue(node, "slider_position", settings.slider_position);
+      for (const [name, value] of [
+        ["before_label", settings.before_label],
+        ["after_label", settings.after_label],
+        ["show_labels", settings.show_labels],
+        ["loop", settings.loop],
+        ["muted", settings.muted],
+      ]) {
+        if (value !== undefined) {
+          const widget = getWidget(node, name);
+          if (widget) widget.value = value;
+        }
+      }
+      commonDuration = 0;
+      scrubber.max = "0";
+      scrubber.value = "0";
+      beforeVideo.src = videoUrl(beforeInfo.path);
+      afterVideo.src = videoUrl(afterInfo.path);
+      beforeVideo.load();
+      afterVideo.load();
+      empty.style.display = "none";
+      applyWidgets();
+      node.setDirtyCanvas?.(true, true);
+    },
+    destroy() {
+      pauseBoth();
+      clearVideo(beforeVideo);
+      clearVideo(afterVideo);
+    },
+  };
+}
+
+app.registerExtension({
+  name: "vrgdg." + NODE_NAME,
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_NAME) return;
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    const onConfigure = nodeType.prototype.onConfigure;
+    const onExecuted = nodeType.prototype.onExecuted;
+    const onRemoved = nodeType.prototype.onRemoved;
+    const onResize = nodeType.prototype.onResize;
+
+    nodeType.prototype.onNodeCreated = function () {
+      const result = onNodeCreated?.apply(this, arguments);
+      this.resizable = true;
+      this.serialize_widgets = true;
+      this.size = [
+        Math.max(MIN_WIDTH, this.size?.[0] || MIN_WIDTH),
+        Math.max(MIN_HEIGHT, this.size?.[1] || MIN_HEIGHT),
+      ];
+      const ui = createCompareUI(this);
+      this._vrgdgVideoCompareUI = ui;
+      const domWidget = this.addDOMWidget("video_compare", "vrgdg-video-compare", ui.root, {
+        serialize: false,
+        hideOnZoom: false,
+        getMinHeight: () => 430,
+        getMaxHeight: () => 430,
+      });
+      if (domWidget) {
+        domWidget.serialize = false;
+        domWidget.computeSize = (width) => [width, 430];
+      }
+      for (const widget of this.widgets || []) {
+        if (widget.name === "video_compare" || widget._vrgdgVideoCompareBound) continue;
+        const callback = widget.callback;
+        widget.callback = function () {
+          const callbackResult = callback?.apply(this, arguments);
+          ui.applyWidgets();
+          return callbackResult;
+        };
+        widget._vrgdgVideoCompareBound = true;
+      }
+      return result;
+    };
+
+    nodeType.prototype.onConfigure = function () {
+      const result = onConfigure?.apply(this, arguments);
+      this.size = [
+        Math.max(MIN_WIDTH, this.size?.[0] || MIN_WIDTH),
+        Math.max(MIN_HEIGHT, this.size?.[1] || MIN_HEIGHT),
+      ];
+      this._vrgdgVideoCompareUI?.applyWidgets();
+      return result;
+    };
+
+    nodeType.prototype.onExecuted = function (message) {
+      onExecuted?.apply(this, arguments);
+      this._vrgdgVideoCompareUI?.load(
+        message?.compare_videos || [],
+        message?.compare_video_settings || {},
+      );
+    };
+
+    nodeType.prototype.onResize = function (size) {
+      const result = onResize?.apply(this, arguments);
+      this.size = [
+        Math.max(MIN_WIDTH, size?.[0] || MIN_WIDTH),
+        Math.max(MIN_HEIGHT, size?.[1] || MIN_HEIGHT),
+      ];
+      return result;
+    };
+
+    nodeType.prototype.onRemoved = function () {
+      this._vrgdgVideoCompareUI?.destroy();
+      this._vrgdgVideoCompareUI = null;
+      return onRemoved?.apply(this, arguments);
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- add the `VRGDG Video Compare Slider` node with synchronized VHS playback, a draggable before/after wipe, scrubbing, looping, labels, audio control, and pass-through outputs
- make global audio the final-stitch priority and use it as the fallback for scenes without custom audio
- restore the global waveform and timeline playback after loading audio or reopening a project
- make the Video Builder menu viewport-limited and scrollable
- add a visual multi-subject picker to Storyboard Builder and merge imported subjects/locations with existing references
- reduce Builder memory and network churn with deduplicated undo-history media and stable versioned thumbnail URLs
- raise `Fast Unsharp Sharpen` maximum strength from 2.0 to 10.0
- add a July 30 entry to `update_notes.json` for the news and updates banner

## Why

A silent per-scene override could incorrectly displace the project’s global soundtrack, and reloading global audio could leave timeline playback and the waveform tied to silent scene audio. Long menus hid actions below the viewport. Builder history snapshots repeatedly copied large embedded media, while timestamped thumbnail URLs forced unnecessary reloads. Storyboard subject assignment also required uploading instead of choosing existing references.

The comparison node provides an interactive way to evaluate original and processed videos while they play in sync.

## User impact

Users can keep global music while selectively overriding scene audio, access every Builder menu action, compare two videos directly in ComfyUI, assign existing Storyboard subjects visually, use stronger sharpening, and work with lower history-memory and thumbnail-network overhead.

## Validation

- `python -B -m py_compile VRGDG_MusicVideoBuilderNodes.py VRGDG_VideoEditorNodes.py VRGDG_VideoCompareNode.py nodes.py`
- JavaScript module syntax checks for Music Video Builder, Storyboard Builder, and Video Compare
- `python -m json.tool update_notes.json`
- `python -m unittest discover -s tests` — 21 tests passed
- `git diff --check origin/main...HEAD`
