### PR TITLE
Add Video Builder timeline and Storyboard prompt controls

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -729,6 +729,132 @@ def _srt_path(project_folder):
     return os.path.join(project_folder, "builder_segments.srt")
 
 
+def _render_logs_folder(project_folder):
+    return os.path.join(project_folder, "render_logs")
+
+
+def _render_log_duration_text(milliseconds):
+    try:
+        total_seconds = max(0, int(round(float(milliseconds or 0) / 1000.0)))
+    except (TypeError, ValueError):
+        total_seconds = 0
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m {seconds:02d}s"
+    if minutes:
+        return f"{minutes}m {seconds:02d}s"
+    return f"{seconds}s"
+
+
+def _render_log_text(log):
+    log = log if isinstance(log, dict) else {}
+    summary = log.get("summary") if isinstance(log.get("summary"), dict) else {}
+    scenes = log.get("scenes") if isinstance(log.get("scenes"), list) else []
+    lines = [
+        "VRGDG Video Builder Render Log",
+        "=" * 32,
+        f"Session: {log.get('id', '')}",
+        f"Status: {str(log.get('status') or 'unknown').upper()}",
+        f"Project: {log.get('project_folder', '')}",
+        f"Mode: {log.get('mode_label') or log.get('scene_scope') or 'Render All'}",
+        f"Started: {log.get('started_at', '')}",
+        f"Finished: {log.get('ended_at', '')}",
+        "",
+        "Summary",
+        "-" * 32,
+        f"Total wall time: {_render_log_duration_text(summary.get('total_ms', log.get('total_ms', 0)))}",
+        f"Active scene rendering: {_render_log_duration_text(summary.get('render_ms', 0))}",
+        f"Between-render time: {_render_log_duration_text(summary.get('between_render_ms', 0))}",
+        f"Setup time: {_render_log_duration_text(summary.get('setup_ms', 0))}",
+        f"Final stitching: {_render_log_duration_text(summary.get('stitch_ms', 0))}",
+        f"Other overhead: {_render_log_duration_text(summary.get('overhead_ms', 0))}",
+        f"Scenes completed: {int(summary.get('completed_scenes', 0) or 0)}/{int(summary.get('target_scenes', len(scenes)) or 0)}",
+        f"Existing scenes skipped: {int(summary.get('skipped_existing_scenes', 0) or 0)}",
+        f"Average render per completed scene: {_render_log_duration_text(summary.get('average_render_ms', 0))}",
+    ]
+    if log.get("final_video_path"):
+        lines.append(f"Final video: {log.get('final_video_path')}")
+    if log.get("error"):
+        lines.extend(["", f"Error: {log.get('error')}"])
+    lines.extend(["", "Scene Details", "-" * 32])
+    if not scenes:
+        lines.append("No scene render timing has been recorded yet.")
+    for scene in scenes:
+        if not isinstance(scene, dict):
+            continue
+        label = scene.get("label") or f"Scene {scene.get('scene_number', '?')}"
+        lines.extend([
+            f"{label} [{str(scene.get('status') or 'pending').upper()}]",
+            f"  Total scene step: {_render_log_duration_text(scene.get('total_ms', 0))}",
+            f"  Preparation: {_render_log_duration_text(scene.get('preparation_ms', 0))}",
+            f"  Video render: {_render_log_duration_text(scene.get('render_ms', 0))}",
+            f"  Post-processing/cleanup: {_render_log_duration_text(scene.get('post_ms', 0))}",
+            f"  Time since previous render: {_render_log_duration_text(scene.get('gap_before_render_ms', 0))}",
+        ])
+        if scene.get("video_path"):
+            lines.append(f"  Video: {scene.get('video_path')}")
+        if scene.get("error"):
+            lines.append(f"  Error: {scene.get('error')}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _save_builder_render_log(payload):
+    project_folder_raw = str(payload.get("project_folder", "") or "").strip().strip('"')
+    if not project_folder_raw:
+        raise ValueError("Project folder is required before saving a render log.")
+    project_folder = os.path.abspath(project_folder_raw)
+    os.makedirs(project_folder, exist_ok=True)
+    log = payload.get("log") if isinstance(payload.get("log"), dict) else {}
+    if not log:
+        raise ValueError("Render log data is empty.")
+    log_id = re.sub(r"[^A-Za-z0-9._-]+", "_", str(log.get("id") or "").strip()).strip("._")
+    if not log_id:
+        log_id = f"render_{time.strftime('%Y%m%d_%H%M%S')}"
+    log = {**log, "id": log_id, "project_folder": project_folder}
+    logs_folder = _render_logs_folder(project_folder)
+    os.makedirs(logs_folder, exist_ok=True)
+    json_path = os.path.join(logs_folder, f"{log_id}.json")
+    text_path = os.path.join(logs_folder, f"{log_id}.txt")
+    log["report_json_path"] = json_path
+    log["report_text_path"] = text_path
+    json_temp = json_path + ".tmp"
+    text_temp = text_path + ".tmp"
+    with open(json_temp, "w", encoding="utf-8") as handle:
+        json.dump(log, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    with open(text_temp, "w", encoding="utf-8") as handle:
+        handle.write(_render_log_text(log))
+    os.replace(json_temp, json_path)
+    os.replace(text_temp, text_path)
+
+    session_path = _session_path(project_folder)
+    if os.path.isfile(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8-sig") as handle:
+                session = json.load(handle)
+            if not isinstance(session, dict):
+                session = {}
+        except Exception:
+            session = {}
+        logs = session.get("render_logs") if isinstance(session.get("render_logs"), list) else []
+        logs = [item for item in logs if isinstance(item, dict) and item.get("id") != log_id]
+        logs.append(log)
+        session["render_logs"] = logs[-20:]
+        session["active_render_log_id"] = log_id if log.get("status") == "running" else ""
+        session["updated"] = time.time()
+        session_temp = session_path + ".render-log.tmp"
+        with open(session_temp, "w", encoding="utf-8") as handle:
+            json.dump(session, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+        os.replace(session_temp, session_path)
+    return {
+        "log": log,
+        "report_json_path": json_path,
+        "report_text_path": text_path,
+    }
+
+
 def _images_folder(project_folder):
     return os.path.join(project_folder, "zimage_approved")
 
@@ -9131,6 +9257,15 @@ def _ensure_music_builder_routes():
         try:
             payload = await request.json()
             result = _save_builder_session(payload)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        return web.json_response({"ok": True, **result})
+
+    @server_instance.routes.post("/vrgdg/music_builder/save_render_log")
+    async def vrgdg_music_builder_save_render_log(request):
+        try:
+            payload = await request.json()
+            result = _save_builder_render_log(payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -79,8 +79,8 @@ Rules:
 * If `starting_shot.required` is true, the first sentence must explicitly state that the video begins with `starting_shot.selected_starting_shot`. Do not merely imply this framing or move it to the middle or end of the prompt.
 * For an `eyes shot`, explicitly say that the video begins with an extreme close-up of the subject's eyes.
 * Begin the selected `camera_motion` from the required starting-shot framing; it may widen, orbit, track, or otherwise move afterward.
-* Use `motion_video_summary` or `camera_motion` for camera movement.
-* If `camera_motion` is empty, use `motion_video_summary`.
+* If `motion_summary` is non-empty, it is the authoritative custom motion and camera direction. Ignore `camera_motion` rather than combining the two.
+* Use `camera_motion` only when `motion_summary` is empty.
 * Follow `camera_guidance` when present. If it says to avoid default inward moves, do not add zoom-in, push-in, dolly-in, crash-zoom, or close-up endings unless the scene explicitly requests that exact motion.
 * Follow `camera_motion_speed_guidance` or `camera_guidance.camera_motion_speed_guidance` when present. Low values mean static/slow camera; high values mean faster or compound camera action with no static hold ending.
 * Do not default to zoom-in, push-in, dolly-in, crash-zoom, or close-up endings. Use those inward camera moves only when `camera_motion`, `shot_type`, or the user notes explicitly ask for them.
@@ -1163,6 +1163,8 @@ def _build_storyboard_video_prompt(payload):
             or "",
             12000,
         )
+        motion_summary = _clean_scene_text(selected_scene.get("motion_summary") or "", 1200)
+        camera_motion = "" if motion_summary else _clean_scene_text(selected_scene.get("camera_motion") or "", 500)
         user_notes = "\n\n".join(
             part for part in [
                 f"Required starting shot:\n{json.dumps(selected_scene.get('starting_shot'), ensure_ascii=False)}" if _storyboard_starting_shot_value(selected_scene) else "",
@@ -1170,8 +1172,8 @@ def _build_storyboard_video_prompt(payload):
                 f"Scene lyrics:\n{_clean_scene_text(vocal_status.get('lyric_text') or '', 1000)}",
                 f"Lyric section:\n{_clean_scene_text(vocal_status.get('lyric_section') or story_layer.get('lyric_section') or '', 200)}",
                 f"Scene story beat:\n{_clean_scene_text(story_layer.get('scene_story_beat') or '', 1200)}",
-                f"Motion/video summary:\n{_clean_scene_text(selected_scene.get('motion_summary') or '', 1200)}",
-                f"Camera motion:\n{_clean_scene_text(selected_scene.get('camera_motion') or '', 500)}",
+                f"Motion/video summary:\n{motion_summary}",
+                f"Camera motion:\n{camera_motion}",
                 f"Camera motion speed guidance:\n{_clean_scene_text(camera_speed_guidance, 1000)}",
                 f"Character motion guidance:\n{_clean_scene_text(selected_scene.get('character_motion_guidance') or '', 1000)}",
                 f"Performance direction:\n{_clean_scene_text(selected_scene.get('performance_direction') or selected_scene.get('performance_style') or '', 1000)}",

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,40 @@
   "product": "LTX 2.3 Video Builder",
   "releases": [
     {
+      "id": "2026-07-31-builder-timeline-storyboard-prompts",
+      "version": "2026.07.31-builder",
+      "date": "2026-07-31",
+      "title": "Timeline controls and smarter Storyboard prompts",
+      "commit": "ffd79be3512273e864d8a00f316c86bdb5af3d60",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added persistent Render All logs with live timing, per-scene phase details, ETA summaries, final-stitch timing, and saved JSON and text reports.",
+            "Added an inline Motion Notes column to Storyboard Video Prep using the same notes stored in each Scene Card and sent to prompt generation.",
+            "Gemma Video All now opens an in-app choice to create only missing prompts or redo every visible scene, with exact missing and completed counts."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Add Segment now uses the scrubber as the new endpoint when it is at least 0.5 seconds beyond the last clip, snaps that endpoint to the nearest beat when beat snapping is enabled, and confirms unusually long segments.",
+            "Added Space for play or pause and S for Add Segment, and made the Storyboard prompt status and scene actions more compact.",
+            "Missing-only Storyboard prompt generation preserves completed prompts and saves successful partial progress if a later scene fails."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Fixed Left and Right Arrow scene navigation so it continues working after scene-list re-renders while remaining inactive during text entry and dialogs.",
+            "Custom Storyboard Motion Notes now override the scene-default camera-motion preset in Gemma requests, preventing conflicting directions such as a push-in combined with track left."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-07-30-standalone-video-enhancer",
       "version": "2026.07.30-enhancer",
       "date": "2026-07-30",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -1016,6 +1016,40 @@ function showAddSegmentPositionModal(sceneLabel = "selected scene") {
   });
 }
 
+function showLongSegmentConfirm(duration) {
+  return new Promise((resolve) => {
+    const seconds = Math.max(0, Number(duration || 0));
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100007;background:rgba(0,0,0,.68);display:flex;align-items:center;justify-content:center;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(500px,calc(100vw - 40px));border:1px solid #92400e;border-radius:8px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
+    const heading = document.createElement("div");
+    heading.textContent = "Insert Long Segment?";
+    heading.style.cssText = "font-size:16px;font-weight:900;color:#fde68a;";
+    const body = document.createElement("div");
+    body.textContent = `Are you sure you want to insert this segment? It will be ${seconds.toFixed(2)} seconds long.`;
+    body.style.cssText = "font-size:13px;color:#d4d4d8;line-height:1.45;";
+    const actions = document.createElement("div");
+    actions.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:8px;";
+    const cancel = makeButton("Cancel");
+    const confirm = makeButton("Insert Segment", "primary");
+    const finish = (value) => {
+      backdrop.remove();
+      resolve(value);
+    };
+    cancel.onclick = () => finish(false);
+    confirm.onclick = () => finish(true);
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") finish(false);
+    });
+    actions.append(cancel, confirm);
+    box.append(heading, body, actions);
+    backdrop.append(box);
+    document.body.append(backdrop);
+    cancel.focus();
+  });
+}
+
 function pickProjectSessionFile() {
   return new Promise((resolve, reject) => {
     const input = document.createElement("input");
@@ -1866,6 +1900,7 @@ function normalizeNotificationSettings(settings = {}) {
 function openBuilder(node) {
   console.log(`[VRGDG Music Builder] UI version ${BUILDER_UI_VERSION}`);
   const overlay = document.createElement("div");
+  let builderKeydownHandler = null;
   overlay.dataset.vrgdgThemeRoot = "true";
   overlay.style.cssText = "position:fixed;inset:0;z-index:100000;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;";
   const shell = document.createElement("div");
@@ -2149,6 +2184,7 @@ function openBuilder(node) {
   const closeButton = makeButton("Close");
   closeButton.onclick = () => {
     window.removeEventListener("vrgdg:builder-toast", toastNotificationHandler);
+    if (builderKeydownHandler) document.removeEventListener("keydown", builderKeydownHandler, true);
     restoreBrowserAiDownloadsQuietly().catch(() => null);
     overlay.remove();
   };
@@ -2165,6 +2201,8 @@ function openBuilder(node) {
   const builderAgentButton = makeButton("Agent");
   const clearMemoryButton = makeButton("Clear Memory");
   const renderAllButton = makeButton("Render All");
+  const renderLogButton = makeButton("Render Log");
+  renderLogButton.title = "View live and previous Render All timing reports.";
   const stitchPreviewButton = makeButton("Stitch Preview");
   const slideshowPreviewButton = makeButton("Image Slideshow Preview");
   const gemmaT2IAllButton = makeButton("LLM T2I All");
@@ -2200,7 +2238,7 @@ function openBuilder(node) {
     button.style.justifyContent = "flex-start";
   };
   menuDropdown.append(buyMeACoffeeButton);
-  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, reviewGuideButton, whatsNewMenuButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton]) {
+  for (const button of [newProjectButton, loadSessionButton, loadLastProjectButton, saveProjectAsButton, branchProjectButton, exportProjectButton, importProjectButton, settingsButton, reviewGuideButton, whatsNewMenuButton, gemmaT2IAllButton, gemmaVideoAllButton, zImageAllButton, zEnhanceAllButton, renderAllButton, renderLogButton, stitchPreviewButton, slideshowPreviewButton, fullBuildButton, fullFLFBuildButton]) {
     styleMenuItem(button);
     menuDropdown.append(button);
   }
@@ -4620,11 +4658,11 @@ function openBuilder(node) {
   overlayTrackToggleButton.title = "Turn the advanced overlay timeline on or off.";
   overlayTrackHintButton.title = "How does the overlay timeline work?";
   addTimelineMarkerButton.title = "Add a free timeline note/song marker at the playhead or selected In/Out range.";
-  addSegmentButton.title = "Add segment";
+  addSegmentButton.title = "Add a segment (S). If the playhead is at least 0.5 seconds past the final base scene, the new segment fills the gap to the playhead and its end snaps to the nearest beat when Snap beats is on.";
   addOverlaySegmentButton.title = "Add a new clip to the overlay track at the playhead without changing the base timeline.";
   undoButton.title = "Undo";
   redoButton.title = "Redo";
-  playButton.title = "Play / Pause";
+  playButton.title = "Play / Pause (Space)";
   stopButton.title = "Stop";
   multiSelectButton.title = "Select multiple scenes, then batch-apply image/video settings or stitch a preview.";
   multiSelectHintButton.title = "What does Select Multi do?";
@@ -5251,11 +5289,314 @@ function openBuilder(node) {
     adjustLivePreviewPending: false,
     adjustLivePreviewStatus: "",
     builderAgentFloating: null,
+    renderLogs: [],
+    activeRenderLogId: "",
+    renderLogModalRefresh: null,
     undoStack: [],
     redoStack: [],
     isRestoringHistory: false,
     batchCancelled: false,
   };
+
+  function normalizeRenderLog(raw) {
+    const value = raw && typeof raw === "object" ? raw : {};
+    return {
+      ...value,
+      id: String(value.id || ""),
+      status: String(value.status || "unknown"),
+      scenes: Array.isArray(value.scenes)
+        ? value.scenes.filter((scene) => scene && typeof scene === "object").map((scene) => ({ ...scene }))
+        : [],
+      summary: value.summary && typeof value.summary === "object" ? { ...value.summary } : {},
+    };
+  }
+
+  function normalizeRenderLogs(items) {
+    const byId = new Map();
+    for (const raw of (Array.isArray(items) ? items : [])) {
+      const log = normalizeRenderLog(raw);
+      if (log.id) byId.set(log.id, log);
+    }
+    return [...byId.values()]
+      .sort((left, right) => String(left.started_at || "").localeCompare(String(right.started_at || "")))
+      .slice(-20);
+  }
+
+  function renderLogDuration(milliseconds) {
+    const totalSeconds = Math.max(0, Math.round(Number(milliseconds || 0) / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours) return `${hours}h ${String(minutes).padStart(2, "0")}m ${String(seconds).padStart(2, "0")}s`;
+    if (minutes) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+    return `${seconds}s`;
+  }
+
+  function updateRenderLogSummary(log, now = Date.now()) {
+    if (!log) return {};
+    const scenes = Array.isArray(log.scenes) ? log.scenes : [];
+    const startedMs = Date.parse(log.started_at || "") || now;
+    const endedMs = Date.parse(log.ended_at || "") || (log.status === "running" ? now : startedMs);
+    const totalMs = log.status === "running"
+      ? Math.max(0, now - startedMs)
+      : Math.max(0, Number(log.total_ms || endedMs - startedMs));
+    const completed = scenes.filter((scene) => scene.status === "complete");
+    const renderMs = completed.reduce((sum, scene) => sum + Math.max(0, Number(scene.render_ms || 0)), 0);
+    const betweenRenderMs = scenes.reduce((sum, scene) => sum + Math.max(0, Number(scene.gap_before_render_ms || 0)), 0);
+    const setupMs = Math.max(0, Number(log.setup_ms || 0));
+    const stitchMs = Math.max(0, Number(log.stitch_ms || 0));
+    const averageRenderMs = completed.length ? renderMs / completed.length : 0;
+    const completedTotalMs = completed.reduce((sum, scene) => sum + Math.max(0, Number(scene.total_ms || 0)), 0);
+    const averageSceneStepMs = completed.length ? completedTotalMs / completed.length : 0;
+    const targetScenes = Math.max(0, Number(log.target_scene_count || scenes.length || 0));
+    const remainingScenes = Math.max(0, targetScenes - completed.length);
+    const etaMs = log.status === "running" && completed.length
+      ? remainingScenes * averageSceneStepMs
+      : 0;
+    const longest = completed.reduce((best, scene) =>
+      Number(scene.render_ms || 0) > Number(best?.render_ms || 0) ? scene : best, null);
+    log.total_ms = totalMs;
+    log.summary = {
+      total_ms: totalMs,
+      render_ms: renderMs,
+      between_render_ms: betweenRenderMs,
+      setup_ms: setupMs,
+      stitch_ms: stitchMs,
+      overhead_ms: Math.max(0, totalMs - renderMs - stitchMs),
+      completed_scenes: completed.length,
+      failed_scenes: scenes.filter((scene) => scene.status === "failed").length,
+      target_scenes: targetScenes,
+      skipped_existing_scenes: Math.max(0, Number(log.skipped_existing_count || 0)),
+      average_render_ms: averageRenderMs,
+      average_scene_step_ms: averageSceneStepMs,
+      eta_ms: etaMs,
+      longest_scene_label: longest?.label || "",
+      longest_scene_ms: Math.max(0, Number(longest?.render_ms || 0)),
+    };
+    return log.summary;
+  }
+
+  function upsertRenderLog(log) {
+    if (!log?.id) return;
+    updateRenderLogSummary(log);
+    const logs = normalizeRenderLogs(state.renderLogs);
+    const index = logs.findIndex((item) => item.id === log.id);
+    if (index >= 0) logs[index] = log;
+    else logs.push(log);
+    state.renderLogs = logs.slice(-20);
+    state.activeRenderLogId = log.id;
+    state.renderLogModalRefresh?.();
+  }
+
+  async function persistRenderLog(log) {
+    if (!log?.id) return null;
+    upsertRenderLog(log);
+    const projectFolder = String(state.projectFolder || projectInput.value || "").trim();
+    if (!projectFolder) return null;
+    try {
+      const data = await postJson("/vrgdg/music_builder/save_render_log", {
+        project_folder: projectFolder,
+        log,
+      }, 60000);
+      if (data.log) Object.assign(log, data.log);
+      if (data.report_json_path) log.report_json_path = data.report_json_path;
+      if (data.report_text_path) log.report_text_path = data.report_text_path;
+      log.persistence_error = "";
+      upsertRenderLog(log);
+      return data;
+    } catch (error) {
+      log.persistence_error = String(error?.message || error);
+      console.warn("[VRGDG Music Builder] Could not persist render log:", error);
+      upsertRenderLog(log);
+      return null;
+    }
+  }
+
+  function renderLogAsText(log) {
+    const summary = updateRenderLogSummary(log);
+    const lines = [
+      "VRGDG Video Builder Render Log",
+      "================================",
+      `Session: ${log.id || ""}`,
+      `Status: ${String(log.status || "unknown").toUpperCase()}`,
+      `Project: ${log.project_folder || state.projectFolder || ""}`,
+      `Mode: ${log.mode_label || log.scene_scope || "Render All"}`,
+      `Started: ${log.started_at || ""}`,
+      `Finished: ${log.ended_at || ""}`,
+      "",
+      "Summary",
+      "--------------------------------",
+      `Total wall time: ${renderLogDuration(summary.total_ms)}`,
+      `Active scene rendering: ${renderLogDuration(summary.render_ms)}`,
+      `Between-render time: ${renderLogDuration(summary.between_render_ms)}`,
+      `Setup time: ${renderLogDuration(summary.setup_ms)}`,
+      `Final stitching: ${renderLogDuration(summary.stitch_ms)}`,
+      `Other overhead: ${renderLogDuration(summary.overhead_ms)}`,
+      `Scenes completed: ${summary.completed_scenes}/${summary.target_scenes}`,
+      `Existing scenes skipped: ${summary.skipped_existing_scenes}`,
+      `Average render per scene: ${renderLogDuration(summary.average_render_ms)}`,
+    ];
+    if (summary.longest_scene_label) {
+      lines.push(`Longest scene: ${summary.longest_scene_label} — ${renderLogDuration(summary.longest_scene_ms)}`);
+    }
+    if (log.final_video_path) lines.push(`Final video: ${log.final_video_path}`);
+    if (log.error) lines.push("", `Error: ${log.error}`);
+    lines.push("", "Scene Details", "--------------------------------");
+    for (const scene of (log.scenes || [])) {
+      lines.push(
+        `${scene.label || `Scene ${scene.scene_number || "?"}`} [${String(scene.status || "pending").toUpperCase()}]`,
+        `  Total scene step: ${renderLogDuration(scene.total_ms)}`,
+        `  Preparation: ${renderLogDuration(scene.preparation_ms)}`,
+        `  Video render: ${renderLogDuration(scene.render_ms)}`,
+        `  Post-processing/cleanup: ${renderLogDuration(scene.post_ms)}`,
+        `  Time since previous render: ${renderLogDuration(scene.gap_before_render_ms)}`,
+      );
+      if (scene.video_path) lines.push(`  Video: ${scene.video_path}`);
+      if (scene.error) lines.push(`  Error: ${scene.error}`);
+    }
+    return lines.join("\n");
+  }
+
+  function downloadRenderLog(log, kind = "json") {
+    if (!log) return;
+    updateRenderLogSummary(log);
+    const isJson = kind === "json";
+    const content = isJson ? `${JSON.stringify(log, null, 2)}\n` : `${renderLogAsText(log)}\n`;
+    const blob = new Blob([content], { type: isJson ? "application/json" : "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${log.id || "VRGDG_Render_Log"}.${isJson ? "json" : "txt"}`;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  function openRenderLogModal() {
+    document.querySelector(".vrgdg-render-log-modal")?.remove();
+    let selectedId = state.activeRenderLogId || state.renderLogs[state.renderLogs.length - 1]?.id || "";
+    const backdrop = document.createElement("div");
+    backdrop.className = "vrgdg-render-log-modal";
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:18px;box-sizing:border-box;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(1180px,calc(100vw - 36px));height:min(900px,calc(100vh - 36px));border:1px solid #155e75;border-radius:10px;background:#0b1220;color:#e2e8f0;box-shadow:0 28px 90px rgba(0,0,0,.72);display:flex;flex-direction:column;overflow:hidden;font-family:Arial,sans-serif;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-bottom:1px solid #334155;background:#0f172a;";
+    const title = document.createElement("div");
+    title.textContent = "Render Log";
+    title.style.cssText = "font-size:17px;font-weight:900;color:#cffafe;";
+    const close = makeButton("Close");
+    header.append(title, close);
+    const toolbar = document.createElement("div");
+    toolbar.style.cssText = "display:grid;grid-template-columns:minmax(220px,1fr) auto auto auto auto;gap:8px;padding:10px 14px;border-bottom:1px solid #334155;align-items:center;";
+    const history = document.createElement("select");
+    history.style.cssText = "width:100%;border:1px solid #475569;border-radius:6px;background:#020617;color:#f8fafc;padding:8px;";
+    const openSaved = makeButton("Open Saved Report");
+    const copy = makeButton("Copy Summary");
+    const downloadJson = makeButton("Download JSON");
+    const downloadText = makeButton("Download Text");
+    toolbar.append(history, openSaved, copy, downloadJson, downloadText);
+    const content = document.createElement("div");
+    content.style.cssText = "flex:1 1 auto;min-height:0;overflow:auto;padding:14px;";
+    box.append(header, toolbar, content);
+    backdrop.append(box);
+    document.body.append(backdrop);
+
+    const selectedLog = () => state.renderLogs.find((item) => item.id === selectedId) || state.renderLogs[state.renderLogs.length - 1] || null;
+    const refresh = () => {
+      const logs = normalizeRenderLogs(state.renderLogs).slice().reverse();
+      const previous = history.value || selectedId;
+      history.textContent = "";
+      for (const log of logs) {
+        const option = document.createElement("option");
+        option.value = log.id;
+        option.textContent = `${log.status === "running" ? "● LIVE — " : ""}${log.started_at ? new Date(log.started_at).toLocaleString() : log.id} — ${String(log.status || "").toUpperCase()}`;
+        history.append(option);
+      }
+      if (logs.some((log) => log.id === previous)) selectedId = previous;
+      else selectedId = logs[0]?.id || "";
+      history.value = selectedId;
+      const log = selectedLog();
+      if (!log) {
+        content.innerHTML = '<div style="border:1px dashed #475569;border-radius:8px;padding:30px;text-align:center;color:#94a3b8;">No Render All sessions have been recorded for this project yet.</div>';
+        openSaved.disabled = true;
+        copy.disabled = true;
+        downloadJson.disabled = true;
+        downloadText.disabled = true;
+        return;
+      }
+      const summary = updateRenderLogSummary(log);
+      openSaved.disabled = !log.report_text_path;
+      copy.disabled = false;
+      downloadJson.disabled = false;
+      downloadText.disabled = false;
+      const statusColor = log.status === "complete" ? "#86efac" : log.status === "running" ? "#67e8f9" : "#fca5a5";
+      const card = (label, value) => `<div style="border:1px solid #334155;border-radius:8px;background:#111827;padding:10px;"><div style="color:#64748b;font-size:10px;font-weight:900;text-transform:uppercase;">${escapeHtml(label)}</div><div style="margin-top:4px;color:#f8fafc;font-size:16px;font-weight:900;">${escapeHtml(value)}</div></div>`;
+      const rows = (log.scenes || []).map((scene) => `
+        <tr>
+          <td>${escapeHtml(scene.label || `Scene ${scene.scene_number || "?"}`)}</td>
+          <td style="color:${scene.status === "complete" ? "#86efac" : scene.status === "failed" ? "#fca5a5" : "#67e8f9"};font-weight:900;">${escapeHtml(String(scene.status || "pending").toUpperCase())}</td>
+          <td>${escapeHtml(renderLogDuration(scene.render_ms))}</td>
+          <td>${escapeHtml(renderLogDuration(scene.preparation_ms))}</td>
+          <td>${escapeHtml(renderLogDuration(scene.post_ms))}</td>
+          <td>${escapeHtml(renderLogDuration(scene.gap_before_render_ms))}</td>
+          <td>${escapeHtml(renderLogDuration(scene.total_ms))}</td>
+        </tr>`).join("");
+      content.innerHTML = `
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px;">
+          <div><div style="font-size:18px;font-weight:900;color:${statusColor};">${escapeHtml(String(log.status || "unknown").toUpperCase())}</div><div style="color:#94a3b8;font-size:11px;margin-top:4px;">${escapeHtml(log.mode_label || "Render All")} · Started ${escapeHtml(log.started_at ? new Date(log.started_at).toLocaleString() : "")}</div></div>
+          ${log.status === "running" && summary.eta_ms ? `<div style="border:1px solid #0e7490;border-radius:7px;background:#083344;padding:8px 10px;color:#a5f3fc;font-weight:900;">Estimated remaining: ${escapeHtml(renderLogDuration(summary.eta_ms))}</div>` : ""}
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(4,minmax(130px,1fr));gap:9px;">
+          ${card("Total wall time", renderLogDuration(summary.total_ms))}
+          ${card("Active rendering", renderLogDuration(summary.render_ms))}
+          ${card("Between renders", renderLogDuration(summary.between_render_ms))}
+          ${card("Final stitching", renderLogDuration(summary.stitch_ms))}
+          ${card("Setup", renderLogDuration(summary.setup_ms))}
+          ${card("Other overhead", renderLogDuration(summary.overhead_ms))}
+          ${card("Scenes completed", `${summary.completed_scenes}/${summary.target_scenes}`)}
+          ${card("Average render", renderLogDuration(summary.average_render_ms))}
+        </div>
+        ${summary.longest_scene_label ? `<div style="margin-top:10px;color:#cbd5e1;font-size:11px;">Longest scene: <strong>${escapeHtml(summary.longest_scene_label)}</strong> — ${escapeHtml(renderLogDuration(summary.longest_scene_ms))}</div>` : ""}
+        ${log.error ? `<div style="margin-top:12px;border:1px solid #7f1d1d;border-radius:7px;background:#2a0b0b;color:#fecaca;padding:10px;white-space:pre-wrap;">${escapeHtml(log.error)}</div>` : ""}
+        <div style="margin-top:14px;border:1px solid #334155;border-radius:8px;overflow:auto;">
+          <table style="width:100%;border-collapse:collapse;font-size:11px;">
+            <thead style="position:sticky;top:0;background:#083344;color:#cffafe;"><tr><th>Scene</th><th>Status</th><th>Render</th><th>Prep</th><th>Post/Cleanup</th><th>Between</th><th>Total Step</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="7" style="padding:18px;text-align:center;color:#64748b;">Waiting for the first scene...</td></tr>'}</tbody>
+          </table>
+        </div>
+        <style>.vrgdg-render-log-modal th,.vrgdg-render-log-modal td{padding:8px 9px;border-bottom:1px solid #1e293b;text-align:left;white-space:nowrap}.vrgdg-render-log-modal tbody tr:hover{background:#111827}</style>
+        <div style="margin-top:12px;border:1px solid #334155;border-radius:7px;background:#020617;padding:9px;color:#94a3b8;font-size:10px;line-height:1.45;white-space:pre-wrap;">JSON: ${escapeHtml(log.report_json_path || "Not saved yet")}\nText: ${escapeHtml(log.report_text_path || "Not saved yet")}${log.persistence_error ? `\nSave warning: ${escapeHtml(log.persistence_error)}` : ""}</div>`;
+    };
+    const finish = () => {
+      clearInterval(timer);
+      if (state.renderLogModalRefresh === refresh) state.renderLogModalRefresh = null;
+      backdrop.remove();
+    };
+    state.renderLogModalRefresh = refresh;
+    const timer = setInterval(refresh, 1000);
+    history.onchange = () => { selectedId = history.value; refresh(); };
+    close.onclick = finish;
+    backdrop.onpointerdown = (event) => { if (event.target === backdrop) finish(); };
+    openSaved.onclick = async () => {
+      const log = selectedLog();
+      if (log?.report_text_path) await postJson("/vrgdg/music_builder/open_local_file", { path: log.report_text_path }, 30000);
+    };
+    copy.onclick = async () => {
+      const log = selectedLog();
+      if (!log) return;
+      try {
+        await navigator.clipboard.writeText(renderLogAsText(log));
+        toast("Render Log summary copied.");
+      } catch (error) {
+        toast(`Could not copy Render Log:\n${String(error?.message || error)}`, true);
+      }
+    };
+    downloadJson.onclick = () => downloadRenderLog(selectedLog(), "json");
+    downloadText.onclick = () => downloadRenderLog(selectedLog(), "text");
+    refresh();
+  }
 
   function resolvedFacialPerformanceText(segment = null) {
     if (segment?.no_character_present) return "";
@@ -7799,7 +8140,7 @@ function openBuilder(node) {
   function updatePlayPauseButton() {
     const playing = isTimelinePlaying();
     playButton.textContent = playing ? "Ⅱ" : "▶";
-    playButton.title = playing ? "Pause" : "Play";
+    playButton.title = playing ? "Pause (Space)" : "Play (Space)";
   }
 
   function updateGlobalAudioMuteButton() {
@@ -14589,6 +14930,20 @@ function openBuilder(node) {
       }
     }
     return bestDelta <= 0.14 ? best : value;
+  }
+
+  function snapAddedSegmentEndToNearestBeat(time, segmentStart) {
+    const value = Math.max(0, Number(time || 0));
+    if (!state.snapToBeats || !Array.isArray(state.beats) || !state.beats.length) return value;
+    const minimumEnd = Number(segmentStart || 0) + 0.05;
+    const audioEnd = loadedGlobalAudioDuration();
+    const beatTimes = state.beats
+      .map((beat) => Number(beat?.time ?? beat))
+      .filter((beat) => Number.isFinite(beat) && beat >= minimumEnd && (!(audioEnd > 0) || beat <= audioEnd + 0.0001));
+    if (!beatTimes.length) return value;
+    return beatTimes.reduce((closest, beat) => (
+      Math.abs(beat - value) < Math.abs(closest - value) ? beat : closest
+    ), beatTimes[0]);
   }
 
   function drawWaveform() {
@@ -29608,6 +29963,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       builder_story_reference_notes: state.builderStoryReferenceNotes || "",
       builder_story_layer: normalizeBuilderStoryLayer(state.builderStoryLayer),
       builder_storyboard_defaults: normalizeBuilderStoryboardDefaults(state.builderStoryboardDefaults),
+      render_logs: normalizeRenderLogs(state.renderLogs),
+      active_render_log_id: state.activeRenderLogId || "",
     };
   }
 
@@ -29806,6 +30163,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.builderStoryReferenceNotes = data.session.builder_story_reference_notes || state.builderStoryReferenceNotes || "";
         state.builderStoryLayer = normalizeBuilderStoryLayer(data.session.builder_story_layer || {});
         state.builderStoryboardDefaults = normalizeBuilderStoryboardDefaults(data.session.builder_storyboard_defaults || data.session.builderStoryboardDefaults || {});
+        state.renderLogs = normalizeRenderLogs(data.session.render_logs || state.renderLogs);
+        state.activeRenderLogId = data.session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
         state.textGemmaRunner = data.session.text_gemma_runner || state.textGemmaRunner || "builtin";
         state.gemmaContextLimit = normalizeGemmaContextLimit(data.session.gemma_context_limit ?? data.session.n_ctx ?? state.gemmaContextLimit);
         state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.session.gemma_gpu_layers ?? data.session.n_gpu_layers ?? state.gemmaGpuLayers);
@@ -30125,6 +30484,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.builderStoryReferenceNotes = session.builder_story_reference_notes || "";
       state.builderStoryLayer = normalizeBuilderStoryLayer(session.builder_story_layer || {});
       state.builderStoryboardDefaults = normalizeBuilderStoryboardDefaults(session.builder_storyboard_defaults || session.builderStoryboardDefaults || {});
+      state.renderLogs = normalizeRenderLogs(session.render_logs);
+      state.activeRenderLogId = session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
       state.textGemmaRunner = session.text_gemma_runner || state.textGemmaRunner || "builtin";
       state.gemmaContextLimit = normalizeGemmaContextLimit(session.gemma_context_limit ?? session.n_ctx ?? state.gemmaContextLimit);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(session.gemma_gpu_layers ?? session.n_gpu_layers ?? state.gemmaGpuLayers);
@@ -36017,6 +36378,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const randomizeVideoSeed = Boolean(options.randomizeVideoSeed);
     const sceneScope = normalizeBatchScope(options.sceneScope);
     const skipFinalStitch = Boolean(options.skipFinalStitch || sceneScope === "selected");
+    let renderLog = null;
+    let currentSceneLog = null;
+    let previousRenderEndedMs = 0;
     if (!forceVideos) {
       try {
         await recoverSceneVideosFromProject({
@@ -36036,12 +36400,44 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast("Render All needs a few things fixed first.", true);
       return;
     }
+    const logStartedMs = Date.now();
+    const logStarted = new Date(logStartedMs);
+    const logStamp = logStarted.toISOString().replace(/\D/g, "").slice(0, 14);
+    const modeLabel = sceneScope === "selected"
+      ? "Render Selected Scenes"
+      : sceneScope === "from_selected"
+        ? "Render From Selected Scene"
+        : "Render All";
+    renderLog = {
+      schema_version: 1,
+      id: `render_${logStamp}_${Math.random().toString(16).slice(2, 8)}`,
+      status: "running",
+      mode_label: modeLabel,
+      scene_scope: sceneScope,
+      project_folder: String(state.projectFolder || projectInput.value || ""),
+      video_mode: currentVideoMode(),
+      force_videos: forceVideos,
+      randomize_video_seed: randomizeVideoSeed,
+      skip_final_stitch: skipFinalStitch,
+      started_at: logStarted.toISOString(),
+      ended_at: "",
+      setup_started_at: logStarted.toISOString(),
+      setup_ms: 0,
+      stitch_ms: 0,
+      target_scene_count: 0,
+      skipped_existing_count: 0,
+      scenes: [],
+      final_video_path: "",
+      error: "",
+    };
+    upsertRenderLog(renderLog);
     try {
       state.batchCancelled = false;
       renderAllButton.disabled = true;
       renderAllButton.textContent = "Rendering...";
       setButtonGroupState(createSceneVideoButtons, { disabled: true });
       setButtonGroupState(gemmaThenCreateVideoButtons, { disabled: true });
+      await persistRenderLog(renderLog);
       progress.set(`Autosaving session/SRT before ${sceneScope === "selected" ? "Render Selected" : sceneScope === "from_selected" ? "Render From Selected" : "Render All"}...`, 3);
       await saveSessionForSceneVideo();
       const preparedAudio = skipFinalStitch
@@ -36049,6 +36445,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         : await prepareSceneAudioMix(progress, "Preparing combined scene-audio track for LTX");
       const scenes = batchTargetItems(sceneScope)
         .filter(({ segment }) => forceVideos || !String(selectedSegmentVideoPath(segment) || "").trim());
+      const requestedSceneCount = batchTargetItems(sceneScope).length;
+      renderLog.target_scene_count = scenes.length;
+      renderLog.skipped_existing_count = Math.max(0, requestedSceneCount - scenes.length);
       if (!scenes.length) {
         progress.set(skipFinalStitch ? "Selected scenes already have video. Nothing to render." : "All scenes already have video. Stitching existing scene videos...", 80);
       }
@@ -36072,10 +36471,33 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }
         if (promptTargets.length) await autoSaveSessionQuiet("FLF provisional prompt batch complete");
       }
+      renderLog.setup_ms = Math.max(0, Date.now() - logStartedMs);
+      renderLog.setup_ended_at = new Date().toISOString();
+      await persistRenderLog(renderLog);
       for (let index = 0; index < scenes.length; index += 1) {
         assertBatchNotStopped();
         const { segment, index: sceneIndex } = scenes[index];
         const sceneLabel = sceneDisplayName(segment, sceneIndex);
+        const sceneStartedMs = Date.now();
+        currentSceneLog = {
+          scene_id: String(segment.id || ""),
+          scene_number: sceneSlotNumber(segment),
+          timeline_index: sceneIndex,
+          label: sceneLabel,
+          status: "running",
+          phase: "preparation",
+          started_at: new Date(sceneStartedMs).toISOString(),
+          ended_at: "",
+          preparation_ms: 0,
+          render_ms: 0,
+          post_ms: 0,
+          gap_before_render_ms: 0,
+          total_ms: 0,
+          video_path: "",
+          error: "",
+        };
+        renderLog.scenes.push(currentSceneLog);
+        upsertRenderLog(renderLog);
         const base = Math.floor((index / scenes.length) * 100);
         const span = Math.max(1, Math.floor(80 / scenes.length));
         if (randomizeVideoSeed) setVideoSeedRandom(segment);
@@ -36126,8 +36548,19 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             await autoSaveSessionQuiet(`Img2Img continuity image scene ${sceneIndex + 1}`);
           }
         }
-        progress.set(`Rendering ${sceneLabel} (${index + 1} of ${scenes.length}; ${forceVideos ? "creating a new video version" : "existing videos skipped"})...`, base);
-        await renderSceneVideoWithProgress(segment, sceneIndex, progress, {
+        const sceneRenderStartedMs = Date.now();
+        currentSceneLog.phase = "render";
+        currentSceneLog.preparation_ms = Math.max(0, sceneRenderStartedMs - sceneStartedMs);
+        currentSceneLog.render_started_at = new Date(sceneRenderStartedMs).toISOString();
+        currentSceneLog.gap_before_render_ms = previousRenderEndedMs
+          ? Math.max(0, sceneRenderStartedMs - previousRenderEndedMs)
+          : 0;
+        const liveSummary = updateRenderLogSummary(renderLog);
+        const timingLine = liveSummary.completed_scenes
+          ? `\nElapsed: ${renderLogDuration(liveSummary.total_ms)} · Estimated remaining: ${renderLogDuration(liveSummary.eta_ms)}`
+          : `\nElapsed: ${renderLogDuration(liveSummary.total_ms)}`;
+        progress.set(`Rendering ${sceneLabel} (${index + 1} of ${scenes.length}; ${forceVideos ? "creating a new video version" : "existing videos skipped"})...${timingLine}`, base);
+        const renderedVideoPath = await renderSceneVideoWithProgress(segment, sceneIndex, progress, {
           progressBase: base,
           progressSpan: span,
           batchLabel: `Render All ${index + 1}/${scenes.length}: ${segment.label || `Scene ${sceneIndex + 1}`}`,
@@ -36136,6 +36569,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           audioPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.audioPath,
           srtPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.srtPath,
         });
+        const sceneRenderEndedMs = Date.now();
+        previousRenderEndedMs = sceneRenderEndedMs;
+        currentSceneLog.phase = "post";
+        currentSceneLog.render_ended_at = new Date(sceneRenderEndedMs).toISOString();
+        currentSceneLog.render_ms = Math.max(0, sceneRenderEndedMs - sceneRenderStartedMs);
+        currentSceneLog.video_path = String(renderedVideoPath || selectedSegmentVideoPath(segment) || "");
         if (currentVideoMode() === "flf" && scenes[index + 1]?.segment && flfChainingEnabled(scenes[index + 1].segment) && flfRenderChainStartSource(scenes[index + 1].segment) === "rendered_frame") {
           assertBatchNotStopped();
           const nextSegment = scenes[index + 1].segment;
@@ -36162,22 +36601,77 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }
         assertBatchNotStopped();
         await runClearMemoryWorkflowQuiet(progress, sceneLabel, Math.min(98, base + span));
+        const sceneEndedMs = Date.now();
+        currentSceneLog.phase = "complete";
+        currentSceneLog.status = "complete";
+        currentSceneLog.ended_at = new Date(sceneEndedMs).toISOString();
+        currentSceneLog.post_ms = Math.max(0, sceneEndedMs - sceneRenderEndedMs);
+        currentSceneLog.total_ms = Math.max(0, sceneEndedMs - sceneStartedMs);
+        await persistRenderLog(renderLog);
+        currentSceneLog = null;
       }
       assertBatchNotStopped();
       if (skipFinalStitch) {
+        const completedAt = Date.now();
+        renderLog.status = "complete";
+        renderLog.ended_at = new Date(completedAt).toISOString();
+        renderLog.total_ms = Math.max(0, completedAt - logStartedMs);
+        await persistRenderLog(renderLog);
         await autoSaveSessionQuiet("render selected scenes complete");
-        progress.set(`Render Selected complete.\n\nRendered/checked ${scenes.length} selected scene${scenes.length === 1 ? "" : "s"}.\nNo final stitch was run.`, 100);
+        const summary = updateRenderLogSummary(renderLog);
+        progress.set(`Render Selected complete.\n\nRendered/checked ${scenes.length} selected scene${scenes.length === 1 ? "" : "s"}.\nNo final stitch was run.\n\nTotal time: ${renderLogDuration(summary.total_ms)}\nActive rendering: ${renderLogDuration(summary.render_ms)}\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}`, 100);
         progress.close(4500);
         toast("Render Selected complete. No final stitch was run.");
         return;
       }
+      const stitchStartedMs = Date.now();
+      renderLog.stitch_started_at = new Date(stitchStartedMs).toISOString();
+      await persistRenderLog(renderLog);
       const stitched = await stitchRenderedScenes(progress);
+      const stitchEndedMs = Date.now();
+      renderLog.stitch_ended_at = new Date(stitchEndedMs).toISOString();
+      renderLog.stitch_ms = Math.max(0, stitchEndedMs - stitchStartedMs);
+      renderLog.final_video_path = String(stitched.final_video_path || "");
+      renderLog.status = "complete";
+      renderLog.ended_at = new Date(stitchEndedMs).toISOString();
+      renderLog.total_ms = Math.max(0, stitchEndedMs - logStartedMs);
+      await persistRenderLog(renderLog);
       await autoSaveSessionQuiet("render all final stitch complete");
-      progress.set(`Render All complete.\n\nFinal video:\n${stitched.final_video_path}\n\nScene clips:\n${stitched.video_folder}`, 100);
+      const summary = updateRenderLogSummary(renderLog);
+      progress.set(`Render All complete.\n\nFinal video:\n${stitched.final_video_path}\n\nScene clips:\n${stitched.video_folder}\n\nTotal time: ${renderLogDuration(summary.total_ms)}\nActive scene rendering: ${renderLogDuration(summary.render_ms)}\nFinal stitching: ${renderLogDuration(summary.stitch_ms)}\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}`, 100);
       progress.close(6500);
       toast(`Render All complete:\n${stitched.final_video_path}`);
       showFinalVideoReadyModal(stitched.final_video_path);
     } catch (error) {
+      const failedAt = Date.now();
+      const message = String(error?.message || error);
+      if (currentSceneLog && currentSceneLog.status === "running") {
+        if (currentSceneLog.phase === "preparation") {
+          currentSceneLog.preparation_ms = Math.max(0, failedAt - (Date.parse(currentSceneLog.started_at) || failedAt));
+        } else if (currentSceneLog.phase === "render") {
+          currentSceneLog.render_ms = Math.max(0, failedAt - (Date.parse(currentSceneLog.render_started_at) || failedAt));
+        } else if (currentSceneLog.phase === "post") {
+          currentSceneLog.post_ms = Math.max(0, failedAt - (Date.parse(currentSceneLog.render_ended_at) || failedAt));
+        }
+        currentSceneLog.status = state.batchCancelled ? "canceled" : "failed";
+        currentSceneLog.ended_at = new Date(failedAt).toISOString();
+        currentSceneLog.total_ms = Math.max(0, failedAt - (Date.parse(currentSceneLog.started_at) || failedAt));
+        currentSceneLog.error = message;
+      }
+      if (renderLog) {
+        if (!renderLog.setup_ended_at) {
+          renderLog.setup_ms = Math.max(0, failedAt - logStartedMs);
+          renderLog.setup_ended_at = new Date(failedAt).toISOString();
+        }
+        if (renderLog.stitch_started_at && !renderLog.stitch_ms) {
+          renderLog.stitch_ms = Math.max(0, failedAt - (Date.parse(renderLog.stitch_started_at) || failedAt));
+        }
+        renderLog.status = state.batchCancelled || /\b(?:cancel|stopp?ed|interrupt)/i.test(message) ? "canceled" : "failed";
+        renderLog.ended_at = new Date(failedAt).toISOString();
+        renderLog.total_ms = Math.max(0, failedAt - logStartedMs);
+        renderLog.error = message;
+        await persistRenderLog(renderLog);
+      }
       progress.set(`Error:\n${String(error?.message || error)}`, 100);
       toast(String(error?.message || error), true);
       if (options.throwOnError) throw error;
@@ -37921,6 +38415,30 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function addSegment() {
+    const lastSegmentEnd = state.segments.reduce(
+      (latest, segment) => Math.max(latest, Number(segment.end || 0)),
+      0,
+    );
+    const playheadTime = Math.max(0, Number(currentGlobalTime() || 0));
+    const playheadAppendDuration = playheadTime - lastSegmentEnd;
+    if (state.segments.length && playheadAppendDuration >= 0.5) {
+      const segmentEnd = snapAddedSegmentEndToNearestBeat(playheadTime, lastSegmentEnd);
+      const segmentDuration = segmentEnd - lastSegmentEnd;
+      if (segmentDuration > 10 && !await showLongSegmentConfirm(segmentDuration)) return;
+      pushHistory();
+      const segment = newSegment(lastSegmentEnd, segmentEnd);
+      segment.source = state.srtMode ? "inserted" : "manual";
+      state.segments.push(segment);
+      state.duration = Math.max(Number(state.duration || 0), segmentEnd);
+      enforceAudioTimelineEnd();
+      sortSegments(state.segments);
+      setActiveSegment(segment);
+      await syncPromptJsonFromSegments("segment added at playhead");
+      await syncI2VMotionJsonFromSegments("segment added at playhead");
+      autoSaveSessionQuiet("segment added at playhead");
+      return;
+    }
+
     const active = activeSegment();
     let duration = 4;
     let insertIndex = state.segments.length;
@@ -38619,6 +39137,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     state.builderStorySourcePreview = "";
     state.builderStoryReferenceImages = [];
     state.builderStoryReferenceNotes = "";
+    state.renderLogs = [];
+    state.activeRenderLogId = "";
     state.useVrgdgTextContext = true;
     state.projectFolder = cleanProjectFolder;
     state.sessionPath = sessionPath || "";
@@ -43710,6 +44230,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     loadAudio();
   };
   settingsButton.onclick = openSettingsModal;
+  renderLogButton.onclick = openRenderLogModal;
   reviewGuideButton.onclick = () => {
     menuDropdown.style.display = "none";
     window.open(
@@ -44406,11 +44927,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       updateAudioScrubbers();
     }
   });
-  overlay.addEventListener("keydown", (event) => {
+  builderKeydownHandler = (event) => {
+    if (!overlay.isConnected) return;
+    const target = event.target;
+    const targetIsBuilder = target === document || target === document.body || target === document.documentElement || overlay.contains(target);
+    if (!targetIsBuilder) return;
     const tag = String(event.target?.tagName || "").toLowerCase();
     const isTyping = tag === "input" || tag === "textarea" || tag === "select" || event.target?.isContentEditable;
     if (isTyping) return;
     const shortcutKey = event.key.toLowerCase();
+    const isPlainShortcut = !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
     const snapSide = event.ctrlKey && !event.shiftKey && !event.altKey
       ? shortcutKey === "s"
         ? "start"
@@ -44418,7 +44944,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           ? "end"
           : ""
       : "";
-    if (snapSide) {
+    if (isPlainShortcut && (event.code === "Space" || event.key === " ")) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!event.repeat) playButton.click();
+    } else if (isPlainShortcut && shortcutKey === "s") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!event.repeat) addSegmentButton.click();
+    } else if (snapSide) {
       event.preventDefault();
       event.stopPropagation();
       if (event.repeat) return;
@@ -44432,16 +44966,25 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       });
     } else if (event.ctrlKey && !event.shiftKey && shortcutKey === "z") {
       event.preventDefault();
+      event.stopPropagation();
       undo();
     } else if ((event.ctrlKey && shortcutKey === "y") || (event.ctrlKey && event.shiftKey && shortcutKey === "z")) {
       event.preventDefault();
+      event.stopPropagation();
       redo();
     } else if (!event.ctrlKey && !event.metaKey && !event.altKey && event.key === "ArrowRight") {
-      if (moveActiveSceneSelection(1)) event.preventDefault();
+      if (moveActiveSceneSelection(1)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
     } else if (!event.ctrlKey && !event.metaKey && !event.altKey && event.key === "ArrowLeft") {
-      if (moveActiveSceneSelection(-1)) event.preventDefault();
+      if (moveActiveSceneSelection(-1)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
     }
-  });
+  };
+  document.addEventListener("keydown", builderKeydownHandler, true);
   overlay.tabIndex = -1;
   setTimeout(() => overlay.focus(), 0);
 

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -10166,9 +10166,10 @@ function openBuilder(node) {
     add(parts, "FLF storyboard continuous transformation", scene.flf_transformation || segment.flf_transformation);
     add(parts, "FLF storyboard end state", scene.flf_end_state || segment.flf_end_state);
     add(parts, "FLF storyboard carry-forward continuity", scene.flf_carry_forward || segment.flf_carry_forward);
-    add(parts, "Storyboard motion/video summary", scene.motion_summary || segment.i2v_notes || segment.video_notes);
+    const customMotionSummary = String(scene.motion_summary || segment.i2v_notes || segment.video_notes || "").trim();
+    add(parts, "Storyboard motion/video summary", customMotionSummary);
     add(parts, "Storyboard still shot direction", scene.shot_type || segment.shot_type);
-    add(parts, "Storyboard camera motion", scene.camera_motion || segment.camera_motion || segment.motion_preset);
+    if (!customMotionSummary) add(parts, "Storyboard camera motion", scene.camera_motion || segment.camera_motion || segment.motion_preset);
     add(parts, "Storyboard camera motion speed guidance", defaults.camera_guidance || builderMotionSpeedGuidance(defaults.camera_motion_speed, "camera"));
     add(parts, "Storyboard character motion guidance", segment.character_motion || defaults.character_guidance || builderMotionSpeedGuidance(defaults.character_motion_speed, "character"));
     const performanceStyle = String(segment.performance_style || defaults.performance_style || "").trim();
@@ -34081,8 +34082,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         );
       }
       add(parts, "Storyboard scene story beat", storyLayer.scene_story_beat || scene.story_beat);
-      add(parts, "Storyboard motion/video summary", selectedScene.motion_summary || scene.motion_summary || scene.video_notes);
-      add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
+      const customMotionSummary = String(selectedScene.motion_summary || scene.motion_summary || scene.video_notes || "").trim();
+      add(parts, "Storyboard motion/video summary", customMotionSummary);
+      if (!customMotionSummary) add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
       add(parts, "Storyboard camera motion speed guidance", selectedScene.camera_motion_speed_guidance || selectedScene.camera_guidance?.camera_motion_speed_guidance);
       add(parts, "Storyboard character motion guidance", selectedScene.character_motion_guidance || scene.character_motion);
       add(parts, "Storyboard performance direction", selectedScene.performance_direction || scene.performance_style);

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -1750,6 +1750,8 @@ function storyboardScenesForGpt(state) {
     const shotType = normalized.shot_type || cameraFallback?.shot || "";
     const requiresStartingShot = !imageMode && normalized.video_prompt_type !== "i2v" && Boolean(shotType);
     const cameraMotion = normalized.camera_motion || (imageMode ? "" : cameraFallback?.camera) || "";
+    const motionSummary = String(normalized.motion_summary || "").trim();
+    const cameraMotionForPrompt = motionSummary ? "" : cameraMotion;
     if (!imageMode) previousCameraMotion = cameraMotion || previousCameraMotion;
     const lyricText = String(normalized.lyrics || "").trim();
     const performanceMode = normalizeStoryboardPerformanceMode(normalized.performance_mode || state.performanceMode || state.videoType || state.performance_mode);
@@ -1844,8 +1846,8 @@ function storyboardScenesForGpt(state) {
         lyric_story_strength: normalizeStoryLayer(state.storyLayer).lyric_story_strength,
         instruction: "Use the story brief and scene story beat as narrative guidance. Lyric story strength controls how literally to follow lyric_line: 0 ignores lyrics, 1-3 uses mood only, 4-6 balances lyrics with story, 7-8 strongly follows lyric meaning, and 9-10 uses concrete lyric objects/actions/emotions whenever possible. Do not turn the prompt into plot exposition.",
       },
-      motion_summary: imageMode ? "" : normalized.motion_summary,
-      still_image_notes: imageMode ? normalized.motion_summary : "",
+      motion_summary: imageMode ? "" : motionSummary,
+      still_image_notes: imageMode ? motionSummary : "",
       image_aesthetic: imageMode ? storyboardImageAestheticGuidance(state.imageAesthetic, { idLoraMode }) : "",
       image_aesthetic_instruction: imageMode
         ? "Translate the selected image aesthetic into concrete prompt details: pose, wardrobe styling, hair, makeup, accessories, lighting setup, lens/framing, composition, environment treatment, texture, weather/time if useful, and art direction. Do not merely name the preset or append it as a short tag."
@@ -1892,7 +1894,7 @@ function storyboardScenesForGpt(state) {
             instruction: storyboardStartingShotInstruction(shotType),
           }
         : null,
-      camera_motion: imageMode ? "" : cameraMotion,
+      camera_motion: imageMode ? "" : cameraMotionForPrompt,
       still_camera_style: imageMode ? cameraMotion : "",
       camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
       camera_motion_speed_guidance: imageMode ? "" : storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
@@ -1902,11 +1904,13 @@ function storyboardScenesForGpt(state) {
             instruction: "Use this as still photography composition, lens, lighting, or framing guidance only. Do not turn it into camera movement.",
           }
         : {
-            selected_camera_motion: cameraMotion,
+            selected_camera_motion: cameraMotionForPrompt,
             camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
             camera_motion_speed_guidance: storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
             avoid_default_inward_moves: true,
-            instruction: "Use the selected camera motion as written. Do not add zoom-in, push-in, dolly-in, crash-zoom, or a close-up ending unless that exact inward motion is selected or requested in notes.",
+            instruction: motionSummary
+              ? "The custom motion_summary is authoritative. Do not add or reuse the scene-default camera motion preset."
+              : "Use the selected camera motion as written. Do not add zoom-in, push-in, dolly-in, crash-zoom, or a close-up ending unless that exact inward motion is selected or requested in notes.",
           },
       character_motion: imageMode ? "" : normalized.character_motion,
       character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
@@ -2604,7 +2608,7 @@ function openStoryboardBuilder(payload = {}) {
       : "Image Prep creates text-to-image prompts from subjects, locations, lyrics, story beats, shot direction, and the story layer.";
     gemmaAllButton.textContent = promptAllButtonText();
     gemmaAllButton.title = mode === "image_to_video_prep"
-      ? "Create video prompts for the visible scenes. If a scene has an image path, local vision uses it as guidance."
+      ? "Choose whether to create only missing video prompts or redo all visible scenes. If a scene has an image path, local vision uses it as guidance."
       : "Create text-to-image prompts for the visible scenes with the selected LLM runner.";
     gptButton.textContent = mode === "image_to_video_prep" ? "GPT Video All" : "GPT Image All";
     gptButton.title = mode === "image_to_video_prep"
@@ -3724,7 +3728,11 @@ function openStoryboardBuilder(payload = {}) {
       flfStartState.style.opacity = "0.78";
     }
     const summary = makeTextarea(scene.prompt_summary, "Image prompt summary...", 3);
-    const motion = makeTextarea(scene.motion_summary, isImagePrepMode ? "Still photography notes..." : "Motion/video summary...", 3);
+    const motion = makeTextarea(
+      scene.motion_summary,
+      isImagePrepMode ? "Still photography notes..." : "Custom motion, camera, action, or LLM direction...",
+      3,
+    );
     const cameraGroups = isImagePrepMode ? STILL_CAMERA_STYLE_GROUPS : CAMERA_MOTION_GROUPS;
     const cameraMotionOptions = cameraGroups.flatMap((group) => group.options || []);
     const cameraMotionValue = scene.camera_motion || cameraMotionOptions.find((item) => String(scene.motion_summary || "").toLowerCase().includes(item.toLowerCase())) || "";
@@ -3924,7 +3932,7 @@ function openStoryboardBuilder(payload = {}) {
     const facialPerformanceField = field("Facial performance", facialPerformance);
     const facialPerformanceCustomField = field("Custom facial performance", facialPerformanceCustom);
     const imagePathField = field("Starting image", startingImageControl);
-    const motionField = field("Motion / video summary", motion);
+    const motionField = field(isImagePrepMode ? "Still photography notes" : "Motion Notes / LLM Direction", motion);
     const t2iPromptField = field("T2I prompt", imagePrompt);
     if (isVideoPrepMode) {
       grid.append(field("Video prompt type", videoPromptType), field("Setting", setting), videoTypeHint, field("Subjects", subjects), performanceStyleField, facialPerformanceField, facialPerformanceCustomField, includeMicLabel, noCharacterLabel, shotPresetField, shotCustomField, cameraMotionField, characterMotionField, customCharacterMotionField, imagePathField, field("Scene trigger phrase", triggerPhrase), field("Trigger placement", triggerPosition));
@@ -4031,7 +4039,7 @@ function openStoryboardBuilder(payload = {}) {
 
     const advancedGrid = twoCol();
     if (isVideoPrepMode) {
-      advancedGrid.append(field("Prompt summary", summary), field("Motion / video prompt summary", motion), field("Character details", subjectDetails), field("Location details", locationDetails), imagePathField, t2iPromptField, field("Video prompt", videoPrompt));
+      advancedGrid.append(field("Prompt summary", summary), motionField, field("Character details", subjectDetails), field("Location details", locationDetails), imagePathField, t2iPromptField, field("Video prompt", videoPrompt));
     } else {
       advancedGrid.append(t2iPromptField, field("Character details", subjectDetails), field("Location details", locationDetails), field("Still photography notes", motion));
     }
@@ -4085,10 +4093,10 @@ function openStoryboardBuilder(payload = {}) {
       motionField.firstChild.textContent = isImagePrepMode
         ? "Still photography notes"
         : type === "i2v"
-          ? "Motion / camera direction"
+          ? "Motion Notes / LLM Direction"
           : type === "rtv"
-            ? "Motion / camera direction with references"
-            : "Motion / camera direction";
+            ? "Motion Notes / LLM Direction (with references)"
+            : "Motion Notes / LLM Direction";
       t2iPromptField.style.display = isImagePrepMode || (type !== "t2v" && type !== "rtv") ? "flex" : "none";
       imagePathField.style.display = isVideoPrepMode && type !== "t2v" && type !== "rtv" ? "flex" : "none";
       videoPrompt.style.display = isVideoPrepMode ? "" : "none";
@@ -4307,36 +4315,52 @@ function openStoryboardBuilder(payload = {}) {
     const rows = currentRows();
     const mode = state.mode;
     const head = mode === "image_to_video_prep"
-      ? ["", "#", "Image", "Scene / Lyrics", "Motion / Video Prompt Summary", "Subjects", "Setting", "Shot Type", "Prompt Status", "Actions"]
+      ? ["", "#", "Image", "Scene / Lyrics", "Motion Notes", "Video Prompt", "Subjects", "Setting", "Shot Type", "Status", "Actions"]
       : ["#", "Reference", "Scene / Lyrics", "Prompt Summary", "Subjects", "Setting", "Shot Type", "Prompt Status", "Actions"];
     const table = document.createElement("table");
-    table.style.cssText = "width:100%;border-collapse:collapse;min-width:1250px;font-size:13px;";
+    table.style.cssText = mode === "image_to_video_prep"
+      ? "width:100%;border-collapse:collapse;table-layout:fixed;min-width:1567px;font-size:13px;"
+      : "width:100%;border-collapse:collapse;min-width:1250px;font-size:13px;";
+    if (mode === "image_to_video_prep") {
+      const colgroup = document.createElement("colgroup");
+      [36, 50, 166, 190, 205, 185, 205, 150, 120, 54, 206].forEach((width) => {
+        const col = document.createElement("col");
+        col.style.width = `${width}px`;
+        colgroup.appendChild(col);
+      });
+      table.appendChild(colgroup);
+    }
     const thead = document.createElement("thead");
-    thead.innerHTML = `<tr>${head.map((item) => `<th style="position:sticky;top:0;background:#111827;border-bottom:1px solid #334155;color:#cffafe;text-align:left;padding:13px;font-weight:900;">${escapeHtml(item)}</th>`).join("")}</tr>`;
+    thead.innerHTML = `<tr>${head.map((item) => `<th style="position:sticky;top:0;background:#111827;border-bottom:1px solid #334155;color:#cffafe;text-align:${item === "Status" ? "center" : "left"};padding:${mode === "image_to_video_prep" ? "11px 9px" : "13px"};font-weight:900;">${escapeHtml(item)}</th>`).join("")}</tr>`;
     const tbody = document.createElement("tbody");
     for (const scene of rows) {
-      const meta = statusMeta(scene);
       const tr = document.createElement("tr");
       tr.style.borderBottom = "1px solid #1e293b";
       tr.style.background = "#0b1220";
       const sceneImageSource = storyboardReferenceImageSrc({ path: scene.image_path, data: scene.image_data || scene.image_reference_data });
+      const imageWidth = mode === "image_to_video_prep" ? 148 : 170;
       const imageCell = sceneImageSource
-        ? `<div style="width:170px;height:78px;border-radius:6px;background:#0f172a url('${escapeHtml(sceneImageSource)}') center/cover no-repeat;"></div>`
-        : `<div style="width:170px;height:78px;border:1px dashed #334155;border-radius:6px;display:grid;place-items:center;color:#94a3b8;font-size:12px;text-align:center;background:#07111f;">No image in storyboard<br>Optional reference</div>`;
-      const sceneActionStyle = "border:1px solid #155e75;border-radius:6px;background:#0f172a;color:#a5f3fc;padding:8px 10px;font-weight:800;cursor:pointer;";
-      const sceneGptStyle = "border:1px solid #06b6d4;border-radius:6px;background:#0e7490;color:#f8fafc;padding:8px 10px;font-weight:900;cursor:pointer;";
-      const sceneGemmaStyle = "border:1px solid #22c55e;border-radius:6px;background:#166534;color:#f0fdf4;padding:8px 10px;font-weight:900;cursor:pointer;";
+        ? `<div style="width:${imageWidth}px;height:78px;border-radius:6px;background:#0f172a url('${escapeHtml(sceneImageSource)}') center/cover no-repeat;"></div>`
+        : `<div style="width:${imageWidth}px;height:78px;border:1px dashed #334155;border-radius:6px;display:grid;place-items:center;color:#94a3b8;font-size:12px;text-align:center;background:#07111f;">No image in storyboard<br>Optional reference</div>`;
+      const sceneActionStyle = mode === "image_to_video_prep"
+        ? "border:1px solid #155e75;border-radius:6px;background:#0f172a;color:#a5f3fc;width:76px;min-height:54px;padding:6px 7px;line-height:1.15;white-space:normal;font-weight:800;cursor:pointer;"
+        : "border:1px solid #155e75;border-radius:6px;background:#0f172a;color:#a5f3fc;padding:8px 10px;font-weight:800;cursor:pointer;";
+      const sceneGptStyle = "border:1px solid #06b6d4;border-radius:6px;background:#0e7490;color:#f8fafc;padding:7px 8px;font-weight:900;cursor:pointer;";
+      const sceneGemmaStyle = "border:1px solid #22c55e;border-radius:6px;background:#166534;color:#f0fdf4;padding:7px 8px;font-weight:900;cursor:pointer;";
       const runnerName = promptRunnerName();
       const gemmaTitle = mode === "image_to_video_prep"
         ? `Create this scene's video prompt with ${runnerName}. If the scene has an image, local vision uses it as guidance.`
         : `Create this scene's text-to-image prompt with ${runnerName}.`;
       const actionHtml = `
-        <div style="display:flex;align-items:center;gap:7px;white-space:nowrap;">
-          <button data-action="edit" style="${sceneActionStyle}">Open Scene Card</button>
+        <div style="display:${mode === "image_to_video_prep" ? "grid" : "flex"};grid-template-columns:${mode === "image_to_video_prep" ? "76px minmax(62px, 1fr) 44px" : "none"};align-items:stretch;gap:6px;white-space:nowrap;">
+          <button data-action="edit" style="${sceneActionStyle}">${mode === "image_to_video_prep" ? "Open Scene<br>Card" : "Open Scene Card"}</button>
           <button data-action="gemma" style="${sceneGemmaStyle}" title="${escapeHtml(gemmaTitle)}">${escapeHtml(runnerName)}</button>
           <button data-action="gpt" style="${sceneGptStyle}" title="Copy only this scene card as GPT JSON.">GPT</button>
         </div>`;
-      const status = `<span style="display:inline-flex;align-items:center;gap:6px;color:${meta.color};font-weight:900;"><span style="width:8px;height:8px;border-radius:999px;background:${meta.color};display:inline-block;"></span>${escapeHtml(meta.label)}</span>`;
+      const promptReady = Boolean(String(mode === "image_to_video_prep" ? scene.video_prompt : scene.image_prompt).trim());
+      const promptStatusLabel = promptReady ? "Prompt ready" : "Prompt missing";
+      const promptStatusColor = promptReady ? "#22c55e" : "#ef4444";
+      const status = `<span role="img" aria-label="${promptStatusLabel}" title="${promptStatusLabel}" style="display:flex;align-items:center;justify-content:center;width:100%;"><span style="width:12px;height:12px;border-radius:999px;background:${promptStatusColor};box-shadow:0 0 0 2px ${promptReady ? "rgba(34,197,94,.16)" : "rgba(239,68,68,.16)"};display:inline-block;"></span></span>`;
       const miniRefButtonStyle = "margin-top:7px;border:1px dashed #155e75;border-radius:6px;background:#07111f;color:#a5f3fc;padding:5px 7px;font-size:11px;font-weight:900;cursor:pointer;";
       const subjectCell = `<div>${subjectRefsHtml(scene)}</div><button data-action="load-subject-ref" title="Choose subjects from Reference Builder or upload a new subject image" style="${miniRefButtonStyle}">+ Subject</button>`;
       const settingCell = `<div>${settingRefHtml(scene)}</div><button data-action="load-location-ref" title="Load a location image for this scene" style="${miniRefButtonStyle}">+ Location</button>`;
@@ -4344,17 +4368,22 @@ function openStoryboardBuilder(payload = {}) {
       const shotCell = `<div style="display:flex;flex-direction:column;gap:4px;"><span style="align-self:flex-start;border:1px solid #155e75;border-radius:999px;background:#0f172a;color:#a5f3fc;font-size:11px;font-weight:900;padding:2px 7px;">${escapeHtml(videoType)}</span><strong style="color:#f8fafc;">${escapeHtml(scene.shot_type || "-")}</strong></div>`;
       const storyPreview = `${scene.lyric_section ? `<div style="margin-top:5px;color:#67e8f9;font-size:11px;font-weight:900;">${escapeHtml(scene.lyric_section)}</div>` : ""}${scene.story_beat ? `<div style="margin-top:5px;color:#94a3b8;font-size:11px;">Beat: ${escapeHtml(truncate(scene.story_beat, 90))}</div>` : ""}`;
       if (mode === "image_to_video_prep") {
+        const motionNotes = `<textarea data-action="motion-notes" aria-label="Motion notes for ${escapeHtml(scene.label || `Scene ${scene.scene_number}`)}" placeholder="Custom motion or LLM direction..." style="display:block;width:100%;height:80px;box-sizing:border-box;resize:vertical;border:1px solid #334155;border-radius:6px;background:#07111f;color:#e2e8f0;padding:8px;font:inherit;line-height:1.35;outline:none;">${escapeHtml(scene.motion_summary || "")}</textarea>`;
+        const videoPrompt = scene.video_prompt
+          ? `<div title="${escapeHtml(scene.video_prompt)}" style="color:#d4d4d8;line-height:1.38;overflow-wrap:anywhere;">${escapeHtml(truncate(scene.video_prompt, 115))}</div>`
+          : `<span style="color:#64748b;font-style:italic;">No video prompt yet.</span>`;
         tr.innerHTML = `
-          <td style="padding:13px;"><input type="checkbox" data-action="select" ${state.selected.has(scene.id) ? "checked" : ""}></td>
-          <td style="padding:13px;font-weight:900;font-size:17px;">${String(scene.scene_number).padStart(2, "0")}</td>
-          <td style="padding:13px;">${imageCell}</td>
-          <td style="padding:13px;max-width:210px;"><strong style="color:#f8fafc;">${escapeHtml(scene.label)}</strong><br><span style="color:#cbd5e1;">${escapeHtml(truncate(scene.lyrics, 95))}</span>${storyPreview}</td>
-          <td style="padding:13px;max-width:270px;color:#d4d4d8;">${escapeHtml(truncate(scene.motion_summary || scene.video_prompt, 150))}</td>
-          <td style="padding:13px;max-width:230px;">${subjectCell}</td>
-          <td style="padding:13px;color:#d4d4d8;max-width:210px;">${settingCell}</td>
-          <td style="padding:13px;">${shotCell}</td>
-          <td style="padding:13px;">${status}</td>
-          <td style="padding:13px;white-space:nowrap;">${actionHtml}</td>
+          <td style="padding:9px;text-align:center;"><input type="checkbox" data-action="select" ${state.selected.has(scene.id) ? "checked" : ""}></td>
+          <td style="padding:9px;font-weight:900;font-size:17px;">${String(scene.scene_number).padStart(2, "0")}</td>
+          <td style="padding:9px;">${imageCell}</td>
+          <td style="padding:9px;overflow:hidden;"><strong style="color:#f8fafc;">${escapeHtml(scene.label)}</strong><br><span style="color:#cbd5e1;">${escapeHtml(truncate(scene.lyrics, 70))}</span>${storyPreview}</td>
+          <td style="padding:9px;vertical-align:middle;">${motionNotes}</td>
+          <td style="padding:9px;vertical-align:middle;">${videoPrompt}</td>
+          <td style="padding:9px;overflow:hidden;">${subjectCell}</td>
+          <td style="padding:9px;color:#d4d4d8;overflow:hidden;">${settingCell}</td>
+          <td style="padding:9px;overflow:hidden;">${shotCell}</td>
+          <td style="padding:9px;text-align:center;">${status}</td>
+          <td style="padding:9px;white-space:nowrap;">${actionHtml}</td>
         `;
       } else {
         tr.innerHTML = `
@@ -4370,6 +4399,16 @@ function openStoryboardBuilder(payload = {}) {
         `;
       }
       tr.querySelector('[data-action="edit"]')?.addEventListener("click", () => openSceneEditor(scene));
+      const motionNotesInput = tr.querySelector('[data-action="motion-notes"]');
+      if (motionNotesInput) {
+        motionNotesInput.addEventListener("input", () => {
+          scene.motion_summary = motionNotesInput.value;
+        });
+        motionNotesInput.addEventListener("change", () => {
+          scene.motion_summary = motionNotesInput.value.trim();
+        });
+        motionNotesInput.addEventListener("keydown", (event) => event.stopPropagation());
+      }
       tr.querySelector('[data-action="load-subject-ref"]')?.addEventListener("click", () => openStoryboardSubjectPicker(scene));
       tr.querySelector('[data-action="load-location-ref"]')?.addEventListener("click", () => addStoryboardReferenceFromFile("location", scene));
       tr.querySelector('[data-action="gemma"]')?.addEventListener("click", async () => {
@@ -4894,14 +4933,91 @@ function openStoryboardBuilder(payload = {}) {
       : createSceneImagePromptWithGemma(scene, options);
   }
 
-  async function createAllPromptsWithGemma() {
-    const scenes = currentRows();
-    if (!scenes.length) {
+  const chooseVideoPromptGenerationScope = (scenes = []) => new Promise((resolve) => {
+    const missingCount = scenes.filter((scene) => !String(scene.video_prompt || "").trim()).length;
+    const completedCount = scenes.length - missingCount;
+    const runnerName = promptRunnerName();
+    const choiceBackdrop = document.createElement("div");
+    choiceBackdrop.style.cssText = "position:fixed;inset:0;z-index:100060;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:22px;box-sizing:border-box;";
+    const panel = document.createElement("div");
+    panel.setAttribute("role", "dialog");
+    panel.setAttribute("aria-modal", "true");
+    panel.setAttribute("aria-labelledby", "vrgdg-video-all-choice-title");
+    panel.style.cssText = "width:min(650px,calc(100vw - 44px));border:1px solid #155e75;border-radius:11px;background:#0f172a;color:#e5e7eb;box-shadow:0 24px 90px rgba(0,0,0,.7);overflow:hidden;";
+    const header = document.createElement("div");
+    header.style.cssText = "padding:16px 18px;background:#083f4f;border-bottom:1px solid #155e75;";
+    const title = document.createElement("div");
+    title.id = "vrgdg-video-all-choice-title";
+    title.style.cssText = "font-size:18px;font-weight:900;color:#cffafe;";
+    title.textContent = `${runnerName} Video All`;
+    const subtitle = document.createElement("div");
+    subtitle.style.cssText = "margin-top:4px;color:#bae6fd;font-size:12px;line-height:1.4;";
+    subtitle.textContent = "Choose whether to preserve completed video prompts or regenerate every visible scene.";
+    header.append(title, subtitle);
+    const body = document.createElement("div");
+    body.style.cssText = "padding:18px;display:flex;flex-direction:column;gap:14px;";
+    const counts = document.createElement("div");
+    counts.style.cssText = "border:1px solid #334155;border-radius:8px;background:#07111f;padding:12px;color:#e2e8f0;font-weight:800;line-height:1.45;";
+    counts.textContent = `${missingCount} missing  •  ${completedCount} already complete  •  ${scenes.length} total visible scene${scenes.length === 1 ? "" : "s"}`;
+    const guidance = document.createElement("div");
+    guidance.style.cssText = "color:#cbd5e1;font-size:13px;line-height:1.5;";
+    guidance.textContent = "Only Missing keeps every existing video prompt unchanged and creates prompts only for blank scenes. Redo All replaces the generated video prompt for every visible scene.";
+    const actions = document.createElement("div");
+    actions.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:10px;";
+    const onlyMissing = makeButton(`Only Missing (${missingCount})`, "primary");
+    onlyMissing.style.minHeight = "46px";
+    onlyMissing.disabled = missingCount === 0;
+    onlyMissing.title = missingCount
+      ? "Keep completed prompts and create only the missing video prompts."
+      : "Every visible scene already has a video prompt.";
+    const redoAll = makeButton(`Redo All (${scenes.length})`);
+    redoAll.style.cssText += "min-height:46px;border-color:#d97706;background:#78350f;color:#fef3c7;";
+    redoAll.title = "Replace all existing video prompts for the visible scenes.";
+    const cancel = makeButton("Cancel");
+    cancel.style.cssText += "grid-column:1 / -1;min-height:40px;";
+    actions.append(onlyMissing, redoAll, cancel);
+    body.append(counts, guidance, actions);
+    panel.append(header, body);
+    choiceBackdrop.append(panel);
+    document.body.append(choiceBackdrop);
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        finish(null);
+      }
+    };
+    const finish = (choice) => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      choiceBackdrop.remove();
+      resolve(choice);
+    };
+    onlyMissing.onclick = () => finish("missing");
+    redoAll.onclick = () => finish("all");
+    cancel.onclick = () => finish(null);
+    choiceBackdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === choiceBackdrop) finish(null);
+    });
+    document.addEventListener("keydown", onKeyDown, true);
+    requestAnimationFrame(() => (missingCount ? onlyMissing : redoAll).focus());
+  });
+
+  async function createAllPromptsWithGemma({ onlyMissing = false } = {}) {
+    const visibleScenes = currentRows();
+    if (!visibleScenes.length) {
       createToast("No storyboard scenes found.", true);
       return;
     }
     const videoMode = state.mode === "image_to_video_prep";
     const promptKind = videoMode ? "video" : "image";
+    const promptField = videoMode ? "video_prompt" : "image_prompt";
+    const scenes = onlyMissing
+      ? visibleScenes.filter((scene) => !String(scene[promptField] || "").trim())
+      : visibleScenes;
+    if (!scenes.length) {
+      createToast(`Every visible scene already has a ${promptKind} prompt.`);
+      return;
+    }
     gemmaAllButton.disabled = true;
     const previousText = gemmaAllButton.textContent;
     const runnerName = promptRunnerName();
@@ -4910,7 +5026,7 @@ function openStoryboardBuilder(payload = {}) {
     let created = 0;
     try {
       const keepLoaded = Boolean(keepGemmaLoadedInput.checked);
-      progress.set(`Starting Storyboard ${runnerName} All...\nMode: ${videoMode ? "Video Prep" : "Image Prep"}\nScenes: ${scenes.length}\nKeep local LLM loaded: ${keepLoaded ? "yes" : "no"}`, 5);
+      progress.set(`Starting Storyboard ${runnerName} All...\nMode: ${videoMode ? "Video Prep" : "Image Prep"}\nScope: ${onlyMissing ? `only missing (${scenes.length} of ${visibleScenes.length})` : `redo all (${scenes.length})`}\nKeep local LLM loaded: ${keepLoaded ? "yes" : "no"}`, 5);
       for (let index = 0; index < scenes.length; index += 1) {
         gemmaAllButton.textContent = `${runnerName} ${index + 1}/${scenes.length}`;
         const unloadAfter = keepLoaded ? index === scenes.length - 1 : true;
@@ -4922,10 +5038,14 @@ function openStoryboardBuilder(payload = {}) {
       }
       progress.set("Saving storyboard prompts...", 96);
       await saveStoryboard();
-      progress.set(`${runnerName} All complete.\nCreated ${created} storyboard ${promptKind} prompt${created === 1 ? "" : "s"}.`, 100);
+      progress.set(`${runnerName} All complete.\nCreated ${created} storyboard ${promptKind} prompt${created === 1 ? "" : "s"}${onlyMissing ? "; existing prompts were preserved" : ""}.`, 100);
       progress.close(1800);
-      createToast(`${genericName} created ${created} storyboard ${promptKind} prompt${created === 1 ? "" : "s"}.`);
+      createToast(`${genericName} created ${created} storyboard ${promptKind} prompt${created === 1 ? "" : "s"}${onlyMissing ? "; existing prompts were preserved" : ""}.`);
     } catch (error) {
+      if (created > 0) {
+        progress.set(`Saving ${created} completed prompt${created === 1 ? "" : "s"} before stopping...`, 96);
+        await saveStoryboard();
+      }
       progress.set(`${runnerName} All stopped after ${created}/${scenes.length} scenes:\n${String(error?.message || error)}`, 100);
       createToast(`${runnerName} All stopped after ${created}/${scenes.length} scenes:\n${String(error?.message || error)}`, true);
     } finally {
@@ -4933,6 +5053,21 @@ function openStoryboardBuilder(payload = {}) {
       gemmaAllButton.textContent = previousText;
       renderTable();
     }
+  }
+
+  async function startAllPromptsWithGemma() {
+    const scenes = currentRows();
+    if (!scenes.length) {
+      createToast("No storyboard scenes found.", true);
+      return;
+    }
+    if (state.mode !== "image_to_video_prep") {
+      await createAllPromptsWithGemma();
+      return;
+    }
+    const scope = await chooseVideoPromptGenerationScope(scenes);
+    if (!scope) return;
+    await createAllPromptsWithGemma({ onlyMissing: scope === "missing" });
   }
 
   stepPrompts.onclick = () => setMode("storyboard_prompts");
@@ -5031,7 +5166,7 @@ function openStoryboardBuilder(payload = {}) {
   };
   gptButton.onclick = copyStoryboardForGpt;
   importImagePromptsButton.onclick = openImportImagePromptsFromGptModal;
-  gemmaAllButton.onclick = createAllPromptsWithGemma;
+  gemmaAllButton.onclick = startAllPromptsWithGemma;
   clearPromptsButton.onclick = clearAllStoryboardPrompts;
   clearStoryBeatsButton.onclick = clearAllStoryboardStoryBeats;
   storyLayerEnabledInput.addEventListener("change", () => syncStoryLayerFromInputs({ notify: true }));


### PR DESCRIPTION
## Summary

- Add persistent Render All logs with live timing, per-scene phase details, ETA summaries, final-stitch timing, and JSON/text reports saved in each project.
- Add a Render Log viewer so current and previous runs can be inspected and downloaded from the Video Builder.
- Make Add Segment append from the final base clip to the playhead when the playhead is at least 0.5 seconds later, snap the endpoint to the nearest beat when enabled, and confirm segments longer than 10 seconds.
- Add Space for play/pause and S for Add Segment, and fix Left/Right scene navigation so shortcuts survive scene-list re-renders while remaining disabled during text entry and dialogs.
- Add an inline Storyboard Motion Notes editor backed by the same scene field used by Scene Card and prompt generation, while compacting prompt status and scene actions.
- Make Gemma Video All open an in-app choice between Only Missing and Redo All, preserve existing prompts in missing-only mode, and save partial progress after a later scene fails.
- Treat custom Motion Notes as authoritative camera direction: when present, the scene-default camera-motion preset is withheld from Gemma to prevent conflicting instructions.
- Add a matching What's New release entry for the complete Builder and Storyboard update.

## Why

Render All previously offered little visibility into where time was spent or why a long batch stalled. Timeline segment creation ignored a deliberately positioned playhead, and scene-selection shortcuts lost keyboard focus after the UI re-rendered the selected scene. Storyboard motion notes also required opening every Scene Card, bulk prompt retries regenerated completed work, and custom camera direction could conflict with a scene-default camera preset.

## User impact

Builders can review live and historical render performance, create precisely timed beat-aligned segments, navigate the timeline from the keyboard, edit per-scene LLM motion direction directly in Video Prep, safely retry only missing prompts, and generate video prompts without contradictory camera instructions. The What's New banner now advertises these features after updating.

## Validation

- Python compilation for `VRGDG_MusicVideoBuilderNodes.py` and `VRGDG_StoryboardBuilderNodes.py`
- JavaScript module syntax checks for `web/VRGDG_MusicVideoBuilderUI.js` and `web/VRGDG_StoryboardBuilderUI.js`
- Full earlier regression run: 26 passed, 1 skipped
- Storyboard regression checks: 9 passed across subject mapping, starting-shot behavior, and project-frame import
- Parsed `update_notes.json` and verified the newest release ID and section structure
- `git diff --check`

## Scope

Only intended tracked product files are included. No untracked files, SRT files, backups, generated media, or test scripts were added.