### PR TITLE
Add MiniMax H3 Video Builder testing support

### DIFF
--- a/VRGDG_MiniMaxH3PromptInstructions.py
+++ b/VRGDG_MiniMaxH3PromptInstructions.py
@@ -1,0 +1,176 @@
+"""Default LLM instructions for MiniMax H3 Builder prompt creation.
+
+These defaults deliberately target the Builder's first MiniMax H3 workflow,
+which receives custom project audio as ``Audio 1``.  A future native-audio
+workflow should use a separate instruction family instead of weakening this
+contract.
+"""
+
+
+MINIMAX_H3_PROMPT_DIRECTOR_CORE = """You are the MiniMax H3 Prompt Director for the Video Builder. Convert the supplied scene context into one polished MiniMax H3 video prompt.
+
+The input context will identify the exact scene duration, aspect ratio, visual idea, lyrics or dialogue when available, scene notes, and any ordered reference media. Treat the supplied duration and media assignments as authoritative.
+
+CORE WORKFLOW
+1. Use the exact duration supplied for the scene. Never round it, shorten it, or extend it.
+2. Begin exactly with: Generate a [duration]-second [aspect ratio] [visual style] video.
+3. Replace every bracketed placeholder with concrete values. Never leave placeholder text in the result.
+4. Use the exact sectioned layout described under OUTPUT FORMAT. Preserve every required blank line and line break.
+5. Follow the media assignments with a timestamped visual schedule covering the entire duration.
+6. Every timestamp must connect precisely, with no gaps or overlaps.
+7. Expand the idea into an exciting but physically readable sequence while preserving the user's subject, location, story intent, and requested ending.
+8. Make reasonable creative decisions from the supplied context without asking questions.
+
+TIMELINE DENSITY
+- 4-5 seconds: 2-3 clear visual beats.
+- 6-8 seconds: 3-5 clear visual beats.
+- 9-12 seconds: 4-6 clear visual beats.
+- 13-15 seconds: 5-8 clear visual beats.
+- For other durations, use the fewest beats needed to make the requested action clear and achievable.
+
+Format timestamps like:
+[0s-2s]
+[2s-4.5s]
+[4.5s-8s]
+
+VISUAL DIRECTION
+- Describe visible actions literally and chronologically.
+- Include the subject and relevant appearance, environment, physical action, camera framing and movement, lighting and atmosphere, important facial expression, object interaction, and physical consequences.
+- Prioritize visible action over decorative adjectives. Describe exactly what transforms, moves, breaks, appears, disappears, or changes.
+- Give each timestamp one main readable event, especially in fast sequences.
+- Do not overload one moment with incompatible camera movements.
+- Use clear camera language such as wide establishing shot, extreme close-up, low-angle tracking shot, fast push-in, orbiting camera, handheld chase shot, rapid pullback, continuous unbroken shot, hard cut, or match cut.
+- In multi-shot sequences, make each shot meaningfully different and connect them with a hard cut, match cut, motivated transition, or continuous movement.
+- Do not fill time with slow motion unless the user requests it.
+
+SUPPLIED AUDIO AND VOCAL CONTRACT
+- The current Builder workflow receives the project's custom audio as Audio 1.
+- Always place an Audio 1: assignment before the timestamped timeline and an Audio: section after it.
+- Always include an Audio: section after the timestamped timeline.
+- When an exact sung lyric is supplied, the Audio 1: assignment must quote that exact lyric and explicitly require the visible singer to sing it with precise lip, mouth-shape, jaw, facial-muscle, and breathing synchronization to Audio 1. Every timestamp during which the vocal occurs must visibly describe the singer singing that exact line in sync. Do not weaken this to merely timing the camera, steps, mood, or visual emphasis to the lyric.
+- When exact spoken dialogue is supplied, apply the same rule using speaking and precise dialogue lip sync rather than singing.
+- When the scene is explicitly visual-only, instrumental, no-lip-sync, or has no visible character, do not invent visible singing or speaking. State the appropriate visual-only use of Audio 1 without quoting hidden lyrics as performed words.
+- Never invent, rewrite, replace, extend, or add words that were not supplied.
+- In the final Audio: section, require Audio 1 to remain unchanged as the primary track, preserving its exact vocal timing, phrasing, tone, and duration. Only request subtle supporting ambience or sound effects when appropriate, and keep them underneath Audio 1.
+- Do not request newly generated music, replacement dialogue, replacement voices, or additional vocal layers that conflict with Audio 1.
+- Do not claim the scene is silent when Audio 1 is supplied.
+
+CONTINUITY
+- Add a Continuity: section only when identity, clothing, objects, locations, or spatial relationships must remain consistent.
+- Preserve the same face, hairstyle, clothing, age, body proportions, accessories, and held objects across beats unless the user explicitly requests a visible change.
+- Track important objects and spatial positions coherently across cuts.
+
+TEXT ON SCREEN
+- Include visible text only when the user explicitly requests it.
+- Put the exact requested text in quotation marks, require exact spelling, say it appears only once, and do not invent captions, logos, subtitles, credits, or other text.
+
+OUTPUT FORMAT
+Return the finished prompt in this exact visual structure, with real line breaks rather than one continuous paragraph:
+
+Generate a [duration]-second [aspect ratio] [visual style] video.
+
+[One separate Image N: or Video N: assignment paragraph for each supplied visual reference. Omit this block only for text-to-video.]
+
+Audio 1: [exact custom-audio assignment; include the exact supplied sung lyric or dialogue and the explicit lip-sync contract when applicable.]
+
+[0s–...s]
+[Visible action, performance, camera, and environment for this interval.]
+
+[next timestamp]
+[Visible action, performance, camera, and environment for this interval.]
+
+Audio: [how Audio 1 remains unchanged and how the entire result synchronizes to it.]
+
+Continuity: [identity, clothing, environment, spatial, and no-new-elements requirements.]
+
+- Put each timestamp header on its own line.
+- Put a blank line before every media assignment, timestamp block, Audio: section, and Continuity: section.
+- Never collapse the result into one paragraph.
+- Refer to media naturally as Image 1, Image 2, Video 1, and Audio 1. Do not print angle-bracket media tags in the finished prompt.
+
+SILENT QUALITY CHECK
+Before answering, verify that the timeline starts at 0 seconds, ends at the exact requested duration, contains no gaps or overlaps, gives every action enough time, follows Audio 1, preserves required continuity, visibly performs the exact supplied lyric or dialogue when lip sync is requested, and ends with a deliberate payoff rather than stopping randomly.
+
+OUTPUT RULES
+- Return only the finished MiniMax H3 prompt as plain text.
+- Do not use a markdown code fence.
+- Keep the required paragraph breaks and timestamp line breaks exactly as specified.
+- Do not explain the prompt, provide alternatives, add a negative prompt, repeat the request, mention these instructions, or mention Builder metadata.
+"""
+
+
+_MINIMAX_H3_TEXT_TO_VIDEO_MODE = """MODE: TEXT TO VIDEO
+- Build the complete visible scene from the user's idea, scene notes, story context, and exact duration.
+- Do not claim that an image or video reference exists and do not use Image N or Video N labels.
+- Preserve named subjects, wardrobe, setting, mood, and story requirements from the input.
+- Infer only missing visual and camera details needed to make the scene complete.
+- The only required media label for this custom-audio workflow is Audio 1.
+"""
+
+
+_MINIMAX_H3_IMAGE_TO_VIDEO_MODE = """MODE: IMAGE TO VIDEO
+- Image 1 is the supplied opening image and the authoritative starting composition.
+- Explicitly identify Image 1 as the exact start frame and the subject-identity, clothing, setting, lighting, and composition anchor.
+- Start from Image 1 exactly, then animate the subject, camera, lighting, and environment naturally.
+- Preserve the visible subject's face, hairstyle, age, body proportions, clothing, accessories, location, and major composition details unless the user explicitly requests a visible transformation.
+- Do not treat Image 1 as a cutaway, a later insert, or a loose style suggestion.
+- Do not invent additional image or video labels.
+- Use Audio 1 only according to the supplied-audio and vocal contract.
+"""
+
+
+_MINIMAX_H3_REFERENCE_TO_VIDEO_MODE = """MODE: REFERENCE TO VIDEO
+- The input context will list the connected images in their exact workflow order and state the intended purpose of each one. Refer to them as Image 1 through Image 9 only when they are actually supplied.
+- Clearly assign every supplied picture its stated purpose in the finished prompt. Purposes may include character identity and clothing, location, visual style, prop, start frame, end frame, or storyboard guidance.
+- Never assume a fixed purpose from slot number. The supplied ordered assignments are authoritative.
+- Preserve character and location identity from the pictures assigned to those purposes without copying an unwanted pose, crop, camera angle, panel layout, or collage.
+- When a picture is identified as a storyboard grid, interpret its panels as ordered visual beats and composition guidance. Do not generate the grid, borders, panels, labels, or a collage as the output video.
+- When start and end pictures are assigned, begin from the start picture and arrive coherently at the end picture. Follow the user's requested transition behavior, including surreal morph, cinematic non-morphing continuation, or longer action between the endpoints.
+- When Image 1 is assigned as the exact start frame and later images are character references, Image 1 controls only the opening composition, pose, camera angle, environment, and lighting. The character-reference images remain authoritative for face, hair, clothing, body proportions, and identity details that are hidden in Image 1. Use those identity details to keep the character correct when they turn around, change angle, become partially occluded, or move into a different framing.
+- Do not mention any image label that was not supplied.
+- Use Audio 1 only according to the supplied-audio and vocal contract.
+"""
+
+
+_MINIMAX_H3_VIDEO_TO_VIDEO_MODE = """MODE: VIDEO TO VIDEO
+- The input context will list connected videos in exact workflow order, with a purpose for each. Refer to them as Video 1 through Video 3 only when they are actually supplied.
+- Explicitly assign every supplied video its stated role, such as continuation source, movement guide, camera guide, edit/rhythm guide, transformation source, or visual-style guide.
+- Follow only the intended property of each reference video. Do not copy an unwanted subject identity, clothing, location, text, watermark, or unrelated content from a motion or camera reference.
+- For continuation or extension, begin coherently from the supplied video's ending state and preserve identity, clothing, location, object positions, movement direction, and camera logic unless the user requests a transition.
+- If ordered image references are also supplied, use their exact Image N labels and stated purposes without overriding the assigned role of the video references.
+- Do not mention image or video labels that were not supplied.
+- Audio 1 is the authoritative custom project audio. Do not treat audio embedded in a reference video as the soundtrack unless the input context explicitly assigns that audio a purpose.
+"""
+
+
+MINIMAX_H3_TEXT_TO_VIDEO_INSTRUCTIONS = (
+    MINIMAX_H3_PROMPT_DIRECTOR_CORE + "\n" + _MINIMAX_H3_TEXT_TO_VIDEO_MODE
+)
+
+MINIMAX_H3_IMAGE_TO_VIDEO_INSTRUCTIONS = (
+    MINIMAX_H3_PROMPT_DIRECTOR_CORE + "\n" + _MINIMAX_H3_IMAGE_TO_VIDEO_MODE
+)
+
+MINIMAX_H3_REFERENCE_TO_VIDEO_INSTRUCTIONS = (
+    MINIMAX_H3_PROMPT_DIRECTOR_CORE + "\n" + _MINIMAX_H3_REFERENCE_TO_VIDEO_MODE
+)
+
+MINIMAX_H3_VIDEO_TO_VIDEO_INSTRUCTIONS = (
+    MINIMAX_H3_PROMPT_DIRECTOR_CORE + "\n" + _MINIMAX_H3_VIDEO_TO_VIDEO_MODE
+)
+
+
+MINIMAX_H3_INSTRUCTIONS_BY_MODE = {
+    "text_to_video": MINIMAX_H3_TEXT_TO_VIDEO_INSTRUCTIONS,
+    "image_to_video": MINIMAX_H3_IMAGE_TO_VIDEO_INSTRUCTIONS,
+    "reference_to_video": MINIMAX_H3_REFERENCE_TO_VIDEO_INSTRUCTIONS,
+    "video_to_video": MINIMAX_H3_VIDEO_TO_VIDEO_INSTRUCTIONS,
+}
+
+
+MINIMAX_H3_INSTRUCTION_KEYS_BY_MODE = {
+    "text_to_video": "minimax_h3_text_to_video",
+    "image_to_video": "minimax_h3_image_to_video",
+    "reference_to_video": "minimax_h3_reference_to_video",
+    "video_to_video": "minimax_h3_video_to_video",
+}

--- a/VRGDG_MiniMaxH3ReferenceMedia.py
+++ b/VRGDG_MiniMaxH3ReferenceMedia.py
@@ -1,0 +1,253 @@
+import json
+import os
+import re
+
+import folder_paths
+import numpy as np
+import torch
+from PIL import Image, ImageOps
+
+
+MAX_REFERENCE_IMAGES = 9
+MAX_REFERENCE_VIDEOS = 3
+REFERENCE_VIDEO_FPS = 24
+REFERENCE_VIDEO_MAX_FRAMES = 15 * REFERENCE_VIDEO_FPS
+
+
+def _parse_path_values(raw, collection_keys=()):
+    text = str(raw or "").strip()
+    if not text:
+        return []
+
+    parsed = None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        pass
+
+    if isinstance(parsed, list):
+        values = parsed
+    elif isinstance(parsed, dict):
+        values = None
+        for key in collection_keys:
+            if isinstance(parsed.get(key), list):
+                values = parsed[key]
+                break
+        if values is None:
+            values = list(parsed.values())
+    else:
+        values = re.split(r"[\r\n]+", text)
+    return values
+
+
+def _clean_path(value):
+    if isinstance(value, dict):
+        value = value.get("path") or value.get("file") or value.get("image") or value.get("video") or ""
+    return str(value or "").strip().strip('"').strip("'")
+
+
+def _parse_image_paths(raw):
+    return [
+        path
+        for path in (_clean_path(item) for item in _parse_path_values(raw, ("image_paths", "images")))
+        if path
+    ]
+
+
+def _as_bool(value, default=False):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _as_nonnegative_float(value, default=0.0):
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return max(0.0, float(default))
+
+
+def _parse_video_references(raw):
+    references = []
+    for item in _parse_path_values(raw, ("video_references", "videos")):
+        if isinstance(item, dict):
+            path = _clean_path(item)
+            start_seconds = _as_nonnegative_float(
+                item.get("start_seconds", item.get("start", item.get("seek_seconds", 0)))
+            )
+            duration = _as_nonnegative_float(
+                item.get("duration_seconds", item.get("duration", 0))
+            )
+            use_audio = _as_bool(
+                item.get("use_audio", item.get("include_audio", item.get("reference_audio", False)))
+            )
+        else:
+            path = _clean_path(item)
+            start_seconds = 0.0
+            duration = 0.0
+            use_audio = False
+        if path:
+            references.append({
+                "path": path,
+                "start_seconds": start_seconds,
+                "duration": duration,
+                "use_audio": use_audio,
+            })
+    return references
+
+
+def _resolve_media_path(raw_path):
+    path_text = _clean_path(raw_path)
+    if not path_text:
+        raise FileNotFoundError("MiniMax H3 reference media path was empty.")
+
+    candidates = []
+    if os.path.isabs(path_text):
+        candidates.append(path_text)
+    else:
+        candidates.extend([
+            path_text,
+            os.path.abspath(path_text),
+            os.path.join(folder_paths.get_input_directory(), path_text),
+            os.path.join(folder_paths.get_output_directory(), path_text),
+        ])
+        get_temp_directory = getattr(folder_paths, "get_temp_directory", None)
+        if callable(get_temp_directory):
+            candidates.append(os.path.join(get_temp_directory(), path_text))
+
+    seen = set()
+    for candidate in candidates:
+        normalized = os.path.normpath(os.path.abspath(candidate))
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        if os.path.isfile(normalized):
+            return normalized
+    raise FileNotFoundError(f"MiniMax H3 reference media was not found: {path_text}")
+
+
+def _load_image_tensor(raw_path):
+    resolved = _resolve_media_path(raw_path)
+    with Image.open(resolved) as image:
+        image = ImageOps.exif_transpose(image).convert("RGB")
+        array = np.asarray(image).astype(np.float32) / 255.0
+    return torch.from_numpy(array).unsqueeze(0)
+
+
+def _vhs_video_loader():
+    import nodes
+
+    loader_class = nodes.NODE_CLASS_MAPPINGS.get("VHS_LoadVideoPath")
+    if loader_class is None:
+        raise RuntimeError(
+            "MiniMax H3 video references require Video Helper Suite's VHS_LoadVideoPath node."
+        )
+    return loader_class()
+
+
+def _load_video_reference(reference, slot_index):
+    resolved = _resolve_media_path(reference["path"])
+    fps = REFERENCE_VIDEO_FPS
+    start_seconds = _as_nonnegative_float(reference.get("start_seconds", 0))
+    duration = _as_nonnegative_float(reference.get("duration", 0))
+    skip_first_frames = max(0, round(start_seconds * fps))
+    frame_load_cap = (
+        min(REFERENCE_VIDEO_MAX_FRAMES, max(1, round(duration * fps)))
+        if duration > 0
+        else REFERENCE_VIDEO_MAX_FRAMES
+    )
+
+    loader = _vhs_video_loader()
+    load_function = getattr(loader, getattr(loader, "FUNCTION", "load_video"))
+    frames, _frame_count, audio, _video_info = load_function(
+        video=resolved,
+        force_rate=fps,
+        custom_width=0,
+        custom_height=0,
+        frame_load_cap=frame_load_cap,
+        skip_first_frames=skip_first_frames,
+        select_every_nth=1,
+        unique_id=f"vrgdg_minimax_h3_reference_video_{slot_index}",
+    )
+    return frames, audio if reference.get("use_audio") else None
+
+
+def _pad_slots(values, count):
+    values = list(values[:count])
+    return values + [None] * (count - len(values))
+
+
+class VRGDG_MiniMaxH3ReferenceMediaFromPaths:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_paths": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": (
+                            "Ordered MiniMax H3 reference images. Use a JSON list, an object with "
+                            "image_paths/images, or one path per line. Supports up to 9 images."
+                        ),
+                    },
+                ),
+                "video_references": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": (
+                            "Ordered MiniMax H3 reference videos. Use a JSON list of paths or objects "
+                            "with path, start_seconds, duration, and use_audio. Supports up to 3 videos."
+                        ),
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",) * MAX_REFERENCE_IMAGES + ("IMAGE",) * MAX_REFERENCE_VIDEOS + ("AUDIO",) * MAX_REFERENCE_VIDEOS
+    RETURN_NAMES = (
+        tuple(f"ref_image_{index}" for index in range(MAX_REFERENCE_IMAGES))
+        + tuple(f"ref_video_{index}" for index in range(MAX_REFERENCE_VIDEOS))
+        + tuple(f"ref_video_audio_{index}" for index in range(MAX_REFERENCE_VIDEOS))
+    )
+    FUNCTION = "load_references"
+    CATEGORY = "VRGDG/Video/Conditioning"
+    DESCRIPTION = (
+        "Builder-friendly ordered media loader for MiniMax H3. It accepts project/input/output paths, "
+        "keeps each image and video in its own H3 reference slot, and returns None for unused slots."
+    )
+
+    def load_references(self, image_paths, video_references):
+        paths = _parse_image_paths(image_paths)
+        videos = _parse_video_references(video_references)
+        if len(paths) > MAX_REFERENCE_IMAGES:
+            raise ValueError(
+                f"MiniMax H3 supports at most {MAX_REFERENCE_IMAGES} reference images; received {len(paths)}."
+            )
+        if len(videos) > MAX_REFERENCE_VIDEOS:
+            raise ValueError(
+                f"MiniMax H3 supports at most {MAX_REFERENCE_VIDEOS} reference videos; received {len(videos)}."
+            )
+
+        image_outputs = _pad_slots([_load_image_tensor(path) for path in paths], MAX_REFERENCE_IMAGES)
+        loaded_videos = [
+            _load_video_reference(reference, index)
+            for index, reference in enumerate(videos)
+        ]
+        video_outputs = _pad_slots([item[0] for item in loaded_videos], MAX_REFERENCE_VIDEOS)
+        video_audio_outputs = _pad_slots([item[1] for item in loaded_videos], MAX_REFERENCE_VIDEOS)
+        return tuple(image_outputs + video_outputs + video_audio_outputs)
+
+
+NODE_CLASS_MAPPINGS = {
+    "VRGDG_MiniMaxH3ReferenceMediaFromPaths": VRGDG_MiniMaxH3ReferenceMediaFromPaths,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VRGDG_MiniMaxH3ReferenceMediaFromPaths": "VRGDG MiniMax H3 Reference Media From Paths",
+}

--- a/VRGDG_MiniMaxH3Timing.py
+++ b/VRGDG_MiniMaxH3Timing.py
@@ -1,0 +1,186 @@
+"""Exact scene timing calculations for MiniMax H3 Video Builder renders.
+
+This module deliberately has no ComfyUI dependencies.  The Builder runner can
+use it before patching a hidden workflow, and the same plan can later drive the
+post-render trim.
+"""
+
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation, ROUND_CEILING
+from typing import Optional
+
+
+H3_FPS = 24
+H3_FRAME_STEP = 17
+H3_FRAME_OFFSET = 5
+H3_MIN_FRAME_COUNT = 5
+H3_MAX_FRAME_COUNT = 362
+
+
+def _decimal(value, name):
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite number.") from exc
+    if not result.is_finite():
+        raise ValueError(f"{name} must be a finite number.")
+    return result
+
+
+def _non_negative_int(value, name):
+    number = _decimal(value, name)
+    if number < 0 or number != number.to_integral_value():
+        raise ValueError(f"{name} must be a non-negative whole number.")
+    return int(number)
+
+
+def _seconds(value):
+    """Return a stable JSON-friendly seconds value."""
+    return float(value.quantize(Decimal("0.000000001")))
+
+
+def align_h3_frame_count(frame_count):
+    """Round a frame count up to MiniMax H3's 17n+5 frame grid."""
+    frames = max(H3_MIN_FRAME_COUNT, _non_negative_int(frame_count, "frame_count"))
+    return frames + ((H3_FRAME_OFFSET - frames) % H3_FRAME_STEP)
+
+
+def frames_covering_duration(duration_seconds, fps=H3_FPS):
+    """Return the number of whole frames needed to cover a duration."""
+    duration = _decimal(duration_seconds, "duration_seconds")
+    frame_rate = _non_negative_int(fps, "fps")
+    if duration < 0:
+        raise ValueError("duration_seconds must not be negative.")
+    if frame_rate <= 0:
+        raise ValueError("fps must be greater than zero.")
+    return int((duration * frame_rate).to_integral_value(rounding=ROUND_CEILING))
+
+
+@dataclass(frozen=True)
+class MiniMaxH3TimingPlan:
+    timeline_start_seconds: float
+    timeline_end_seconds: float
+    scene_duration_seconds: float
+    source_start_seconds: float
+    source_duration_seconds: Optional[float]
+    requested_warmup_frames: int
+    requested_cooldown_frames: int
+    actual_warmup_seconds: float
+    actual_cooldown_seconds: float
+    audio_trim_start_seconds: float
+    audio_trim_duration_seconds: float
+    context_duration_seconds: float
+    context_frame_count: int
+    workflow_duration_input_seconds: float
+    h3_frame_count: int
+    h3_render_duration_seconds: float
+    alignment_padding_seconds: float
+    final_trim_start_seconds: float
+    final_trim_duration_seconds: float
+    discard_after_scene_seconds: float
+
+    def to_dict(self):
+        return asdict(self)
+
+
+def calculate_minimax_h3_timing(
+    timeline_start_seconds,
+    timeline_end_seconds,
+    warmup_frames=0,
+    cooldown_frames=0,
+    *,
+    source_start_seconds=None,
+    source_duration_seconds=None,
+    fps=H3_FPS,
+    max_frame_count=H3_MAX_FRAME_COUNT,
+):
+    """Create the complete render/trim timing plan for one Builder scene.
+
+    Timeline start/end are authoritative.  Warm-up and cool-down are context
+    frames and never alter ``final_trim_duration_seconds``.  If the source audio
+    starts or ends too close to a boundary, only the unavailable handle is
+    clamped; the selected scene itself must still exist in the source audio.
+
+    ``workflow_duration_input_seconds`` is intentionally based on the ceiling
+    frame count.  Passing it through the current hidden workflow's seconds-to-
+    frames expression can therefore never produce a render shorter than the
+    requested context.
+    """
+    frame_rate = _non_negative_int(fps, "fps")
+    if frame_rate != H3_FPS:
+        raise ValueError(f"MiniMax H3 timing requires {H3_FPS} FPS.")
+
+    timeline_start = _decimal(timeline_start_seconds, "timeline_start_seconds")
+    timeline_end = _decimal(timeline_end_seconds, "timeline_end_seconds")
+    if timeline_start < 0:
+        raise ValueError("timeline_start_seconds must not be negative.")
+    if timeline_end <= timeline_start:
+        raise ValueError("timeline_end_seconds must be greater than timeline_start_seconds.")
+    scene_duration = timeline_end - timeline_start
+
+    warm_frames = _non_negative_int(warmup_frames, "warmup_frames")
+    cool_frames = _non_negative_int(cooldown_frames, "cooldown_frames")
+    requested_warmup = Decimal(warm_frames) / frame_rate
+    requested_cooldown = Decimal(cool_frames) / frame_rate
+
+    source_start = timeline_start if source_start_seconds is None else _decimal(
+        source_start_seconds, "source_start_seconds"
+    )
+    if source_start < 0:
+        raise ValueError("source_start_seconds must not be negative.")
+
+    source_duration = None
+    if source_duration_seconds is not None:
+        source_duration = _decimal(source_duration_seconds, "source_duration_seconds")
+        if source_duration < 0:
+            raise ValueError("source_duration_seconds must not be negative.")
+        if source_start + scene_duration > source_duration:
+            raise ValueError(
+                "The selected scene extends beyond the available source audio."
+            )
+
+    actual_warmup = min(requested_warmup, source_start)
+    actual_cooldown = requested_cooldown
+    if source_duration is not None:
+        audio_after_scene = source_duration - (source_start + scene_duration)
+        actual_cooldown = min(requested_cooldown, max(Decimal(0), audio_after_scene))
+
+    audio_trim_start = source_start - actual_warmup
+    context_duration = actual_warmup + scene_duration + actual_cooldown
+    context_frames = frames_covering_duration(context_duration, frame_rate)
+    h3_frames = align_h3_frame_count(context_frames)
+    maximum = _non_negative_int(max_frame_count, "max_frame_count")
+    if h3_frames > maximum:
+        raise ValueError(
+            "The scene plus available warm-up/cool-down requires "
+            f"{h3_frames} H3 frames, exceeding the configured maximum of {maximum}."
+        )
+
+    render_duration = Decimal(h3_frames) / frame_rate
+    workflow_duration = Decimal(context_frames) / frame_rate
+    alignment_padding = render_duration - context_duration
+    final_trim_start = actual_warmup
+    discard_after_scene = render_duration - (actual_warmup + scene_duration)
+
+    return MiniMaxH3TimingPlan(
+        timeline_start_seconds=_seconds(timeline_start),
+        timeline_end_seconds=_seconds(timeline_end),
+        scene_duration_seconds=_seconds(scene_duration),
+        source_start_seconds=_seconds(source_start),
+        source_duration_seconds=None if source_duration is None else _seconds(source_duration),
+        requested_warmup_frames=warm_frames,
+        requested_cooldown_frames=cool_frames,
+        actual_warmup_seconds=_seconds(actual_warmup),
+        actual_cooldown_seconds=_seconds(actual_cooldown),
+        audio_trim_start_seconds=_seconds(audio_trim_start),
+        audio_trim_duration_seconds=_seconds(context_duration),
+        context_duration_seconds=_seconds(context_duration),
+        context_frame_count=context_frames,
+        workflow_duration_input_seconds=_seconds(workflow_duration),
+        h3_frame_count=h3_frames,
+        h3_render_duration_seconds=_seconds(render_duration),
+        alignment_padding_seconds=_seconds(alignment_padding),
+        final_trim_start_seconds=_seconds(final_trim_start),
+        final_trim_duration_seconds=_seconds(scene_duration),
+        discard_after_scene_seconds=_seconds(discard_after_scene),
+    )

--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -35,6 +35,12 @@ from .VRGDG_LUTVideoTools import register_lut_routes
 from .VRGDG_FaceFix import register_face_fix_routes
 from .VRGDG_GemmaPromptSanitizer import extract_prompt_text_from_gemma_output
 from .VRGDG_StoryboardBuilderNodes import _STORYBOARD_T2I_GEMMA_INSTRUCTIONS
+from .VRGDG_MiniMaxH3PromptInstructions import (
+    MINIMAX_H3_IMAGE_TO_VIDEO_INSTRUCTIONS,
+    MINIMAX_H3_REFERENCE_TO_VIDEO_INSTRUCTIONS,
+    MINIMAX_H3_TEXT_TO_VIDEO_INSTRUCTIONS,
+    MINIMAX_H3_VIDEO_TO_VIDEO_INSTRUCTIONS,
+)
 
 
 _VRGDG_MUSIC_BUILDER_ROUTES_REGISTERED = False
@@ -875,6 +881,10 @@ _BUILDER_INSTRUCTION_DEFAULTS = {
     "ingredients": _T2V_INSTRUCTIONS,
     "i2v": _I2V_INSTRUCTIONS,
     "krea2_t2i": _STANDARD_IMAGE_T2I_INSTRUCTIONS,
+    "minimax_h3_image_to_video": MINIMAX_H3_IMAGE_TO_VIDEO_INSTRUCTIONS,
+    "minimax_h3_reference_to_video": MINIMAX_H3_REFERENCE_TO_VIDEO_INSTRUCTIONS,
+    "minimax_h3_text_to_video": MINIMAX_H3_TEXT_TO_VIDEO_INSTRUCTIONS,
+    "minimax_h3_video_to_video": MINIMAX_H3_VIDEO_TO_VIDEO_INSTRUCTIONS,
     "nano_b_t2i": _NANO_B_T2I_INSTRUCTIONS,
     "rtv": _T2V_INSTRUCTIONS,
     "t2v": _T2V_INSTRUCTIONS,
@@ -889,6 +899,10 @@ _BUILDER_INSTRUCTION_LABELS = {
     "ingredients": "Ingredients to Video",
     "i2v": "Image to Video",
     "krea2_t2i": "Krea 2 Text to Image",
+    "minimax_h3_image_to_video": "MiniMax H3 Image to Video",
+    "minimax_h3_reference_to_video": "MiniMax H3 Reference to Video",
+    "minimax_h3_text_to_video": "MiniMax H3 Text to Video",
+    "minimax_h3_video_to_video": "MiniMax H3 Video to Video",
     "nano_b_t2i": "Nano B Text to Image",
     "rtv": "Reference to Video",
     "t2v": "Text to Video",
@@ -3511,6 +3525,150 @@ def _clean_lm_studio_plain_text(text):
     return cleaned
 
 
+def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
+    """Keep H3 prompts readable and make exact custom-audio lip sync explicit."""
+    payload = payload if isinstance(payload, dict) else {}
+    cleaned = _clean_lm_studio_plain_text(text).replace("\r\n", "\n").replace("\r", "\n")
+    cleaned = re.sub(r"<\s*Picture\s+(\d+)\s*>", r"Image \1", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"<\s*Video\s+(\d+)\s*>", r"Video \1", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"<\s*Audio\s+1\s*>", "Audio 1", cleaned, flags=re.IGNORECASE)
+
+    timestamp_pattern = r"\[\s*\d+(?:\.\d+)?s?\s*[-\u2013\u2014]\s*\d+(?:\.\d+)?s?\s*\]"
+    section_pattern = rf"(?:Image\s+\d+|Video\s+\d+|Audio\s+1|Audio|Continuity)\s*:|{timestamp_pattern}"
+    cleaned = re.sub(rf"[ \t]*(?={section_pattern})", "\n\n", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(rf"({timestamp_pattern})[ \t]*", r"\1\n", cleaned)
+    cleaned = re.sub(r"\n[ \t]+", "\n", cleaned)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+
+    lyric_text = re.sub(r"\s+", " ", str(payload.get("lyric_text") or "")).strip().strip('"\'\u201c\u201d\u2018\u2019')
+    performance_mode = str(payload.get("performance_mode") or "singing").strip().lower().replace("-", "_").replace(" ", "_")
+    no_visible_character = bool(payload.get("no_character_present"))
+    no_lip_sync = no_visible_character or performance_mode in {"no_lip_sync", "nolipsync", "no_lipsync", "visual_only", "instrumental"}
+    singers_raw = payload.get("singers") or []
+    if isinstance(singers_raw, str):
+        singer_names = [item.strip() for item in re.split(r"[,;\n]+", singers_raw) if item.strip()]
+    elif isinstance(singers_raw, list):
+        singer_names = [str(item or "").strip() for item in singers_raw if str(item or "").strip()]
+    else:
+        singer_names = []
+    performer = " and ".join(singer_names[:2]) if singer_names else "the visible performer"
+
+    def insert_before_first_timeline(block):
+        nonlocal cleaned
+        match = re.search(timestamp_pattern, cleaned)
+        if match:
+            cleaned = f"{cleaned[:match.start()].rstrip()}\n\n{block}\n\n{cleaned[match.start():].lstrip()}"
+        else:
+            cleaned = f"{cleaned.rstrip()}\n\n{block}"
+
+    if instruction_key == "minimax_h3_image_to_video" and not re.search(r"(?im)^Image\s+1\s*:", cleaned):
+        image_assignment = (
+            "Image 1: use as the exact start frame, character appearance and clothing reference, "
+            "environment reference, lighting reference, and composition reference."
+        )
+        first_audio = re.search(r"(?im)^Audio\s+1\s*:", cleaned)
+        if first_audio:
+            cleaned = f"{cleaned[:first_audio.start()].rstrip()}\n\n{image_assignment}\n\n{cleaned[first_audio.start():].lstrip()}"
+        else:
+            insert_before_first_timeline(image_assignment)
+
+    if not re.search(r"(?im)^Audio\s+1\s*:", cleaned):
+        if lyric_text and not no_lip_sync:
+            action = "says" if performance_mode == "speaking" else "is singing"
+            vocal_kind = "spoken" if performance_mode == "speaking" else "sung"
+            audio_assignment = (
+                f"Audio 1: use as the exact vocal, timing, and lip-sync reference. {performer} {action} the exact line "
+                f"“{lyric_text}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely "
+                f"to that {vocal_kind} line in Audio 1. Do not replace, alter, extend, or add vocals."
+            )
+        elif no_lip_sync:
+            audio_assignment = (
+                "Audio 1: use unchanged as the exact timing reference. This scene is visual-only; do not show singing, "
+                "speaking, or mouth synchronization."
+            )
+        else:
+            audio_assignment = (
+                "Audio 1: use unchanged as the exact performance, movement, and timing reference. "
+                "Do not invent lyrics, dialogue, replacement music, or replacement vocals."
+            )
+        insert_before_first_timeline(audio_assignment)
+
+    if lyric_text and not no_lip_sync:
+        lines = cleaned.split("\n")
+        exact_line_lower = lyric_text.casefold()
+        for index, line in enumerate(lines):
+            if re.match(r"^Audio\s+1\s*:", line, flags=re.IGNORECASE):
+                if exact_line_lower not in line.casefold() or "lip" not in line.casefold():
+                    action = "spoken" if performance_mode == "speaking" else "sung"
+                    lines[index] = (
+                        f"{line.rstrip()} Preserve the exact {action} line “{lyric_text}” and synchronize lips, mouth shapes, "
+                        "jaw movement, facial muscles, and breathing precisely to Audio 1."
+                    )
+                break
+        cleaned = "\n".join(lines)
+
+        vocal_verb = "says" if performance_mode == "speaking" else "visibly sings"
+        sync_kind = "spoken dialogue" if performance_mode == "speaking" else "sung lyric"
+        timeline_block_pattern = re.compile(
+            rf"({timestamp_pattern}\n)(.*?)(?=\n\n(?:{timestamp_pattern}|Audio\s*:|Continuity\s*:)|$)",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+
+        def ensure_vocal_in_timeline(match):
+            header = match.group(1)
+            body = match.group(2).strip()
+            body_lower = body.casefold()
+            visibly_performed = (
+                lyric_text.casefold() in body_lower
+                and bool(re.search(r"\b(?:sing|sings|singing|sung|lip[ -]?sync|say|says|speaking|spoken)\b", body_lower))
+            )
+            if visibly_performed:
+                return f"{header}{body}"
+            required_action = (
+                f"Throughout this interval, {performer} {vocal_verb} “{lyric_text}” with precise lip, mouth-shape, jaw, "
+                f"facial-muscle, and breathing synchronization to the {sync_kind} in Audio 1."
+            )
+            return f"{header}{body.rstrip()} {required_action}".strip()
+
+        cleaned = timeline_block_pattern.sub(ensure_vocal_in_timeline, cleaned)
+
+    if not re.search(r"(?im)^Audio\s*:", cleaned):
+        if lyric_text and not no_lip_sync:
+            audio_summary = (
+                f"Audio: Use Audio 1 unchanged as the primary audio track. Preserve its exact voice, timing, phrasing, tone, "
+                f"and duration, and keep the lip sync exact to “{lyric_text}”. Do not add replacement music, dialogue, or vocal layers."
+            )
+        else:
+            audio_summary = (
+                "Audio: Use Audio 1 unchanged as the primary audio track and preserve its exact timing and duration. "
+                "Do not add replacement music, dialogue, or vocal layers."
+            )
+        cleaned = f"{cleaned.rstrip()}\n\n{audio_summary}"
+    elif lyric_text and not no_lip_sync:
+        lines = cleaned.split("\n")
+        for index, line in enumerate(lines):
+            if re.match(r"^Audio\s*:", line, flags=re.IGNORECASE):
+                if lyric_text.casefold() not in line.casefold() or "lip" not in line.casefold():
+                    lines[index] = (
+                        f"{line.rstrip()} Use Audio 1 unchanged as the primary audio track, preserve its exact voice, timing, "
+                        f"phrasing, tone, and duration, and keep the lip sync exact to “{lyric_text}”. "
+                        "Do not add replacement music, dialogue, or vocal layers."
+                    )
+                break
+        cleaned = "\n".join(lines)
+
+    if not re.search(r"(?im)^Continuity\s*:", cleaned):
+        continuity = (
+            "Continuity: Preserve the same visible character identity, appearance, clothing, environment, lighting, and spatial "
+            "relationships throughout. Do not introduce new characters, objects, text, logos, captions, or scene changes unless explicitly requested."
+        )
+        cleaned = f"{cleaned.rstrip()}\n\n{continuity}"
+
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned
+
+
 def _run_builder_text_llm(payload, instruction_text, temperature=0.6, top_p=0.95, max_new_tokens=1200, label="Gemma", preserve_paragraphs=False):
     if _llm_runner_from_payload(payload) == "lm_studio":
         text = _run_lm_studio_text(
@@ -5306,6 +5464,8 @@ def _generate_builder_t2v_prompt(payload):
     subject_context = str(payload.get("subject_context", "") or "").strip()
     location_context = str(payload.get("location_context", "") or "").strip()
     no_character_present = bool(payload.get("no_character_present") or payload.get("no_subject") or payload.get("no_visible_subject"))
+    instruction_key = _safe_builder_instruction_key(payload.get("builder_instruction_key") or payload.get("instruction_key") or "t2v")
+    is_minimax_h3_prompt = instruction_key.startswith("minimax_h3_")
     text_runner = _llm_runner_from_payload(payload)
     if not model_file and text_runner not in {"lm_studio", "llm_api"}:
         raise ValueError("Choose a T2V Gemma model first.")
@@ -5320,7 +5480,8 @@ def _generate_builder_t2v_prompt(payload):
         except Exception:
             image_references = [{"path": line.strip()} for line in image_references.splitlines() if line.strip()]
     if isinstance(image_references, list):
-        for index, item in enumerate(image_references[:4], start=1):
+        reference_limit = 9 if is_minimax_h3_prompt else 4
+        for index, item in enumerate(image_references[:reference_limit], start=1):
             if isinstance(item, str):
                 item = {"path": item}
             if not isinstance(item, dict):
@@ -5403,9 +5564,14 @@ def _generate_builder_t2v_prompt(payload):
         else:
             raise ValueError("Create or paste scene notes, mapped references, motion notes, or a T2I/concept prompt first.")
 
-    instruction_key = _safe_builder_instruction_key(payload.get("builder_instruction_key") or payload.get("instruction_key") or "t2v")
     t2v_instructions = _effective_builder_instruction(payload, instruction_key, _T2V_INSTRUCTIONS)
-    prompt_label = "ID-LoRA I2V" if instruction_key == "id_lora" else "Reference to Video" if instruction_key == "rtv" else "T2V"
+    prompt_label = (
+        _BUILDER_INSTRUCTION_LABELS.get(instruction_key, "MiniMax H3")
+        if is_minimax_h3_prompt
+        else "ID-LoRA I2V" if instruction_key == "id_lora"
+        else "Reference to Video" if instruction_key == "rtv"
+        else "T2V"
+    )
     if has_image_reference and first_last_frame_mode:
         # Generic I2V instructions describe a single first-frame reference and
         # can conflict with FLF endpoint framing (for example, demanding that a
@@ -5472,6 +5638,14 @@ def _generate_builder_t2v_prompt(payload):
                 "- Ignore lyrics, story arc, mapped descriptions, detailed endpoint prose, other scene notes, and camera presets when deciding visible action or camera travel.\n"
                 "- The application adds any required exact vocal line and facial-performance direction after this visual prompt is returned.\n\n"
             )
+    elif has_image_reference and is_minimax_h3_prompt:
+        image_guidance = (
+            "MiniMax H3 ordered visual-reference guidance:\n"
+            "- The attached pictures are in the exact <Picture 1>, <Picture 2>, and subsequent order stated in the scene context.\n"
+            "- Inspect every attached picture and use it only for the purpose assigned to its matching tag.\n"
+            "- Keep the exact <Picture N> tags in the final MiniMax prompt wherever the mode instructions require them.\n"
+            "- Do not merge a storyboard grid into a collage output; interpret its panels as ordered visual guidance.\n\n"
+        )
     elif has_image_reference and instruction_key == "id_lora":
         image_guidance = (
             "Use the provided image as the primary visual truth for the [VISUAL] section. "
@@ -5587,15 +5761,22 @@ def _generate_builder_t2v_prompt(payload):
                 top_p=top_p,
                 max_new_tokens=max_new_tokens,
                 label=f"{prompt_label} Gemma",
+                preserve_paragraphs=is_minimax_h3_prompt,
             )
-        text = _clean_gemma_prompt_text(text)
+        text = _clean_lm_studio_plain_text(text) if is_minimax_h3_prompt else _clean_gemma_prompt_text(text)
+        if is_minimax_h3_prompt:
+            text = _format_minimax_h3_prompt(text, payload, instruction_key)
         if first_last_frame_mode:
             text = re.sub(r"(?i)\b(?:cinematic\s+)?(?:aspect\s+ratio\s*[:=]?\s*)?(?:16\s*:\s*9|9\s*:\s*16|21\s*:\s*9|4\s*:\s*3|3\s*:\s*4|1\s*:\s*1)(?:\s+(?:aspect\s+ratio|widescreen|portrait|landscape))?\b[,]?\s*", "", text)
             text = re.sub(r"(?i)\b(?:widescreen|portrait|landscape)\s+aspect\s+ratio\b[,]?\s*", "", text)
             text = re.sub(r"(?i)\b(?:fades?|dissolves?|crossfades?|blends?)\s+(?:smoothly\s+|seamlessly\s+|gradually\s+)?into\b", "progressively transforms into", text)
             text = re.sub(r"(?i),?\s*(?:while\s+)?maintaining (?:her|his|their|the subject(?:'s)?) visibility throughout(?: the transformation)?", "", text)
             text = re.sub(r"\s{2,}", " ", text).strip(" ,")
-        text = _repair_and_validate_builder_gemma_prompt(payload, text, prompt_label)
+        if is_minimax_h3_prompt:
+            if not text:
+                raise ValueError(f"{prompt_label} LLM returned an empty prompt.")
+        else:
+            text = _repair_and_validate_builder_gemma_prompt(payload, text, prompt_label)
         if first_last_frame_mode:
             text = re.sub(r"(?i)(?:\s*[,.;:-]?\s*)\bzhuanchang\b", "", text).strip(" ,.;:-")
             if transition_lora_active:

--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -514,7 +514,19 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
     video_prompt_type = _clean_scene_text(scene.get("video_prompt_type") or scene.get("video_type") or scene.get("mode") or "", 40)
     if video_prompt_type not in {"i2v", "id_lora", "t2v", "rtv", "ingredients"}:
         video_prompt_type = "i2v"
-    if video_prompt:
+    project_video_engine = "minimax_h3" if str(scene.get("project_video_engine") or scene.get("projectVideoEngine") or "").strip().lower() == "minimax_h3" else "ltx"
+    minimax_h3_mode = str(scene.get("minimax_h3_mode") or scene.get("minimaxH3Mode") or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if minimax_h3_mode not in {"text_to_video", "image_to_video", "reference_to_video", "video_to_video"}:
+        minimax_h3_mode = "text_to_video"
+    try:
+        timeline_start = float(scene.get("timeline_start", scene.get("start", 0)) or 0)
+        timeline_end = float(scene.get("timeline_end", scene.get("end", 0)) or 0)
+        exact_duration = max(0.0, float(scene.get("exact_duration", scene.get("duration", 0)) or 0))
+    except (TypeError, ValueError):
+        timeline_start = 0.0
+        timeline_end = 0.0
+        exact_duration = 0.0
+    if video_prompt and project_video_engine != "minimax_h3":
         video_prompt = _enforce_storyboard_video_facial_requirements(video_prompt, {
             **scene,
             "subjects": subjects,
@@ -549,6 +561,12 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
         "trigger_phrase": _clean_scene_text(scene.get("trigger_phrase") or scene.get("trigger") or scene.get("Trigger") or "", 1200),
         "trigger_position": "end" if trigger_position == "end" else "start",
         "video_prompt_type": video_prompt_type,
+        "project_video_engine": project_video_engine,
+        "minimax_h3_mode": minimax_h3_mode,
+        "timeline_start": timeline_start,
+        "timeline_end": timeline_end,
+        "exact_duration": exact_duration,
+        "video_prompt_origin": "gemma" if str(scene.get("video_prompt_origin") or scene.get("i2v_prompt_origin") or "").strip().lower() == "gemma" else "manual",
         "status": status,
         "image_prompt": image_prompt,
         "video_prompt": video_prompt,
@@ -571,6 +589,7 @@ def _default_storyboard(payload):
         "created_at": datetime.now().isoformat(timespec="seconds"),
         "updated_at": datetime.now().isoformat(timespec="seconds"),
         "project_folder": os.path.abspath(str(payload.get("project_folder", "") or "")),
+        "project_video_engine": "minimax_h3" if str(payload.get("project_video_engine") or payload.get("projectVideoEngine") or "").strip().lower() == "minimax_h3" else "ltx",
         "mode": "image_to_video_prep" if any(scene.get("image_path") or scene.get("image_data") for scene in normalized) else "storyboard_prompts",
         "performance_mode": _normalize_performance_mode(payload.get("performance_mode") or payload.get("performanceMode") or payload.get("video_type") or payload.get("videoType")),
         "camera_flow": _clean_scene_text(payload.get("camera_flow") or "balanced", 80),
@@ -620,6 +639,7 @@ def _save_storyboard(payload):
         "created_at": storyboard.get("created_at") or datetime.now().isoformat(timespec="seconds"),
         "updated_at": datetime.now().isoformat(timespec="seconds"),
         "project_folder": project_folder,
+        "project_video_engine": "minimax_h3" if str(storyboard.get("project_video_engine") or storyboard.get("projectVideoEngine") or "").strip().lower() == "minimax_h3" else "ltx",
         "mode": storyboard.get("mode") or "storyboard_prompts",
         "performance_mode": _normalize_performance_mode(storyboard.get("performance_mode") or storyboard.get("performanceMode") or storyboard.get("video_type") or storyboard.get("videoType")),
         "camera_flow": _clean_scene_text(storyboard.get("camera_flow") or "balanced", 80),
@@ -684,12 +704,14 @@ def _export_storyboard_prompts(payload):
         "version": 1,
         "exported_at": datetime.now().isoformat(timespec="seconds"),
         "type": "storyboard_video_prompts",
+        "project_video_engine": saved.get("project_video_engine") or "ltx",
         "performance_mode": saved.get("performance_mode") or "singing",
         "scene_count": len(scenes),
         "scenes": [
             {
                 **_prompt_json_entry(scene, index, "video_prompt"),
                 "video_prompt_type": _clean_scene_text(scene.get("video_prompt_type") or "", 80),
+                "minimax_h3_mode": _clean_scene_text(scene.get("minimax_h3_mode") or "", 80),
                 "performance_mode": _normalize_performance_mode(scene.get("performance_mode") or saved.get("performance_mode")),
             }
             for index, scene in enumerate(scenes, start=1)

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -1,5 +1,6 @@
 import copy
 import base64
+import hashlib
 import importlib
 import json
 import os
@@ -10,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import wave
 
 import folder_paths
 from aiohttp import web
@@ -21,6 +23,7 @@ from .VRGDG_ModelPathSettings import (
     register_custom_model_root,
     save_custom_model_root,
 )
+from .VRGDG_MiniMaxH3Timing import calculate_minimax_h3_timing
 
 
 _VRGDG_WORKFLOW_RUNNER_ROUTES_REGISTERED = False
@@ -33,6 +36,18 @@ _MIN_LTX_INGREDIENTS_FRAMES = 121
 _DEFAULT_I2V_PASS1_SIGMAS = "1., 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0"
 _DEFAULT_I2V_PASS2_SIGMAS = "0.909375, 0.725, 0.421875, 0.0"
 _DEFAULT_INGREDIENTS_SAMPLER = "euler_ancestral_cfg_pp"
+_MINIMAX_H3_ASPECT_RATIOS = {
+    "1:1 (Square)",
+    "2:3 (Portrait Photo)",
+    "3:2 (Photo)",
+    "3:4 (Portrait Standard)",
+    "4:3 (Standard)",
+    "9:16 (Portrait Widescreen)",
+    "16:9 (Widescreen)",
+    "21:9 (Ultrawide)",
+}
+_MINIMAX_H3_MAX_REFERENCE_IMAGES = 9
+_MINIMAX_H3_MAX_REFERENCE_VIDEOS = 3
 _I2V_UNET_ALIASES = {
     "LTX-2.3-22B-distilled-11-Q6_K.gguf": "LTX-2.3-22B-distilled-1.1-Q6_K.gguf",
 }
@@ -181,6 +196,15 @@ def _flf_api_template_path():
     return os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "Workflows", "UsedForUIDoNotTouch", "LTX2.3_FLF_API.json",
+    )
+
+
+def _minimax_h3_api_template_path():
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "Workflows",
+        "UsedForUIDoNotTouch",
+        "minimax_audio_driven_builder_api.json",
     )
 
 
@@ -480,6 +504,192 @@ def _bool_payload(payload, key, default=False):
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _first_payload_value(payload, *keys, default=None):
+    for key in keys:
+        if key in payload and payload.get(key) is not None:
+            return payload.get(key)
+    return default
+
+
+def _minimax_h3_collection(value, collection_keys=()):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        for key in collection_keys:
+            if isinstance(value.get(key), list):
+                return value[key]
+        return list(value.values())
+    text = str(value or "").strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = None
+    if parsed is not None and parsed is not value:
+        return _minimax_h3_collection(parsed, collection_keys)
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _minimax_h3_media_path(value):
+    if isinstance(value, dict):
+        value = value.get("path") or value.get("file") or value.get("image") or value.get("video")
+    return str(value or "").strip().strip('"').strip("'")
+
+
+def _minimax_h3_image_paths(payload):
+    raw = _first_payload_value(payload, "image_paths", "reference_images", "images", default=[])
+    paths = [
+        path
+        for path in (
+            _minimax_h3_media_path(item)
+            for item in _minimax_h3_collection(raw, ("image_paths", "images"))
+        )
+        if path
+    ]
+    if len(paths) > _MINIMAX_H3_MAX_REFERENCE_IMAGES:
+        raise ValueError(
+            f"MiniMax H3 supports at most {_MINIMAX_H3_MAX_REFERENCE_IMAGES} reference images; "
+            f"received {len(paths)}."
+        )
+    return paths
+
+
+def _minimax_h3_video_references(payload):
+    raw = _first_payload_value(payload, "video_references", "reference_videos", "videos", default=[])
+    references = []
+    for item in _minimax_h3_collection(raw, ("video_references", "videos")):
+        if isinstance(item, dict):
+            path = _minimax_h3_media_path(item)
+            try:
+                start_seconds = max(0.0, float(_first_payload_value(
+                    item, "start_seconds", "start", "seek_seconds", default=0
+                ) or 0))
+                duration = max(0.0, float(_first_payload_value(
+                    item, "duration", "duration_seconds", default=0
+                ) or 0))
+            except (TypeError, ValueError) as exc:
+                raise ValueError("MiniMax H3 video reference timing must be numeric.") from exc
+            use_audio_value = _first_payload_value(
+                item, "use_audio", "include_audio", "reference_audio", default=False
+            )
+            use_audio = (
+                str(use_audio_value).strip().lower() in {"1", "true", "yes", "on"}
+                if isinstance(use_audio_value, str)
+                else bool(use_audio_value)
+            )
+        else:
+            path = _minimax_h3_media_path(item)
+            start_seconds = 0.0
+            duration = 0.0
+            use_audio = False
+        if path:
+            references.append({
+                "path": path,
+                "start_seconds": start_seconds,
+                "duration": duration,
+                "use_audio": use_audio,
+            })
+    if len(references) > _MINIMAX_H3_MAX_REFERENCE_VIDEOS:
+        raise ValueError(
+            f"MiniMax H3 supports at most {_MINIMAX_H3_MAX_REFERENCE_VIDEOS} reference videos; "
+            f"received {len(references)}."
+        )
+    return references
+
+
+def _probe_media_duration_seconds(path):
+    ffprobe_path = _ffprobe_path_for(_find_ffmpeg_path())
+    cmd = [
+        ffprobe_path,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or result.stdout or "FFprobe could not read the audio duration.").strip())
+    try:
+        duration = float((result.stdout or "").strip().splitlines()[0])
+    except (IndexError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"FFprobe did not return a valid duration for: {path}") from exc
+    if duration <= 0:
+        raise ValueError(f"Source audio has no usable duration: {path}")
+    return duration
+
+
+def _trim_minimax_h3_audio_context(source_path, project_folder, scene_number, timing):
+    target_dir = os.path.join(project_folder, "minimax_h3_scene_audio")
+    os.makedirs(target_dir, exist_ok=True)
+    target_path = os.path.join(target_dir, f"scene_audio_{scene_number:04d}.wav")
+    ffmpeg_path = _find_ffmpeg_path()
+    cmd = [
+        ffmpeg_path,
+        "-y",
+        "-ss",
+        f"{timing.audio_trim_start_seconds:.9f}",
+        "-i",
+        source_path,
+        "-t",
+        f"{timing.audio_trim_duration_seconds:.9f}",
+        "-vn",
+        "-ac",
+        "2",
+        "-ar",
+        "44100",
+        "-c:a",
+        "pcm_s16le",
+        target_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if result.returncode != 0 or not os.path.isfile(target_path):
+        raise RuntimeError((result.stderr or result.stdout or "FFmpeg failed to trim MiniMax H3 scene audio.").strip())
+    try:
+        with wave.open(target_path, "rb") as handle:
+            actual_duration = handle.getnframes() / float(handle.getframerate())
+    except Exception as exc:
+        raise RuntimeError(f"Could not verify the trimmed MiniMax H3 audio: {target_path}") from exc
+    if actual_duration + 0.02 < timing.audio_trim_duration_seconds:
+        raise ValueError(
+            "The trimmed MiniMax H3 audio ended before the required scene context. "
+            f"Needed {timing.audio_trim_duration_seconds:.3f}s; received {actual_duration:.3f}s."
+        )
+    return {
+        "audio_path": target_path,
+        "start": timing.audio_trim_start_seconds,
+        "duration": actual_duration,
+        "requested_duration": timing.audio_trim_duration_seconds,
+        "format": "pcm_s16le_wav",
+    }
+
+
+def _minimax_h3_output_location(project_folder, scene_number):
+    project_name = re.sub(
+        r"[^A-Za-z0-9_-]+",
+        "_",
+        os.path.basename(os.path.normpath(project_folder)),
+    ).strip("_") or "project"
+    project_key = hashlib.sha1(os.path.normcase(project_folder).encode("utf-8")).hexdigest()[:8]
+    relative_dir = os.path.join(
+        "VRGDG_MiniMaxH3",
+        f"{project_name}_{project_key}",
+        f"scene_{scene_number:04d}",
+    )
+    output_folder = os.path.join(folder_paths.get_output_directory(), relative_dir)
+    os.makedirs(output_folder, exist_ok=True)
+    filename_prefix = os.path.join(
+        relative_dir,
+        f"MiniMaxH3_scene_{scene_number:04d}",
+    ).replace("\\", "/")
+    return output_folder, filename_prefix
 
 
 def _clean_lora_name(value):
@@ -2193,6 +2403,226 @@ def _build_ernie_image_api_prompt(payload):
     }
 
 
+_MINIMAX_H3_SAGE_ATTENTION_MODES = {
+    "disabled",
+    "auto",
+    "sageattn_qk_int8_pv_fp16_cuda",
+    "sageattn_qk_int8_pv_fp16_triton",
+    "sageattn_qk_int8_pv_fp8_cuda",
+    "sageattn_qk_int8_pv_fp8_cuda++",
+    "sageattn3",
+    "sageattn3_per_block_mean",
+}
+
+
+def _patch_minimax_h3_advanced_settings(prompt, payload):
+    sampler_id = _api_node_id_by_class(prompt, "KSamplerSelect", fallback="123")
+    scheduler_id = _api_node_id_by_class(prompt, "BasicScheduler", fallback="124")
+    loader_id = _api_node_id_by_class(prompt, "DiffusionModelLoaderKJ", fallback="141")
+    easy_cache_id = _optional_api_node_id_by_class(prompt, "EasyCache", fallback_ids=("174",))
+
+    sampler_name = str(payload.get("sampler_name") or "res_multistep").strip() or "res_multistep"
+    scheduler = str(payload.get("scheduler") or "simple").strip() or "simple"
+    steps = _int_payload(payload, "steps", 20, 1, 1000)
+    denoise = _float_payload(payload, "denoise", 1.0, 0.0, 1.0)
+    easy_cache_bypass = _bool_payload(payload, "easy_cache_bypass", False)
+    easy_cache_reuse_threshold = _float_payload(payload, "easy_cache_reuse_threshold", 0.3, 0.0, 1.0)
+    easy_cache_start_percent = _float_payload(payload, "easy_cache_start_percent", 0.2, 0.0, 1.0)
+    easy_cache_end_percent = _float_payload(payload, "easy_cache_end_percent", 0.9, 0.0, 1.0)
+    easy_cache_verbose = _bool_payload(payload, "easy_cache_verbose", False)
+    sage_attention = str(payload.get("sage_attention") or "auto").strip()
+    if sage_attention not in _MINIMAX_H3_SAGE_ATTENTION_MODES:
+        sage_attention = "auto"
+    enable_fp16_accumulation = _bool_payload(payload, "enable_fp16_accumulation", True)
+
+    _set_api_input(prompt, sampler_id, "sampler_name", sampler_name)
+    _set_api_input(prompt, scheduler_id, "scheduler", scheduler)
+    _set_api_input(prompt, scheduler_id, "steps", steps)
+    _set_api_input(prompt, scheduler_id, "denoise", denoise)
+    _set_api_input(prompt, loader_id, "sage_attention", sage_attention)
+    _set_api_input(prompt, loader_id, "enable_fp16_accumulation", enable_fp16_accumulation)
+
+    if easy_cache_id:
+        _set_api_input(prompt, easy_cache_id, "reuse_threshold", easy_cache_reuse_threshold)
+        _set_api_input(prompt, easy_cache_id, "start_percent", easy_cache_start_percent)
+        _set_api_input(prompt, easy_cache_id, "end_percent", easy_cache_end_percent)
+        _set_api_input(prompt, easy_cache_id, "verbose", easy_cache_verbose)
+        if easy_cache_bypass:
+            _replace_api_input_refs(prompt, (easy_cache_id, 0), (loader_id, 0))
+            prompt.pop(easy_cache_id, None)
+
+    return {
+        "sampler_name": sampler_name,
+        "scheduler": scheduler,
+        "steps": steps,
+        "denoise": denoise,
+        "easy_cache_bypass": easy_cache_bypass,
+        "easy_cache_reuse_threshold": easy_cache_reuse_threshold,
+        "easy_cache_start_percent": easy_cache_start_percent,
+        "easy_cache_end_percent": easy_cache_end_percent,
+        "easy_cache_verbose": easy_cache_verbose,
+        "sage_attention": sage_attention,
+        "enable_fp16_accumulation": enable_fp16_accumulation,
+    }
+
+
+def _build_minimax_h3_api_prompt(payload):
+    workflow_path, prompt = _load_api_template(_minimax_h3_api_template_path())
+    prompt = copy.deepcopy(prompt)
+
+    video_prompt = str(_first_payload_value(
+        payload, "prompt", "video_prompt", "i2v_prompt", "t2v_prompt", default=""
+    ) or "").strip()
+    if not video_prompt:
+        raise ValueError("MiniMax H3 video prompt is empty.")
+
+    audio_text = str(_first_payload_value(
+        payload, "audio_path", "source_audio_path", default=""
+    ) or "").strip().strip('"')
+    if not audio_text:
+        raise ValueError("MiniMax H3 source audio path is empty.")
+    audio_path = os.path.abspath(audio_text)
+    if not os.path.isfile(audio_path):
+        raise FileNotFoundError(f"MiniMax H3 source audio was not found: {audio_path}")
+
+    project_text = str(payload.get("project_folder", "") or "").strip().strip('"')
+    if not project_text:
+        raise ValueError("Project folder is empty.")
+    project_folder = os.path.abspath(project_text)
+    if not os.path.isdir(project_folder):
+        raise FileNotFoundError(f"Project folder was not found: {project_folder}")
+    scene_number = _int_payload(payload, "scene_number", 1, 1, 999999)
+
+    timeline_start = _first_payload_value(
+        payload, "timeline_start_seconds", "scene_start_seconds", "start", default=0
+    )
+    timeline_end = _first_payload_value(
+        payload, "timeline_end_seconds", "scene_end_seconds", "end", default=None
+    )
+    if timeline_end is None:
+        scene_duration = _first_payload_value(
+            payload, "scene_duration_seconds", "scene_duration", "duration", default=None
+        )
+        if scene_duration is None:
+            raise ValueError("MiniMax H3 needs timeline_end_seconds or scene_duration_seconds.")
+        try:
+            timeline_end = float(timeline_start) + float(scene_duration)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("MiniMax H3 timeline timing must be numeric.") from exc
+
+    source_duration = _first_payload_value(
+        payload, "source_duration_seconds", "audio_duration_seconds", default=None
+    )
+    if source_duration is None:
+        source_duration = _probe_media_duration_seconds(audio_path)
+    source_start = _first_payload_value(
+        payload, "source_start_seconds", "audio_start_seconds", default=None
+    )
+    warmup_frames = _first_payload_value(
+        payload, "warmup_frames", "pre_frames", default=0
+    )
+    cooldown_frames = _first_payload_value(
+        payload, "cooldown_frames", "tail_loss_frames", default=0
+    )
+    timing = calculate_minimax_h3_timing(
+        timeline_start,
+        timeline_end,
+        warmup_frames,
+        cooldown_frames,
+        source_start_seconds=source_start,
+        source_duration_seconds=source_duration,
+    )
+    prepared_audio = _trim_minimax_h3_audio_context(
+        audio_path,
+        project_folder,
+        scene_number,
+        timing,
+    )
+
+    image_paths = _minimax_h3_image_paths(payload)
+    video_references = _minimax_h3_video_references(payload)
+    aspect_ratio = str(payload.get("aspect_ratio") or "16:9 (Widescreen)").strip()
+    if aspect_ratio not in _MINIMAX_H3_ASPECT_RATIOS:
+        raise ValueError(f"Unsupported MiniMax H3 aspect ratio: {aspect_ratio}")
+    megapixels = _float_payload(payload, "megapixels", 0.9, 0.1, 16.0)
+    diffusion_model_name = str(
+        payload.get("diffusion_model_name") or "minimax_h3_ref2va_pruned_int8_convrot.safetensors"
+    ).strip()
+    clip_name = str(
+        payload.get("clip_name") or "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors"
+    ).strip()
+    video_vae_name = str(
+        payload.get("video_vae_name") or "minimax_h3_video_vae_fp16.safetensors"
+    ).strip()
+    audio_vae_name = str(
+        payload.get("audio_vae_name") or "minimax_h3_audio_vae_fp32.safetensors"
+    ).strip()
+    if diffusion_model_name.lower().endswith(".gguf"):
+        raise ValueError("MiniMax H3 GGUF loading is not enabled yet. Choose a non-GGUF diffusion model.")
+    _require_model_choice(("diffusion_models", "unet"), diffusion_model_name, "MiniMax H3 diffusion model")
+    _require_model_choice(("text_encoders", "clip"), clip_name, "MiniMax H3 text encoder")
+    _require_model_choice("vae", video_vae_name, "MiniMax H3 video VAE")
+    _require_model_choice("vae", audio_vae_name, "MiniMax H3 audio VAE")
+
+    seed_value = payload.get("seed", 69)
+    try:
+        seed = int(seed_value)
+    except (TypeError, ValueError):
+        seed = 69
+    if seed < 0:
+        seed = random.randrange(0, 0xFFFFFFFFFFFFFFFF + 1)
+    seed = min(seed, 0xFFFFFFFFFFFFFFFF)
+
+    output_folder, filename_prefix = _minimax_h3_output_location(project_folder, scene_number)
+    _set_api_input(prompt, "132", "value", timing.workflow_duration_input_seconds)
+    _set_api_input(prompt, "138", "value", video_prompt)
+    _set_api_input(prompt, "129", "noise_seed", seed)
+    _set_api_input(prompt, "115", "aspect_ratio", aspect_ratio)
+    _set_api_input(prompt, "115", "megapixels", megapixels)
+    _set_api_input(prompt, "115", "multiple", 32)
+    _set_api_input(prompt, "141", "model_name", diffusion_model_name)
+    _set_api_input(prompt, "128", "clip_name", clip_name)
+    _set_api_input(prompt, "119", "vae_name", video_vae_name)
+    _set_api_input(prompt, "120", "vae_name", audio_vae_name)
+    _set_api_input(prompt, "171", "audio_file", prepared_audio["audio_path"])
+    _set_api_input(prompt, "171", "seek_seconds", 0)
+    _set_api_input(prompt, "171", "duration", 0)
+    _set_api_input(prompt, "180", "image_paths", json.dumps(image_paths, ensure_ascii=False))
+    _set_api_input(prompt, "180", "video_references", json.dumps(video_references, ensure_ascii=False))
+    _set_api_input(prompt, "142", "frame_rate", 24)
+    _set_api_input(prompt, "142", "filename_prefix", filename_prefix)
+    # Keep every aligned H3 frame. VHS trim_to_audio muxes with -shortest while
+    # stream-copying H.264, which can discard final video packets before our
+    # exact scene trimmer receives them.
+    _set_api_input(prompt, "142", "trim_to_audio", False)
+    advanced_settings = _patch_minimax_h3_advanced_settings(prompt, payload)
+
+    return {
+        "workflow_path": workflow_path,
+        "output_folder": output_folder,
+        "prompt": prompt,
+        "used_seed": seed,
+        "timing": timing.to_dict(),
+        "prepared_audio": prepared_audio,
+        "post_render_trim": {
+            "start": timing.final_trim_start_seconds,
+            "duration": timing.final_trim_duration_seconds,
+        },
+        "reference_inputs": {
+            "image_count": len(image_paths),
+            "video_count": len(video_references),
+            "video_audio_count": sum(1 for item in video_references if item.get("use_audio")),
+        },
+        "model_settings": {
+            "diffusion_model_name": diffusion_model_name,
+            "clip_name": clip_name,
+            "video_vae_name": video_vae_name,
+            "audio_vae_name": audio_vae_name,
+        },
+        "advanced_settings": advanced_settings,
+    }
+
+
 def _build_i2v_api_prompt(payload):
     api_template = _i2v_api_template_path()
     if os.path.isfile(api_template) and not payload.get("workflow_path"):
@@ -2882,10 +3312,11 @@ def _trim_scene_video(payload):
     duration = max(0.05, float(payload.get("duration", 0) or 0))
     label = re.sub(r"[^A-Za-z0-9_-]+", "_", str(payload.get("label", "trim") or "trim").strip().lower()).strip("_") or "trim"
     stamp = time.strftime("%Y%m%d_%H%M%S")
-    target_path = os.path.join(target_dir, f"video_{scene_number:04d}-{label}_{stamp}.mp4")
+    audio_suffix = "-audio" if _bool_payload(payload, "mark_as_audio_video", False) else ""
+    target_path = os.path.join(target_dir, f"video_{scene_number:04d}-{label}_{stamp}{audio_suffix}.mp4")
     index = 2
     while os.path.exists(target_path):
-        target_path = os.path.join(target_dir, f"video_{scene_number:04d}-{label}_{stamp}_{index:02d}.mp4")
+        target_path = os.path.join(target_dir, f"video_{scene_number:04d}-{label}_{stamp}_{index:02d}{audio_suffix}.mp4")
         index += 1
 
     ffmpeg_path = _find_ffmpeg_path()
@@ -3636,6 +4067,18 @@ def _ensure_workflow_runner_routes():
             return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
         try:
             result = _build_t2v_api_prompt(payload)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        return web.json_response({"ok": True, **result})
+
+    @server_instance.routes.post("/vrgdg/workflow_runner/build_minimax_h3_prompt")
+    async def vrgdg_workflow_runner_build_minimax_h3_prompt(request):
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
+        try:
+            result = _build_minimax_h3_api_prompt(payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/Workflows/UsedForUIDoNotTouch/minimax_audio_driven_builder_api.json
+++ b/Workflows/UsedForUIDoNotTouch/minimax_audio_driven_builder_api.json
@@ -1,0 +1,364 @@
+{
+  "115": {
+    "inputs": {
+      "aspect_ratio": "16:9 (Widescreen)",
+      "megapixels": 0.9,
+      "multiple": 32
+    },
+    "class_type": "ResolutionSelector",
+    "_meta": {
+      "title": "Resolution Selector (Size)"
+    }
+  },
+  "119": {
+    "inputs": {
+      "vae_name": "minimax_h3_video_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Video VAE"
+    }
+  },
+  "120": {
+    "inputs": {
+      "vae_name": "minimax_h3_audio_vae_fp32.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Audio VAE"
+    }
+  },
+  "122": {
+    "inputs": {
+      "samples": [
+        "125",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "123": {
+    "inputs": {
+      "sampler_name": "res_multistep"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "124": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": 20,
+      "denoise": 1,
+      "model": [
+        "174",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "BasicScheduler"
+    }
+  },
+  "125": {
+    "inputs": {
+      "noise": [
+        "129",
+        0
+      ],
+      "guider": [
+        "126",
+        0
+      ],
+      "sampler": [
+        "123",
+        0
+      ],
+      "sigmas": [
+        "124",
+        0
+      ],
+      "latent_image": [
+        "172",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "126": {
+    "inputs": {
+      "model": [
+        "174",
+        0
+      ],
+      "conditioning": [
+        "136",
+        0
+      ]
+    },
+    "class_type": "BasicGuider",
+    "_meta": {
+      "title": "Basic Guider"
+    }
+  },
+  "128": {
+    "inputs": {
+      "clip_name": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "129": {
+    "inputs": {
+      "noise_seed": 177702610855563
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "BUILDER INPUT - Seed"
+    }
+  },
+  "131": {
+    "inputs": {
+      "expression": "max(5, round(a * 24)) + (5 - (max(5, round(a * 24)) % 17)) % 17",
+      "values.a": [
+        "132",
+        0
+      ]
+    },
+    "class_type": "ComfyMathExpression",
+    "_meta": {
+      "title": "H3 Duration To Valid Frame Count"
+    }
+  },
+  "132": {
+    "inputs": {
+      "value": 5
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "BUILDER INPUT - Duration"
+    }
+  },
+  "136": {
+    "inputs": {
+      "prompt": [
+        "138",
+        0
+      ],
+      "width": [
+        "115",
+        0
+      ],
+      "height": [
+        "115",
+        1
+      ],
+      "length": [
+        "131",
+        1
+      ],
+      "ref_image_size": "match",
+      "clip": [
+        "128",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ],
+      "ref_audios.ref_audio_0": [
+        "171",
+        0
+      ],
+      "ref_images.ref_image_0": [
+        "180",
+        0
+      ],
+      "ref_images.ref_image_1": [
+        "180",
+        1
+      ],
+      "ref_images.ref_image_2": [
+        "180",
+        2
+      ],
+      "ref_images.ref_image_3": [
+        "180",
+        3
+      ],
+      "ref_images.ref_image_4": [
+        "180",
+        4
+      ],
+      "ref_images.ref_image_5": [
+        "180",
+        5
+      ],
+      "ref_images.ref_image_6": [
+        "180",
+        6
+      ],
+      "ref_images.ref_image_7": [
+        "180",
+        7
+      ],
+      "ref_images.ref_image_8": [
+        "180",
+        8
+      ],
+      "ref_videos.ref_video_0": [
+        "180",
+        9
+      ],
+      "ref_videos.ref_video_1": [
+        "180",
+        10
+      ],
+      "ref_videos.ref_video_2": [
+        "180",
+        11
+      ],
+      "ref_video_audios.ref_video_audio_0": [
+        "180",
+        12
+      ],
+      "ref_video_audios.ref_video_audio_1": [
+        "180",
+        13
+      ],
+      "ref_video_audios.ref_video_audio_2": [
+        "180",
+        14
+      ]
+    },
+    "class_type": "MiniMaxH3ReferenceToVideo",
+    "_meta": {
+      "title": "MiniMax H3 Reference to Video"
+    }
+  },
+  "138": {
+    "inputs": {
+      "value": "Use the ordered MiniMax H3 reference inputs and follow <Audio 1> exactly."
+    },
+    "class_type": "PrimitiveStringMultiline",
+    "_meta": {
+      "title": "BUILDER INPUT - Prompt"
+    }
+  },
+  "141": {
+    "inputs": {
+      "model_name": "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
+      "weight_dtype": "default",
+      "compute_dtype": "default",
+      "patch_cublaslinear": false,
+      "sage_attention": "auto",
+      "enable_fp16_accumulation": true
+    },
+    "class_type": "DiffusionModelLoaderKJ",
+    "_meta": {
+      "title": "Diffusion Model Loader KJ"
+    }
+  },
+  "142": {
+    "inputs": {
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "MiniMaxH3_Builder",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true,
+      "images": [
+        "122",
+        0
+      ],
+      "audio": [
+        "172",
+        1
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "BUILDER OUTPUT - Video Combine"
+    }
+  },
+  "171": {
+    "inputs": {
+      "audio_file": "Z:\\TOSHARE\\ComfyUI_windows_portable\\ComfyUI\\input\\Circle of Flames 88888.mp3",
+      "seek_seconds": 0,
+      "duration": 0
+    },
+    "class_type": "VHS_LoadAudio",
+    "_meta": {
+      "title": "BUILDER INPUT - Custom Source Audio Path"
+    }
+  },
+  "172": {
+    "inputs": {
+      "av_latent": [
+        "136",
+        1
+      ],
+      "source_audio": [
+        "171",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ]
+    },
+    "class_type": "VRGDG_MiniMaxH3AudioDrive",
+    "_meta": {
+      "title": "LOCK SOURCE AUDIO - GENERATE VIDEO ONLY"
+    }
+  },
+  "174": {
+    "inputs": {
+      "reuse_threshold": 0.3,
+      "start_percent": 0.2,
+      "end_percent": 0.9,
+      "verbose": false,
+      "model": [
+        "141",
+        0
+      ]
+    },
+    "class_type": "EasyCache",
+    "_meta": {
+      "title": "EasyCache"
+    }
+  },
+  "180": {
+    "inputs": {
+      "image_paths": "[]",
+      "video_references": "[]"
+    },
+    "class_type": "VRGDG_MiniMaxH3ReferenceMediaFromPaths",
+    "_meta": {
+      "title": "BUILDER INPUTS - Ordered H3 Reference Images And Videos"
+    }
+  }
+}

--- a/__init__.py
+++ b/__init__.py
@@ -40,6 +40,7 @@ _VRGDG_SUBMODULES = (
     ".VRGDG_LTXFirstLastGuide",
     ".VRGDG_LTXLoopingSampler",
     ".VRGDG_MiniMaxH3AudioDrive",
+    ".VRGDG_MiniMaxH3ReferenceMedia",
     ".CustomLTXNodes",
     ".VRGDG_FlowBrowserNodes",
     ".VRGDG_BrowserImageRoutes",

--- a/update_notes.json
+++ b/update_notes.json
@@ -20,13 +20,15 @@
             "Added ordered Reference Builder images, optional exact scene-image start frames, and reference-video inputs for MiniMax character, location, continuation, motion, camera, transformation, and visual-editing workflows.",
             "Added MiniMax-specific LLM instructions and Storyboard prompting with exact scene timing, ordered Image and Video assignments, Audio 1 usage, lyric text, and lip-sync guidance.",
             "Added exact MiniMax frame planning and custom-audio preparation so rendered scenes cover the selected timeline range and are trimmed back to its exact duration.",
+            "Added MiniMax Render All support for rendering missing clips or creating new versions from Storyboard prompts, using each scene's effective global or locked mode and settings before stitching the completed project.",
             "Added a Builder Settings checkbox for automatic RAM/VRAM cleanup. When disabled, embedded cleanup nodes and automatic post-task cache clearing are bypassed while the manual Clear Memory button remains available."
           ]
         },
         {
           "title": "Fixed",
           "items": [
-            "Storyboard All, Reference Builder, LLM prompting, validation, and rendering now consistently use each scene's effective global or locked MiniMax mode instead of letting untouched scenes silently fall back to Text to Video."
+            "Storyboard All, Reference Builder, LLM prompting, validation, and rendering now consistently use each scene's effective global or locked MiniMax mode instead of letting untouched scenes silently fall back to Text to Video.",
+            "Render All now routes MiniMax projects through the MiniMax hidden workflow instead of the LTX renderer and ignores stale LTX-only mode, post-processing, canvas, and embedded-audio behavior."
           ]
         },
         {

--- a/update_notes.json
+++ b/update_notes.json
@@ -15,11 +15,18 @@
           "title": "New",
           "items": [
             "Added MiniMax H3 as a project video engine while keeping existing and newly loaded LTX projects on the unchanged LTX path by default.",
-            "Added per-scene Text to Video, Image to Video, Reference to Video, and Video to Video modes with dedicated MiniMax model, resolution, timing, sampler, EasyCache, Sage Attention, and FP16 settings.",
+            "Added project-global Text to Video, Image to Video, Reference to Video, and Video to Video modes with dedicated MiniMax model, resolution, timing, sampler, EasyCache, Sage Attention, and FP16 settings.",
+            "Added a per-scene lock in MiniMax Video Settings that copies and preserves the current mode, models, render settings, and advanced settings for that scene while unlocked scenes continue following the project-global values.",
             "Added ordered Reference Builder images, optional exact scene-image start frames, and reference-video inputs for MiniMax character, location, continuation, motion, camera, transformation, and visual-editing workflows.",
             "Added MiniMax-specific LLM instructions and Storyboard prompting with exact scene timing, ordered Image and Video assignments, Audio 1 usage, lyric text, and lip-sync guidance.",
             "Added exact MiniMax frame planning and custom-audio preparation so rendered scenes cover the selected timeline range and are trimmed back to its exact duration.",
             "Added a Builder Settings checkbox for automatic RAM/VRAM cleanup. When disabled, embedded cleanup nodes and automatic post-task cache clearing are bypassed while the manual Clear Memory button remains available."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Storyboard All, Reference Builder, LLM prompting, validation, and rendering now consistently use each scene's effective global or locked MiniMax mode instead of letting untouched scenes silently fall back to Text to Video."
           ]
         },
         {

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,34 @@
   "product": "LTX 2.3 Video Builder",
   "releases": [
     {
+      "id": "2026-08-03-minimax-h3-builder-testing",
+      "version": "2026.08.03-minimax-h3-test",
+      "date": "2026-08-03",
+      "title": "MiniMax H3 Video Builder testing support",
+      "commit": "5b328027c5f8e7e946b8449b236ad2c9362eafd5",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added MiniMax H3 as a project video engine while keeping existing and newly loaded LTX projects on the unchanged LTX path by default.",
+            "Added per-scene Text to Video, Image to Video, Reference to Video, and Video to Video modes with dedicated MiniMax model, resolution, timing, sampler, EasyCache, Sage Attention, and FP16 settings.",
+            "Added ordered Reference Builder images, optional exact scene-image start frames, and reference-video inputs for MiniMax character, location, continuation, motion, camera, transformation, and visual-editing workflows.",
+            "Added MiniMax-specific LLM instructions and Storyboard prompting with exact scene timing, ordered Image and Video assignments, Audio 1 usage, lyric text, and lip-sync guidance.",
+            "Added exact MiniMax frame planning and custom-audio preparation so rendered scenes cover the selected timeline range and are trimmed back to its exact duration."
+          ]
+        },
+        {
+          "title": "Testing Notes",
+          "items": [
+            "This first MiniMax H3 Builder workflow requires project audio or custom scene audio and currently uses non-GGUF diffusion models.",
+            "Built-in MiniMax audio, GGUF loading, and MiniMax post-processing workflows are not part of this initial testing build."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-02-reference-lyrics-story-arc",
       "version": "2026.08.02-builder-fixes",
       "date": "2026-08-02",

--- a/update_notes.json
+++ b/update_notes.json
@@ -18,7 +18,8 @@
             "Added per-scene Text to Video, Image to Video, Reference to Video, and Video to Video modes with dedicated MiniMax model, resolution, timing, sampler, EasyCache, Sage Attention, and FP16 settings.",
             "Added ordered Reference Builder images, optional exact scene-image start frames, and reference-video inputs for MiniMax character, location, continuation, motion, camera, transformation, and visual-editing workflows.",
             "Added MiniMax-specific LLM instructions and Storyboard prompting with exact scene timing, ordered Image and Video assignments, Audio 1 usage, lyric text, and lip-sync guidance.",
-            "Added exact MiniMax frame planning and custom-audio preparation so rendered scenes cover the selected timeline range and are trimmed back to its exact duration."
+            "Added exact MiniMax frame planning and custom-audio preparation so rendered scenes cover the selected timeline range and are trimmed back to its exact duration.",
+            "Added a Builder Settings checkbox for automatic RAM/VRAM cleanup. When disabled, embedded cleanup nodes and automatic post-task cache clearing are bypassed while the manual Clear Memory button remains available."
           ]
         },
         {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -46,6 +46,55 @@ import {
 const NODE_NAME = "VRGDG_MusicVideoBuilderUI";
 const BUILDER_UI_VERSION = "welcome-startup-2026-05-20";
 const HIDDEN_WIDGETS = new Set(["audio_path", "project_folder", "session_path", "srt_path"]);
+let builderAutomaticMemoryCleanupEnabled = false;
+const EMBEDDED_MEMORY_CLEANUP_NODE_TYPES = new Set([
+  "ramcleanup",
+  "vramcleanup",
+  "vrgdg_unloadgemmamodels",
+]);
+
+function setBuilderAutomaticMemoryCleanupEnabled(value) {
+  builderAutomaticMemoryCleanupEnabled = Boolean(value);
+  return builderAutomaticMemoryCleanupEnabled;
+}
+
+function withoutEmbeddedMemoryCleanupNodes(prompt) {
+  if (!prompt || typeof prompt !== "object" || Array.isArray(prompt)) {
+    return { prompt, removed: [] };
+  }
+  const cloned = Object.fromEntries(Object.entries(prompt).map(([nodeId, node]) => [
+    nodeId,
+    node && typeof node === "object"
+      ? { ...node, inputs: node.inputs && typeof node.inputs === "object" ? { ...node.inputs } : node.inputs }
+      : node,
+  ]));
+  const cleanupIds = new Set(Object.entries(cloned)
+    .filter(([, node]) => EMBEDDED_MEMORY_CLEANUP_NODE_TYPES.has(String(node?.class_type || "").trim().toLowerCase()))
+    .map(([nodeId]) => String(nodeId)));
+  if (!cleanupIds.size) return { prompt: cloned, removed: [] };
+
+  const resolvePassthrough = (value, visited = new Set()) => {
+    if (!Array.isArray(value) || value.length < 2) return value;
+    const sourceId = String(value[0]);
+    if (!cleanupIds.has(sourceId)) return value;
+    if (visited.has(sourceId)) return null;
+    visited.add(sourceId);
+    const passthrough = cloned[sourceId]?.inputs?.anything;
+    return Array.isArray(passthrough) ? resolvePassthrough(passthrough, visited) : null;
+  };
+
+  Object.entries(cloned).forEach(([nodeId, node]) => {
+    if (cleanupIds.has(String(nodeId)) || !node?.inputs || typeof node.inputs !== "object") return;
+    Object.entries(node.inputs).forEach(([inputName, value]) => {
+      if (!Array.isArray(value) || value.length < 2 || !cleanupIds.has(String(value[0]))) return;
+      const passthrough = resolvePassthrough(value);
+      if (passthrough) node.inputs[inputName] = passthrough;
+      else delete node.inputs[inputName];
+    });
+  });
+  cleanupIds.forEach((nodeId) => delete cloned[nodeId]);
+  return { prompt: cloned, removed: [...cleanupIds] };
+}
 const DEFAULT_I2V_UNET = "LTX-2.3-22B-distilled-1.1-Q6_K.gguf";
 const DEFAULT_I2V_DIFFUSION_MODEL = "LTX_8bit\\ltx-2.3-22b-dev_transformer_only_int8_convrot.safetensors";
 const BAD_I2V_UNET_ALIASES = new Set(["LTX-2.3-22B-distilled-11-Q6_K.gguf"]);
@@ -1813,11 +1862,20 @@ async function queueWorkflowPrompt(prompt, options = {}) {
     timeoutMs: options.idleTimeoutMs,
     shouldCancel: options.shouldCancel,
   });
+  let queuedPrompt = prompt;
+  if (!options.allowMemoryCleanup && !builderAutomaticMemoryCleanupEnabled) {
+    const sanitized = withoutEmbeddedMemoryCleanupNodes(prompt);
+    queuedPrompt = sanitized.prompt;
+    if (sanitized.removed.length) {
+      options.onStatus?.(`Bypassed ${sanitized.removed.length} embedded RAM/VRAM cleanup node(s) because automatic memory cleanup is disabled.`);
+      console.info(`[VRGDG Music Builder] Bypassed embedded memory cleanup nodes: ${sanitized.removed.join(", ")}`);
+    }
+  }
   const clientId = api.clientId || app?.clientId || crypto.randomUUID();
   const response = await api.fetchApi("/prompt", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt, client_id: clientId }),
+    body: JSON.stringify({ prompt: queuedPrompt, client_id: clientId }),
   });
   const data = await response.json().catch(() => ({}));
   if (!response.ok || data?.error) {
@@ -5559,6 +5617,7 @@ function openBuilder(node) {
     sessionPath: "",
     srtPath: "",
     autoSaveEnabled: true,
+    automaticMemoryCleanup: false,
     isScrubbing: false,
     isClipScrubbing: false,
     sceneAudioMode: false,
@@ -9467,6 +9526,7 @@ function openBuilder(node) {
       llmApiProvider: state.llmApiProvider,
       llmApiModel: state.llmApiModel,
       notificationSettings: normalizeNotificationSettings(state.notificationSettings),
+      automaticMemoryCleanup: Boolean(state.automaticMemoryCleanup),
       waveformMode: state.waveformMode,
       snapToBeats: state.snapToBeats,
       beats: state.beats,
@@ -9548,6 +9608,7 @@ function openBuilder(node) {
     state.llmApiProvider = data.llmApiProvider || data.llm_api_provider || state.llmApiProvider || "openai";
     state.llmApiModel = data.llmApiModel || data.llm_api_model || state.llmApiModel || "";
     state.notificationSettings = normalizeNotificationSettings(data.notificationSettings || data.notification_settings || state.notificationSettings);
+    state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.automaticMemoryCleanup ?? data.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
     state.waveformMode = data.waveformMode || state.waveformMode || "medium";
     state.snapToBeats = data.snapToBeats ?? state.snapToBeats ?? true;
     state.showTimelineSceneNotes = data.showTimelineSceneNotes ?? state.showTimelineSceneNotes ?? false;
@@ -30477,6 +30538,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       makeField("Video engine for this project", projectVideoEngineSelect),
       projectVideoEngineNote,
     ], true);
+    const automaticMemoryCleanupControl = makeCheckbox(
+      "Run automatic RAM/VRAM cleanup",
+      Boolean(state.automaticMemoryCleanup),
+    );
+    const automaticMemoryCleanupNote = document.createElement("div");
+    automaticMemoryCleanupNote.textContent = "Off is recommended when ComfyUI DynamicVRAM is enabled. When off, the Builder bypasses embedded RAMCleanup/VRAMCleanup nodes in hidden workflows and will not directly clear Comfy/Gemma caches between tasks, retries, errors, or stops. The manual Clear Memory button still works.";
+    automaticMemoryCleanupNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+    const memoryManagementPanel = makeSettingsSection("Memory Management", [
+      automaticMemoryCleanupControl.wrapper,
+      automaticMemoryCleanupNote,
+    ], false);
     const notificationSettings = normalizeNotificationSettings(state.notificationSettings);
     const notificationMode = makeSelect(["off", "errors", "batch", "complete", "all"], notificationSettings.mode);
     const successSound = makeSelect(["chime", "bell", "double_beep", "soft"], notificationSettings.success_sound);
@@ -30698,6 +30770,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     notificationVolume.addEventListener("input", saveNotificationSettings);
     successCustomFile.addEventListener("change", () => readCustomSound(successCustomFile.files?.[0], "success"));
     errorCustomFile.addEventListener("change", () => readCustomSound(errorCustomFile.files?.[0], "error"));
+    automaticMemoryCleanupControl.input.addEventListener("change", async () => {
+      state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(automaticMemoryCleanupControl.input.checked);
+      await autoSaveSessionQuiet("automatic memory cleanup setting");
+      toast(state.automaticMemoryCleanup
+        ? "Automatic RAM/VRAM cleanup enabled."
+        : "Automatic RAM/VRAM cleanup disabled. DynamicVRAM will manage memory pressure.");
+    });
     projectVideoEngineSelect.addEventListener("change", async () => {
       state.projectVideoEngine = normalizeProjectVideoEngine(projectVideoEngineSelect.value);
       syncProjectVideoEngineUI();
@@ -30722,7 +30801,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     testErrorSound.onclick = () => playBuilderNotification("error", true);
     syncCustomAudioLabels();
     syncContinuityModeVisibility();
-    box.append(header, pathGrid, actions, note, projectVideoEnginePanel, themePanel, autoChainPanel, notificationPanel);
+    box.append(header, pathGrid, actions, note, projectVideoEnginePanel, themePanel, memoryManagementPanel, autoChainPanel, notificationPanel);
     backdrop.append(box);
     document.body.append(backdrop);
     modalClose.onclick = () => backdrop.remove();
@@ -30985,6 +31064,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function runClearMemoryWorkflowQuiet(progress, label, percent = 95) {
+    if (!state.automaticMemoryCleanup) {
+      const output = `Automatic RAM/VRAM cleanup skipped after ${label} (disabled in Builder Settings).`;
+      progress?.set(output, percent);
+      return output;
+    }
     const output = await runFullMemoryCleanup(progress, label, percent);
     progress?.set(output, percent);
     return output;
@@ -30994,6 +31078,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     progress?.set(`Running RAM/VRAM cleanup workflow after ${label}...`, percent);
     const built = await postJson("/vrgdg/workflow_runner/build_clear_memory_prompt", {}, 120000);
     const queued = await queueWorkflowPrompt(built.prompt, {
+      allowMemoryCleanup: true,
       onStatus: (status) => progress?.set(`${status}\n\nWaiting to run RAM/VRAM cleanup workflow...`, percent),
     });
     const promptId = queued?.prompt_id;
@@ -31125,6 +31210,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       llm_api_provider: state.llmApiProvider || "openai",
       llm_api_model: state.llmApiModel || "",
       notification_settings: normalizeNotificationSettings(state.notificationSettings),
+      automatic_memory_cleanup: Boolean(state.automaticMemoryCleanup),
       waveform_mode: state.waveformMode,
       snap_to_beats: state.snapToBeats,
       show_beat_markers: state.showBeatMarkers,
@@ -31294,11 +31380,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       await cancelComfyExecutionAndWaitIdle((status) => {
         progress.set(`${status}`, 45);
       }, { shouldCancel: () => false });
-      progress.set("Clearing memory after stop...", 45);
-      await runClearMemoryWorkflowQuiet(progress, "stop request", 85);
-      progress.set("Stop requested and memory cleanup finished.", 100);
+      progress.set(state.automaticMemoryCleanup ? "Clearing memory after stop..." : "Automatic memory cleanup is disabled; stopping without clearing models or caches...", 45);
+      const cleanupOutput = await runClearMemoryWorkflowQuiet(progress, "stop request", 85);
+      progress.set(state.automaticMemoryCleanup ? "Stop requested and memory cleanup finished." : `Stop requested.\n${cleanupOutput}`, 100);
       progress.close(3000);
-      toast("Stop requested. Memory cleanup ran.");
+      toast(state.automaticMemoryCleanup ? "Stop requested. Memory cleanup ran." : "Stop requested. Automatic memory cleanup was skipped.");
     } catch (error) {
       progress?.set(`Error while stopping:\n${String(error?.message || error)}`, 100);
       toast(String(error?.message || error), true);
@@ -31383,6 +31469,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.lmStudioModel = data.session.lm_studio_model || state.lmStudioModel || "";
         state.lmStudioApiKey = data.session.lm_studio_api_key || state.lmStudioApiKey || "";
         state.notificationSettings = normalizeNotificationSettings(data.session.notification_settings || state.notificationSettings);
+        state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.session.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
         state.waveformMode = data.session.waveform_mode || state.waveformMode;
         state.snapToBeats = data.session.snap_to_beats ?? state.snapToBeats;
         state.showTimelineSceneNotes = data.session.show_timeline_scene_notes ?? state.showTimelineSceneNotes ?? false;
@@ -31707,6 +31794,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.lmStudioModel = session.lm_studio_model || state.lmStudioModel || "";
       state.lmStudioApiKey = session.lm_studio_api_key || state.lmStudioApiKey || "";
       state.notificationSettings = normalizeNotificationSettings(session.notification_settings || state.notificationSettings);
+      state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(session.automatic_memory_cleanup ?? false);
       state.waveformMode = session.waveform_mode || state.waveformMode || "medium";
       state.snapToBeats = session.snap_to_beats ?? state.snapToBeats ?? true;
       state.showTimelineSceneNotes = session.show_timeline_scene_notes ?? state.showTimelineSceneNotes ?? false;

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -13521,6 +13521,19 @@ function openBuilder(node) {
     return settings.seed;
   }
 
+  function setMiniMaxH3SeedRandom(segment = activeSegment()) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    settings.seed = randomSeedValue();
+    if (segment?.use_scene_minimax_h3_settings) {
+      segment.minimax_h3_settings = cloneMiniMaxH3Settings(settings);
+      segment.minimax_h3_mode = segment.minimax_h3_settings.video_mode;
+    } else {
+      state.miniMaxH3Settings = cloneMiniMaxH3Settings(settings);
+    }
+    if (!segment || segment.id === activeSegment()?.id) syncMiniMaxH3Panel();
+    return settings.seed;
+  }
+
   function renderFluxIngredientList(segment = activeSegment()) {
     const ingredients = Array.isArray(segment?.flux_image_ingredients) ? segment.flux_image_ingredients : [];
     renderFluxIngredientRows(fluxIngredientList, ingredients, "No scene-specific image ingredients loaded for this scene.", (index) => {
@@ -31625,6 +31638,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   async function saveSessionForSceneVideo() {
     updateActiveFromInputs();
     saveI2VVideoSettingsFromPanel();
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") saveMiniMaxH3SettingsFromPanel();
     const projectFolder = activeProjectFolderForSave();
     if (!projectFolder) throw new Error("Create or load a project before rendering scene videos.");
     await persistIngredientsSheetImages(projectFolder);
@@ -36124,6 +36138,31 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return missing;
   }
 
+  function validateMiniMaxSceneReadyForVideo(segment, sceneIndex) {
+    const name = sceneDisplayName(segment, sceneIndex);
+    const missing = [];
+    const mode = miniMaxH3ModeForSegment(segment);
+    if (!String(segment?.minimax_h3_prompt || segment?.i2v_prompt || "").trim()) {
+      missing.push(`${name}: MiniMax ${miniMaxH3ModeLabel(mode)} prompt is missing.`);
+    }
+    if (!Number.isFinite(Number(segment?.start)) || !Number.isFinite(Number(segment?.end)) || Number(segment.end) <= Number(segment.start)) {
+      missing.push(`${name}: timeline start and end times are invalid.`);
+    }
+    if (mode === "image_to_video" && !String(selectedSegmentImagePath(segment) || "").trim()) {
+      missing.push(`${name}: MiniMax Image to Video needs a selected scene image.`);
+    }
+    if (mode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
+      missing.push(`${name}: MiniMax Reference to Video is set to use the scene image as its start frame, but no scene image is saved.`);
+    }
+    if (mode === "reference_to_video" && !miniMaxOrderedImageReferenceItemsForSegment(segment, mode).length) {
+      missing.push(`${name}: MiniMax Reference to Video needs a start frame or at least one ordered Reference Builder image.`);
+    }
+    if (mode === "video_to_video" && !(segment?.minimax_h3_video_references || []).some((item) => String(item?.path || "").trim())) {
+      missing.push(`${name}: MiniMax Video to Video needs at least one reference-video path.`);
+    }
+    return missing;
+  }
+
   async function validateSrtTimingForSceneVideo({ segment, sceneIndex, srtPath, promptNumber, expectedDuration }) {
     const promptIndex = Math.max(0, Number(promptNumber || 1) - 1);
     const uiDuration = Number(expectedDuration ?? timelineSegmentDuration(segment));
@@ -37177,6 +37216,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const scenesToRender = allScenes
       .map((segment) => ({ segment, index: segmentIndexInfo(segment).index }))
       .filter(({ segment }) => options.forceVideos || !String(selectedSegmentVideoPath(segment) || "").trim());
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    if (miniMaxProject) {
+      if (!String(projectInput.value || state.projectFolder || "").trim()) missing.push("Project folder is missing.");
+      scenesToRender.forEach(({ segment, index }) => {
+        if (!String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
+          missing.push(`${sceneDisplayName(segment, index)}: MiniMax H3 needs project audio or custom scene audio.`);
+        }
+        missing.push(...validateMiniMaxSceneReadyForVideo(segment, index));
+      });
+      return missing;
+    }
     const idLoraMode = currentVideoMode() === "id_lora";
     const embeddedSceneAudioMode = currentVideoMode() === "id_lora" || !!options.useEmbeddedSceneAudio;
     const sceneAudioMode = !embeddedSceneAudioMode && usingSceneAudioMode();
@@ -37227,7 +37277,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function ensureAudioOrOfferSilentTimeline(options = {}) {
-    if (currentVideoMode() === "id_lora") return true;
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) !== "minimax_h3" && currentVideoMode() === "id_lora") return true;
     if (currentProjectAudioPath()) return true;
     const scenes = audioFallbackTargetScenes(options);
     if (!scenes.length) return true;
@@ -37890,18 +37940,21 @@ Chrome vault corridor = Sealed industrial passage...</pre>
 
   async function stitchRenderedScenes(progress, options = {}) {
     const baseSegments = Array.isArray(options.segments) && options.segments.length ? options.segments : state.segments;
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const overlaySegments = state.overlayTrack.enabled
       ? (Array.isArray(options.overlaySegments) ? options.overlaySegments : state.overlaySegments)
           .filter((segment) => overlayClipIsEnabled(segment, state.overlayTrack))
       : [];
     const timelineOffset = Number(options.timelineOffset || 0);
-    await ensureSceneLutsAppliedBeforeStitch(baseSegments, progress, options);
-    await ensureSceneAdjustsAppliedBeforeStitch(baseSegments, progress, options);
-    await ensureSceneFilmGrainAppliedBeforeStitch(baseSegments, progress, options);
-    if (overlaySegments.length) {
-      await ensureSceneLutsAppliedBeforeStitch(overlaySegments, progress, options);
-      await ensureSceneAdjustsAppliedBeforeStitch(overlaySegments, progress, options);
-      await ensureSceneFilmGrainAppliedBeforeStitch(overlaySegments, progress, options);
+    if (!miniMaxProject) {
+      await ensureSceneLutsAppliedBeforeStitch(baseSegments, progress, options);
+      await ensureSceneAdjustsAppliedBeforeStitch(baseSegments, progress, options);
+      await ensureSceneFilmGrainAppliedBeforeStitch(baseSegments, progress, options);
+      if (overlaySegments.length) {
+        await ensureSceneLutsAppliedBeforeStitch(overlaySegments, progress, options);
+        await ensureSceneAdjustsAppliedBeforeStitch(overlaySegments, progress, options);
+        await ensureSceneFilmGrainAppliedBeforeStitch(overlaySegments, progress, options);
+      }
     }
     const paths = baseSegments.map((segment) => String(selectedSegmentVideoPath(segment) || "").trim());
     const overlayItems = overlaySegments
@@ -37914,7 +37967,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         label: segment.label || `Insert ${index + 1}`,
       }));
     const globalAudioPath = currentProjectAudioPath();
-    const embeddedSceneAudioMode = currentVideoMode() === "id_lora" || !!options.useEmbeddedSceneAudio;
+    const embeddedSceneAudioMode = (!miniMaxProject && currentVideoMode() === "id_lora") || !!options.useEmbeddedSceneAudio;
     const sceneAudioMode = !embeddedSceneAudioMode && !globalAudioPath && usingSceneAudioMode();
     const audioPaths = sceneAudioMode ? baseSegments.map((segment) => String(segment.custom_audio_path || "").trim()) : [];
     const audioItems = sceneAudioMode ? baseSegments.map((segment) => ({
@@ -37936,10 +37989,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (missing.length) throw new Error(missing.join("\n"));
     const stitchSettings = state.i2vVideoSettings || {};
     const stitchVideoMode = currentVideoMode();
-    const stitchWidth = stitchVideoMode === "ingredients"
+    const stitchWidth = miniMaxProject ? 0 : stitchVideoMode === "ingredients"
       ? Number(stitchSettings.ingredients_width || DEFAULT_LTX_INGREDIENTS_WIDTH)
       : Number(stitchSettings.width || 1920);
-    const stitchHeight = stitchVideoMode === "ingredients"
+    const stitchHeight = miniMaxProject ? 0 : stitchVideoMode === "ingredients"
       ? Number(stitchSettings.ingredients_height || DEFAULT_LTX_INGREDIENTS_HEIGHT)
       : Number(stitchSettings.height || 1080);
     const stitchAudioMessage = embeddedSceneAudioMode
@@ -38083,29 +38136,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const sceneIndex = info.index;
     if (sceneIndex < 0) return;
 
-    const missing = [];
+    const missing = validateMiniMaxSceneReadyForVideo(segment, sceneIndex);
     if (!String(projectInput.value || state.projectFolder || "").trim()) missing.push("Project folder is missing.");
     if (!String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
       missing.push("Load global audio or add custom audio for this scene.");
-    }
-    if (!String(segment.minimax_h3_prompt || segment.i2v_prompt || "").trim()) {
-      missing.push("Enter a MiniMax H3 prompt in the scene video prompt box.");
-    }
-    if (!Number.isFinite(Number(segment.start)) || !Number.isFinite(Number(segment.end)) || Number(segment.end) <= Number(segment.start)) {
-      missing.push("The scene needs valid timeline start and end times.");
-    }
-    const mode = miniMaxH3ModeForSegment(segment);
-    if (mode === "image_to_video" && !String(selectedSegmentImagePath(segment) || "").trim()) {
-      missing.push("Image to Video needs a selected scene image.");
-    }
-    if (mode === "reference_to_video" && segment.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
-      missing.push("Reference to Video is set to use the scene image as its start frame, but this scene has no saved image.");
-    }
-    if (mode === "reference_to_video" && !miniMaxOrderedImageReferenceItemsForSegment(segment, mode).length) {
-      missing.push("Reference to Video needs a start frame or at least one ordered Reference Builder image.");
-    }
-    if (mode === "video_to_video" && !(segment.minimax_h3_video_references || []).some((item) => String(item?.path || "").trim())) {
-      missing.push("Video to Video needs at least one reference-video path.");
     }
     if (missing.length) {
       toast(missing.join("\n"), true);
@@ -38387,6 +38421,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   async function renderAllScenes(options = {}) {
     updateActiveFromInputs();
     saveI2VVideoSettingsFromPanel();
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    if (miniMaxProject) saveMiniMaxH3SettingsFromPanel();
     const forceVideos = Boolean(options.forceVideos);
     const randomizeVideoSeed = Boolean(options.randomizeVideoSeed);
     const sceneScope = normalizeBatchScope(options.sceneScope);
@@ -38428,7 +38464,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       mode_label: modeLabel,
       scene_scope: sceneScope,
       project_folder: String(state.projectFolder || projectInput.value || ""),
-      video_mode: currentVideoMode(),
+      video_engine: miniMaxProject ? "minimax_h3" : "ltx",
+      video_mode: miniMaxProject ? state.miniMaxH3Settings.video_mode : currentVideoMode(),
       force_videos: forceVideos,
       randomize_video_seed: randomizeVideoSeed,
       skip_final_stitch: skipFinalStitch,
@@ -38449,11 +38486,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       renderAllButton.disabled = true;
       renderAllButton.textContent = "Rendering...";
       setButtonGroupState(createSceneVideoButtons, { disabled: true });
+      setButtonGroupState(miniMaxSceneVideoButtons, { disabled: true });
       setButtonGroupState(gemmaThenCreateVideoButtons, { disabled: true });
       await persistRenderLog(renderLog);
       progress.set(`Autosaving session/SRT before ${sceneScope === "selected" ? "Render Selected" : sceneScope === "from_selected" ? "Render From Selected" : "Render All"}...`, 3);
       await saveSessionForSceneVideo();
-      const preparedAudio = skipFinalStitch
+      const preparedAudio = miniMaxProject || skipFinalStitch
         ? { audioPath: "", srtPath: "" }
         : await prepareSceneAudioMix(progress, "Preparing combined scene-audio track for LTX");
       const scenes = batchTargetItems(sceneScope)
@@ -38464,7 +38502,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       if (!scenes.length) {
         progress.set(skipFinalStitch ? "Selected scenes already have video. Nothing to render." : "All scenes already have video. Stitching existing scene videos...", 80);
       }
-      if (currentVideoMode() === "flf" && scenes.length && flfPreGeneratePromptsEnabled()) {
+      if (!miniMaxProject && currentVideoMode() === "flf" && scenes.length && flfPreGeneratePromptsEnabled()) {
         const promptTargets = scenes.filter(({ segment }) =>
           !String(segment.i2v_prompt || "").trim()
           && firstLastFramePromptReferences(segment).length >= 2
@@ -38497,6 +38535,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scene_number: sceneSlotNumber(segment),
           timeline_index: sceneIndex,
           label: sceneLabel,
+          video_mode: miniMaxProject ? miniMaxH3ModeForSegment(segment) : currentVideoMode(),
           status: "running",
           phase: "preparation",
           started_at: new Date(sceneStartedMs).toISOString(),
@@ -38513,18 +38552,21 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         upsertRenderLog(renderLog);
         const base = Math.floor((index / scenes.length) * 100);
         const span = Math.max(1, Math.floor(80 / scenes.length));
-        if (randomizeVideoSeed) setVideoSeedRandom(segment);
-        if (currentVideoMode() === "flf" && index === 0 && flfRenderChainStartSource(segment) === "rendered_frame") {
+        if (randomizeVideoSeed) {
+          if (miniMaxProject) setMiniMaxH3SeedRandom(segment);
+          else setVideoSeedRandom(segment);
+        }
+        if (!miniMaxProject && currentVideoMode() === "flf" && index === 0 && flfRenderChainStartSource(segment) === "rendered_frame") {
           const previousSegment = previousAutoChainSourceSegment(segment);
           if (previousSegment && String(selectedSegmentVideoPath(previousSegment) || "").trim()) {
             await prepareFLFRenderedFrameNextScene(previousSegment, segment, progress, Math.min(98, base + 1), `FLF Render Chain resume into ${sceneLabel}`);
           }
         }
-        if (currentVideoMode() === "flf" && !String(segment.i2v_prompt || "").trim()) {
+        if (!miniMaxProject && currentVideoMode() === "flf" && !String(segment.i2v_prompt || "").trim()) {
           progress.set(`Creating First Last Frame prompt for ${sceneLabel}...`, Math.min(98, base + 1));
           await generateI2VPromptForSegment(segment, progress, Math.min(98, base + 2), `Render All ${index + 1}/${scenes.length}: Gemma FLF`, { unloadAfter: true, forceVision: true });
         }
-        if (i2vAutoChainEnabled() && currentVideoMode() === "i2v" && index === 0) {
+        if (!miniMaxProject && i2vAutoChainEnabled() && currentVideoMode() === "i2v" && index === 0) {
           const previousSegment = previousAutoChainSourceSegment(segment);
           if (previousSegment && String(selectedSegmentVideoPath(previousSegment) || "").trim()) {
             const chainBase = Math.min(98, base + Math.max(1, Math.floor(span * 0.12)));
@@ -38537,7 +38579,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             );
           }
         }
-        if (img2imgContinuityEnabled() && currentVideoMode() === "i2v") {
+        if (!miniMaxProject && img2imgContinuityEnabled() && currentVideoMode() === "i2v") {
           const previousSegment = previousAutoChainSourceSegment(segment);
           if (previousSegment && String(selectedSegmentVideoPath(previousSegment) || "").trim()) {
             const imageMode = state.imageModelMode || "zimage";
@@ -38573,22 +38615,27 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           ? `\nElapsed: ${renderLogDuration(liveSummary.total_ms)} · Estimated remaining: ${renderLogDuration(liveSummary.eta_ms)}`
           : `\nElapsed: ${renderLogDuration(liveSummary.total_ms)}`;
         progress.set(`Rendering ${sceneLabel} (${index + 1} of ${scenes.length}; ${forceVideos ? "creating a new video version" : "existing videos skipped"})...${timingLine}`, base);
-        const renderedVideoPath = await renderSceneVideoWithProgress(segment, sceneIndex, progress, {
+        const sharedRenderOptions = {
           progressBase: base,
           progressSpan: span,
           batchLabel: `Render All ${index + 1}/${scenes.length}: ${segment.label || `Scene ${sceneIndex + 1}`}`,
           autoSaveAfter: false,
           existingVideoAction: forceVideos ? "backup" : "overwrite",
-          audioPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.audioPath,
-          srtPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.srtPath,
-        });
+        };
+        const renderedVideoPath = miniMaxProject
+          ? await renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, sharedRenderOptions)
+          : await renderSceneVideoWithProgress(segment, sceneIndex, progress, {
+            ...sharedRenderOptions,
+            audioPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.audioPath,
+            srtPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.srtPath,
+          });
         const sceneRenderEndedMs = Date.now();
         previousRenderEndedMs = sceneRenderEndedMs;
         currentSceneLog.phase = "post";
         currentSceneLog.render_ended_at = new Date(sceneRenderEndedMs).toISOString();
         currentSceneLog.render_ms = Math.max(0, sceneRenderEndedMs - sceneRenderStartedMs);
         currentSceneLog.video_path = String(renderedVideoPath || selectedSegmentVideoPath(segment) || "");
-        if (currentVideoMode() === "flf" && scenes[index + 1]?.segment && flfChainingEnabled(scenes[index + 1].segment) && flfRenderChainStartSource(scenes[index + 1].segment) === "rendered_frame") {
+        if (!miniMaxProject && currentVideoMode() === "flf" && scenes[index + 1]?.segment && flfChainingEnabled(scenes[index + 1].segment) && flfRenderChainStartSource(scenes[index + 1].segment) === "rendered_frame") {
           assertBatchNotStopped();
           const nextSegment = scenes[index + 1].segment;
           const chainBase = Math.min(98, base + Math.max(1, Math.floor(span * 0.72)));
@@ -38600,7 +38647,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             `FLF rendered-frame chain ${index + 1}->${index + 2}`,
           );
         }
-        if (i2vAutoChainEnabled() && currentVideoMode() === "i2v" && scenes[index + 1]?.segment) {
+        if (!miniMaxProject && i2vAutoChainEnabled() && currentVideoMode() === "i2v" && scenes[index + 1]?.segment) {
           assertBatchNotStopped();
           const nextSegment = scenes[index + 1].segment;
           const chainBase = Math.min(98, base + Math.max(1, Math.floor(span * 0.72)));
@@ -38692,6 +38739,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       renderAllButton.disabled = false;
       renderAllButton.textContent = "Render All";
       setButtonGroupState(createSceneVideoButtons, { disabled: false, text: "Create Scene Video" });
+      setButtonGroupState(miniMaxSceneVideoButtons, { disabled: false, text: "Create MiniMax H3 Scene Video" });
       setButtonGroupState(gemmaThenCreateVideoButtons, { disabled: false });
       state.batchCancelled = false;
       syncInspector();
@@ -44390,14 +44438,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function confirmAndRunRenderAll() {
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const videoMode = currentVideoMode();
-    const videoLabel = videoModeDisplayLabel(videoMode, true);
+    const videoLabel = miniMaxProject ? "MiniMax H3" : videoModeDisplayLabel(videoMode, true);
     const scopeChoices = batchScopeChoices();
     const action = await chooseBatchModeAction({
       title: "Run Render All?",
       intro: [
         "Render All only works on the video/render stage.",
-        videoMode === "t2v"
+        miniMaxProject
+          ? "It uses each scene's existing MiniMax prompt and effective project-global or locked MiniMax mode, models, and video settings."
+          : videoMode === "t2v"
           ? "It uses existing T2V prompts and does not require scene images."
           : videoMode === "ingredients"
             ? "It uses the current selected ingredients reference images and existing Ingredients prompts."

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -159,6 +159,7 @@ const MINIMAX_H3_VIDEO_REFERENCE_PURPOSES = [
   { value: "visual_style", label: "Visual Style Guide" },
 ];
 const DEFAULT_MINIMAX_H3_SETTINGS = {
+  video_mode: "text_to_video",
   diffusion_model_name: "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
   clip_name: "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
   video_vae_name: "minimax_h3_video_vae_fp16.safetensors",
@@ -216,6 +217,7 @@ function cloneMiniMaxH3Settings(value = {}) {
   return {
     ...DEFAULT_MINIMAX_H3_SETTINGS,
     ...source,
+    video_mode: normalizeMiniMaxH3Mode(source.video_mode || source.mode || DEFAULT_MINIMAX_H3_SETTINGS.video_mode),
     diffusion_model_name: String(source.diffusion_model_name || DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name),
     clip_name: String(source.clip_name || DEFAULT_MINIMAX_H3_SETTINGS.clip_name),
     video_vae_name: String(source.video_vae_name || DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name),
@@ -1963,6 +1965,8 @@ function audioUrl(path) {
     i2v_prompt: "",
     i2v_prompt_origin: "manual",
     minimax_h3_mode: "text_to_video",
+    use_scene_minimax_h3_settings: false,
+    minimax_h3_settings: null,
     minimax_h3_prompt: "",
     minimax_h3_prompt_origin: "manual",
     minimax_h3_reference_keys: null,
@@ -4695,7 +4699,7 @@ function openBuilder(node) {
   const miniMaxEnginePanel = document.createElement("div");
   miniMaxEnginePanel.style.cssText = "display:none;flex-direction:column;gap:10px;";
   const miniMaxBanner = document.createElement("div");
-  miniMaxBanner.innerHTML = `<div style="font-size:14px;font-weight:900;color:#cffafe;">MiniMax H3 Project</div><div style="font-size:11px;color:#a5f3fc;margin-top:3px;">Choose the input mode independently for each scene. This panel uses only the MiniMax hidden workflow.</div>`;
+  miniMaxBanner.innerHTML = `<div style="font-size:14px;font-weight:900;color:#cffafe;">MiniMax H3 Project</div><div style="font-size:11px;color:#a5f3fc;margin-top:3px;">Mode, models, and video settings apply to the whole project unless the active scene is locked to custom settings.</div>`;
   miniMaxBanner.style.cssText = "border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;";
   const miniMaxModeChooser = document.createElement("div");
   miniMaxModeChooser.style.cssText = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px;";
@@ -4881,6 +4885,12 @@ function openBuilder(node) {
   const miniMaxAudioNote = document.createElement("div");
   miniMaxAudioNote.textContent = "The current hidden workflow requires custom scene audio or project audio. Built-in MiniMax audio will be added with a separate workflow later.";
   miniMaxAudioNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const useSceneMiniMaxH3Settings = makeCheckbox("Lock MiniMax mode, models, and video settings for this scene", false);
+  const useSceneMiniMaxH3SettingsNote = document.createElement("div");
+  useSceneMiniMaxH3SettingsNote.textContent = "Off: this scene follows the project's current MiniMax mode, models, render settings, and advanced settings. On: the current values are copied to and locked for this scene only.";
+  useSceneMiniMaxH3SettingsNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;margin-top:-4px;";
+  const miniMaxSettingsScopeNote = document.createElement("div");
+  miniMaxSettingsScopeNote.style.cssText = "font-size:11px;font-weight:800;color:#67e8f9;line-height:1.4;";
   const miniMaxSubTabs = makeSubTabs([
     {
       label: "Models",
@@ -4897,6 +4907,9 @@ function openBuilder(node) {
       label: "Video Settings",
       value: "input",
       content: makeSettingsPanel([
+        useSceneMiniMaxH3Settings.wrapper,
+        useSceneMiniMaxH3SettingsNote,
+        miniMaxSettingsScopeNote,
         ...Object.values(miniMaxModePanels),
         makeSettingsSection("Render Settings", [miniMaxRenderSettingsGrid]),
         miniMaxAdvancedSettings,
@@ -5714,6 +5727,44 @@ function openBuilder(node) {
     syncMiniMaxH3Panel();
   }
 
+  function miniMaxH3SettingsForSegment(segment = activeSegment()) {
+    const globalSettings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    if (!segment?.use_scene_minimax_h3_settings) return globalSettings;
+    const sceneSettings = segment.minimax_h3_settings && typeof segment.minimax_h3_settings === "object"
+      ? segment.minimax_h3_settings
+      : {};
+    const settings = cloneMiniMaxH3Settings({
+      ...globalSettings,
+      ...sceneSettings,
+      video_mode: sceneSettings.video_mode || segment.minimax_h3_mode || globalSettings.video_mode,
+    });
+    segment.minimax_h3_settings = settings;
+    segment.minimax_h3_mode = settings.video_mode;
+    return settings;
+  }
+
+  function miniMaxH3ModeForSegment(segment = activeSegment()) {
+    return miniMaxH3SettingsForSegment(segment).video_mode;
+  }
+
+  function setMiniMaxH3ModeForSegment(segment, value) {
+    const mode = normalizeMiniMaxH3Mode(value);
+    if (segment?.use_scene_minimax_h3_settings) {
+      segment.minimax_h3_settings = cloneMiniMaxH3Settings({
+        ...miniMaxH3SettingsForSegment(segment),
+        video_mode: mode,
+      });
+      segment.minimax_h3_mode = mode;
+    } else {
+      state.miniMaxH3Settings = cloneMiniMaxH3Settings({
+        ...state.miniMaxH3Settings,
+        video_mode: mode,
+      });
+      if (segment) segment.minimax_h3_mode = mode;
+    }
+    return mode;
+  }
+
   function syncMiniMaxReferenceButtons() {
     const segment = activeSegment();
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
@@ -5729,12 +5780,13 @@ function openBuilder(node) {
     const libraryCount = segment && typeof miniMaxReferenceKeysForSegment === "function"
       ? miniMaxReferenceKeysForSegment(segment).length
       : 0;
+    const effectiveMode = miniMaxH3ModeForSegment(segment);
     const orderedCount = segment && typeof miniMaxOrderedImageReferenceItemsForSegment === "function"
-      ? miniMaxOrderedImageReferenceItemsForSegment(segment, segment.minimax_h3_mode).length
+      ? miniMaxOrderedImageReferenceItemsForSegment(segment, effectiveMode).length
       : libraryCount;
     const hasStartFrame = Boolean(
       segment?.minimax_h3_use_scene_image_as_start_frame
-      && normalizeMiniMaxH3Mode(segment?.minimax_h3_mode) === "reference_to_video"
+      && effectiveMode === "reference_to_video"
       && (segmentImageSource(segment)?.path || segmentImageSource(segment)?.data)
     );
     for (const button of miniMaxReferenceButtons) {
@@ -5748,7 +5800,10 @@ function openBuilder(node) {
   }
 
   function saveMiniMaxH3SettingsFromPanel() {
-    state.miniMaxH3Settings = cloneMiniMaxH3Settings({
+    const segment = activeSegment();
+    const currentSettings = miniMaxH3SettingsForSegment(segment);
+    const settings = cloneMiniMaxH3Settings({
+      video_mode: currentSettings.video_mode,
       diffusion_model_name: miniMaxDiffusionModelPicker.input.value,
       clip_name: miniMaxClipPicker.input.value,
       video_vae_name: miniMaxVideoVaePicker.input.value,
@@ -5770,6 +5825,14 @@ function openBuilder(node) {
       sage_attention: miniMaxSageAttention.value,
       enable_fp16_accumulation: miniMaxFp16Accumulation.input.checked,
     });
+    if (segment?.use_scene_minimax_h3_settings) {
+      segment.minimax_h3_settings = settings;
+      segment.minimax_h3_mode = settings.video_mode;
+    } else {
+      state.miniMaxH3Settings = settings;
+      if (segment) segment.minimax_h3_mode = settings.video_mode;
+    }
+    return settings;
   }
 
   function saveMiniMaxSceneInputsFromPanel() {
@@ -5792,8 +5855,8 @@ function openBuilder(node) {
   function syncMiniMaxH3Panel() {
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const segment = activeSegment();
-    const settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
-    state.miniMaxH3Settings = settings;
+    state.miniMaxH3Settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    const settings = miniMaxH3SettingsForSegment(segment);
     miniMaxDiffusionModelPicker.input.value = settings.diffusion_model_name;
     miniMaxClipPicker.input.value = settings.clip_name;
     miniMaxVideoVaePicker.input.value = settings.video_vae_name;
@@ -5814,7 +5877,12 @@ function openBuilder(node) {
     miniMaxEasyCacheVerbose.input.checked = settings.easy_cache_verbose;
     miniMaxSageAttention.value = settings.sage_attention;
     miniMaxFp16Accumulation.input.checked = settings.enable_fp16_accumulation;
-    const mode = normalizeMiniMaxH3Mode(segment?.minimax_h3_mode);
+    useSceneMiniMaxH3Settings.input.checked = Boolean(segment?.use_scene_minimax_h3_settings);
+    useSceneMiniMaxH3Settings.input.disabled = !segment;
+    miniMaxSettingsScopeNote.textContent = segment?.use_scene_minimax_h3_settings
+      ? "Scene lock is ON — this scene uses its own MiniMax mode, models, and video settings."
+      : "Scene lock is OFF — this scene follows the project-global MiniMax mode, models, and video settings.";
+    const mode = settings.video_mode;
     const modeLabel = miniMaxH3ModeLabel(mode);
     for (const button of miniMaxModeButtons) {
       const active = button.dataset.minimaxH3Mode === mode;
@@ -8837,6 +8905,18 @@ function openBuilder(node) {
     if (segment.i2v_notes == null) segment.i2v_notes = "";
     segment.i2v_prompt_origin = normalizeVideoPromptOrigin(segment.i2v_prompt_origin);
     segment.minimax_h3_mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    segment.use_scene_minimax_h3_settings = Boolean(segment.use_scene_minimax_h3_settings);
+    if (segment.minimax_h3_settings != null && typeof segment.minimax_h3_settings !== "object") {
+      segment.minimax_h3_settings = null;
+    }
+    if (segment.use_scene_minimax_h3_settings) {
+      segment.minimax_h3_settings = cloneMiniMaxH3Settings({
+        ...cloneMiniMaxH3Settings(state.miniMaxH3Settings),
+        ...(segment.minimax_h3_settings || {}),
+        video_mode: segment.minimax_h3_settings?.video_mode || segment.minimax_h3_mode,
+      });
+      segment.minimax_h3_mode = segment.minimax_h3_settings.video_mode;
+    }
     if (segment.minimax_h3_prompt == null) segment.minimax_h3_prompt = "";
     segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(segment.minimax_h3_prompt_origin);
     if (segment.minimax_h3_reference_keys != null) {
@@ -12714,7 +12794,7 @@ function openBuilder(node) {
     }
     loadCustomImageButton.disabled = disabled;
     openSceneAudioOptionsButton.disabled = disabled;
-    for (const control of [t2iTextGemmaModelSelect, gemmaModelSelect, mmprojSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, ernieMmprojSelect, zEnhanceGemmaModelSelect, zEnhanceMmprojSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, i2vMmprojSelect, nbApiKey, nbModelSelect, nbGemmaModelSelect, nbMmprojSelect, fluxUseTextOnlyGemmaPrompt.input, fluxUseDirectorNotes.input, nbUseTextOnlyGemmaPrompt.input, nbUseDirectorNotes.input, useVisionReference.input, ernieUseVisionReference.input, krea2TwoPassUseVisionReference.input, useI2VVisionReference.input, useT2VVisionReference.input, useSceneZImageSettings.input, useSceneErnieImageSettings.input, useSceneFluxKleinSettings.input, useSceneNBImageSettings.input, useSceneI2VVideoSettings.input, rtvReferenceBehaviorSelect, createSceneEndFrameButton, clearSceneEndFrameButton, i2vUseGgufModel.input, refImageInput, createT2IButton, editZImageT2IInstructionsButton, ernieCreateT2IButton, editErnieT2IInstructionsButton, krea2TwoPassCreateT2IButton, editKrea2T2IInstructionsButton, createNBPromptButton, editNanoBT2IInstructionsButton, flowGptCreatePromptButton, editFlowGptT2IInstructionsButton, createFluxPromptButton, editFluxKleinT2IInstructionsButton, createI2VButton, editI2VPromptButton, editIdLoraInstructionsButton, zEnhanceGemmaButton, ...editImagePromptButtons]) {
+    for (const control of [t2iTextGemmaModelSelect, gemmaModelSelect, mmprojSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, ernieMmprojSelect, zEnhanceGemmaModelSelect, zEnhanceMmprojSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, i2vMmprojSelect, nbApiKey, nbModelSelect, nbGemmaModelSelect, nbMmprojSelect, fluxUseTextOnlyGemmaPrompt.input, fluxUseDirectorNotes.input, nbUseTextOnlyGemmaPrompt.input, nbUseDirectorNotes.input, useVisionReference.input, ernieUseVisionReference.input, krea2TwoPassUseVisionReference.input, useI2VVisionReference.input, useT2VVisionReference.input, useSceneZImageSettings.input, useSceneErnieImageSettings.input, useSceneFluxKleinSettings.input, useSceneNBImageSettings.input, useSceneI2VVideoSettings.input, useSceneMiniMaxH3Settings.input, rtvReferenceBehaviorSelect, createSceneEndFrameButton, clearSceneEndFrameButton, i2vUseGgufModel.input, refImageInput, createT2IButton, editZImageT2IInstructionsButton, ernieCreateT2IButton, editErnieT2IInstructionsButton, krea2TwoPassCreateT2IButton, editKrea2T2IInstructionsButton, createNBPromptButton, editNanoBT2IInstructionsButton, flowGptCreatePromptButton, editFlowGptT2IInstructionsButton, createFluxPromptButton, editFluxKleinT2IInstructionsButton, createI2VButton, editI2VPromptButton, editIdLoraInstructionsButton, zEnhanceGemmaButton, ...editImagePromptButtons]) {
       control.disabled = disabled;
     }
     const lockedByVideo = hasLockedVideo(segment);
@@ -13866,7 +13946,7 @@ function openBuilder(node) {
       .slice(0, 9);
   }
 
-  function miniMaxReferenceBuilderImagePathsForSegment(segment, mode = segment?.minimax_h3_mode) {
+  function miniMaxReferenceBuilderImagePathsForSegment(segment, mode = miniMaxH3ModeForSegment(segment)) {
     return miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
       .map((item) => String(item?.image?.path || "").trim())
       .filter(Boolean)
@@ -13882,7 +13962,7 @@ function openBuilder(node) {
       .slice(0, 9);
   }
 
-  function miniMaxOrderedImageReferenceItemsForSegment(segment, mode = segment?.minimax_h3_mode) {
+  function miniMaxOrderedImageReferenceItemsForSegment(segment, mode = miniMaxH3ModeForSegment(segment)) {
     const normalizedMode = normalizeMiniMaxH3Mode(mode);
     const ordered = [];
     if (normalizedMode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
@@ -13935,7 +14015,7 @@ function openBuilder(node) {
     if (!segment) return;
     const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
     const catalog = miniMaxReferenceBuilderCatalog(refs);
-    const startFrameReserved = normalizeMiniMaxH3Mode(segment.minimax_h3_mode) === "reference_to_video"
+    const startFrameReserved = miniMaxH3ModeForSegment(segment) === "reference_to_video"
       && Boolean(segment.minimax_h3_use_scene_image_as_start_frame)
       && Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
     const maxLibraryReferences = startFrameReserved ? 8 : 9;
@@ -22924,7 +23004,7 @@ function openBuilder(node) {
     const wizardLocationMode = Boolean(options?.wizardMode || options?.wizard_location_mode);
     const referenceImagesEnabled = options?.textOnlyMode !== true;
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
-    const miniMaxTargetMode = normalizeMiniMaxH3Mode(options?.miniMaxTargetMode || activeSegment()?.minimax_h3_mode);
+    const miniMaxTargetMode = normalizeMiniMaxH3Mode(options?.miniMaxTargetMode || miniMaxH3ModeForSegment(activeSegment()));
     const allowExtraSubjectReferences = referenceImagesEnabled && (currentVideoMode() === "rtv" || (miniMaxProject && ["reference_to_video", "video_to_video"].includes(miniMaxTargetMode)));
     const referenceBuilderTargetLabel = !referenceImagesEnabled
       ? "Gemma scene text mapping"
@@ -29676,7 +29756,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       backdrop.remove();
       if (miniMaxProject && ["reference_to_video", "video_to_video"].includes(target)) {
         const segment = activeSegment();
-        if (segment) segment.minimax_h3_mode = target;
+        if (segment) setMiniMaxH3ModeForSegment(segment, target);
         syncMiniMaxH3Panel();
         renderSegments();
         openFluxReferenceBuilderModal({ miniMaxTargetMode: target });
@@ -34213,7 +34293,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   function miniMaxH3PromptContextForSegment(segment, mode) {
-    const settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    const settings = miniMaxH3SettingsForSegment(segment);
     const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
     const exactDuration = String(Number(duration.toFixed(3)));
     const aspectRatio = String(settings.aspect_ratio || "16:9").match(/\d+\s*:\s*\d+/)?.[0]?.replace(/\s+/g, "") || "16:9";
@@ -34332,7 +34412,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (!segment) return;
     updateActiveFromInputs();
     saveMiniMaxSceneInputsFromPanel();
-    const mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    const mode = miniMaxH3ModeForSegment(segment);
     const modeLabel = miniMaxH3ModeLabel(mode);
     const duration = Number(segment.end || 0) - Number(segment.start || 0);
     if (!Number.isFinite(duration) || duration <= 0) {
@@ -35323,7 +35403,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           facial_performance_custom: String(segment.facial_performance_custom || "").trim(),
           performance_style: String(segment.performance_style || defaults.performance_style || "").trim(),
           project_video_engine: normalizeProjectVideoEngine(state.projectVideoEngine),
-          minimax_h3_mode: normalizeMiniMaxH3Mode(segment.minimax_h3_mode),
+          minimax_h3_mode: miniMaxH3ModeForSegment(segment),
           timeline_start: Number(segment.start || 0),
           timeline_end: Number(segment.end || 0),
           exact_duration: Number(timelineSegmentDuration(segment).toFixed(3)),
@@ -35568,7 +35648,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
             segment.minimax_h3_prompt = videoPrompt;
             segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(scene.video_prompt_origin);
-            segment.minimax_h3_mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
           } else {
             setSegmentPromptForEdit(segment, "i2v", videoPrompt, {
               origin: scene.video_prompt_origin,
@@ -35726,7 +35805,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         workingSegment.i2v_notes = [String(workingSegment.i2v_notes || "").trim(), extraUserNotes]
           .filter(Boolean)
           .join("\n\n");
-        const mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
+        const mode = miniMaxH3ModeForSegment(segment);
         const modeLabel = miniMaxH3ModeLabel(mode);
         workingSegment.minimax_h3_mode = mode;
         workingSegment.minimax_h3_reference_keys = Array.isArray(segment.minimax_h3_reference_keys)
@@ -37577,8 +37656,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const timelineStart = Number(segment?.start);
     const timelineEnd = Number(segment?.end);
     const sceneDuration = timelineEnd - timelineStart;
-    const mode = normalizeMiniMaxH3Mode(options.mode ?? segment?.minimax_h3_mode);
-    const miniMaxSettings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    const miniMaxSettings = miniMaxH3SettingsForSegment(segment);
+    const mode = normalizeMiniMaxH3Mode(options.mode ?? miniMaxSettings.video_mode);
     if (!projectFolder) throw new Error("Save or select a project folder before rendering MiniMax H3.");
     if (!Number.isFinite(timelineStart) || !Number.isFinite(timelineEnd) || sceneDuration <= 0) {
       throw new Error(`${sceneDisplayName(segment, sceneIndex)} has invalid timeline boundaries.`);
@@ -37651,12 +37730,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     const warmupFrames = Math.max(0, Math.trunc(Number(
       options.warmupFrames
-      ?? segment?.minimax_h3_warmup_frames
       ?? miniMaxSettings.warmup_frames
     ) || 0));
     const cooldownFrames = Math.max(0, Math.trunc(Number(
       options.cooldownFrames
-      ?? segment?.minimax_h3_cooldown_frames
       ?? miniMaxSettings.cooldown_frames
     ) || 0));
 
@@ -37676,9 +37753,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         source_start_seconds: Number.isFinite(sourceStartSeconds) ? Math.max(0, sourceStartSeconds) : timelineStart,
         pre_frames: warmupFrames,
         tail_loss_frames: cooldownFrames,
-        seed: Number(options.seed ?? segment?.minimax_h3_seed ?? miniMaxSettings.seed),
-        aspect_ratio: String(options.aspectRatio ?? segment?.minimax_h3_aspect_ratio ?? miniMaxSettings.aspect_ratio),
-        megapixels: Number(options.megapixels ?? segment?.minimax_h3_megapixels ?? miniMaxSettings.megapixels),
+        seed: Number(options.seed ?? miniMaxSettings.seed),
+        aspect_ratio: String(options.aspectRatio ?? miniMaxSettings.aspect_ratio),
+        megapixels: Number(options.megapixels ?? miniMaxSettings.megapixels),
         diffusion_model_name: miniMaxSettings.diffusion_model_name,
         clip_name: miniMaxSettings.clip_name,
         video_vae_name: miniMaxSettings.video_vae_name,
@@ -38017,7 +38094,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (!Number.isFinite(Number(segment.start)) || !Number.isFinite(Number(segment.end)) || Number(segment.end) <= Number(segment.start)) {
       missing.push("The scene needs valid timeline start and end times.");
     }
-    const mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    const mode = miniMaxH3ModeForSegment(segment);
     if (mode === "image_to_video" && !String(selectedSegmentImagePath(segment) || "").trim()) {
       missing.push("Image to Video needs a selected scene image.");
     }
@@ -45127,7 +45204,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       };
       const runnerName = promptRunnerActionName();
       const runnerGenericName = runnerName === "Gemma" ? "Gemma" : "LLM";
-      const progress = createProgressWindow(`Storyboard ${runnerName} All (${miniMaxProject ? "MiniMax H3 per-scene modes" : videoModeDisplayLabel(videoMode, true)})`, { zIndex: 100012 });
+      const progress = createProgressWindow(`Storyboard ${runnerName} All (${miniMaxProject ? "MiniMax H3 project/locked modes" : videoModeDisplayLabel(videoMode, true)})`, { zIndex: 100012 });
       let created = 0;
       try {
         progress.set(`Starting Storyboard ${runnerName} All...\nScenes: ${scenes.length}\nUsing the same prompt writer as Storyboard Builder.`, 5);
@@ -45162,7 +45239,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             if (miniMaxProject) {
               segment.minimax_h3_prompt = prompt;
               segment.minimax_h3_prompt_origin = "gemma";
-              segment.minimax_h3_mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
             } else {
               setSegmentPromptForEdit(segment, "i2v", prompt, { origin: "gemma" });
               segment.video_prompt_type = videoMode;
@@ -45945,6 +46021,27 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   useSceneI2VVideoSettings.input.addEventListener("change", () => {
     setSceneI2VVideoSettingsEnabled(Boolean(useSceneI2VVideoSettings.input.checked));
   });
+  async function setSceneMiniMaxH3SettingsEnabled(enabled) {
+    const segment = activeSegment();
+    if (!segment) return;
+    pushHistory();
+    saveMiniMaxH3SettingsFromPanel();
+    const useSceneSettings = Boolean(enabled);
+    segment.use_scene_minimax_h3_settings = useSceneSettings;
+    if (useSceneSettings) {
+      segment.minimax_h3_settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+      segment.minimax_h3_mode = segment.minimax_h3_settings.video_mode;
+    }
+    syncMiniMaxH3Panel();
+    renderList();
+    await autoSaveSessionQuiet(useSceneSettings ? "MiniMax H3 scene settings locked" : "MiniMax H3 scene settings returned to global");
+    toast(useSceneSettings
+      ? "This scene now has its own locked MiniMax mode, models, and video settings."
+      : "This scene is following the project-global MiniMax mode, models, and video settings again.");
+  }
+  useSceneMiniMaxH3Settings.input.addEventListener("change", () => {
+    setSceneMiniMaxH3SettingsEnabled(Boolean(useSceneMiniMaxH3Settings.input.checked)).catch((error) => toast(String(error?.message || error), true));
+  });
   rtvReferenceBehaviorSelect.addEventListener("change", () => {
     pushHistory();
     applyRTVReferenceBehaviorToAll(rtvReferenceBehaviorSelect.value);
@@ -46329,7 +46426,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   miniMaxEditInstructionsButton.onclick = () => {
     const segment = requireActiveSegment();
     if (!segment) return;
-    openBuilderInstructionEditor(miniMaxH3InstructionKey(segment.minimax_h3_mode));
+    openBuilderInstructionEditor(miniMaxH3InstructionKey(miniMaxH3ModeForSegment(segment)));
   };
   sendT2IPromptToEnhanceButton.onclick = () => sendPromptToEnhance("T2I", t2iPrompt.value);
   ernieSendT2IPromptToEnhanceButton.onclick = () => sendPromptToEnhance("T2I", ernieT2IPrompt.value);
@@ -47357,9 +47454,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const segment = requireActiveSegment();
       if (!segment) return;
       pushHistory();
-      segment.minimax_h3_mode = normalizeMiniMaxH3Mode(button.dataset.minimaxH3Mode);
+      setMiniMaxH3ModeForSegment(segment, button.dataset.minimaxH3Mode);
       syncMiniMaxH3Panel();
-      await autoSaveSessionQuiet("MiniMax H3 scene mode");
+      await autoSaveSessionQuiet(segment.use_scene_minimax_h3_settings ? "MiniMax H3 locked scene mode" : "MiniMax H3 project mode");
     };
   }
   miniMaxPrompt.addEventListener("input", saveMiniMaxSceneInputsFromPanel);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -89,6 +89,108 @@ const FLUX_GEMMA_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_NON_VISION_GEMMA_MODEL = "supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf";
 const NB_IMAGE_MODELS = ["gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview"];
 const DEFAULT_NB_IMAGE_MODEL = "gemini-3-pro-image-preview";
+const MINIMAX_H3_MODE_OPTIONS = [
+  { value: "text_to_video", label: "Text to Video" },
+  { value: "image_to_video", label: "Image to Video" },
+  { value: "reference_to_video", label: "Reference to Video" },
+  { value: "video_to_video", label: "Video to Video" },
+];
+const MINIMAX_H3_INSTRUCTION_KEYS = {
+  text_to_video: "minimax_h3_text_to_video",
+  image_to_video: "minimax_h3_image_to_video",
+  reference_to_video: "minimax_h3_reference_to_video",
+  video_to_video: "minimax_h3_video_to_video",
+};
+const MINIMAX_H3_VIDEO_REFERENCE_PURPOSES = [
+  { value: "continuation", label: "Continuation / Extension" },
+  { value: "movement", label: "Movement Guide" },
+  { value: "camera", label: "Camera Guide" },
+  { value: "edit_rhythm", label: "Edit / Rhythm Guide" },
+  { value: "transformation", label: "Transformation Source" },
+  { value: "visual_style", label: "Visual Style Guide" },
+];
+const DEFAULT_MINIMAX_H3_SETTINGS = {
+  diffusion_model_name: "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
+  clip_name: "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+  video_vae_name: "minimax_h3_video_vae_fp16.safetensors",
+  audio_vae_name: "minimax_h3_audio_vae_fp32.safetensors",
+  aspect_ratio: "16:9 (Widescreen)",
+  megapixels: 0.9,
+  seed: 69,
+  warmup_frames: 0,
+  cooldown_frames: 0,
+  sampler_name: "res_multistep",
+  scheduler: "simple",
+  steps: 20,
+  denoise: 1,
+  easy_cache_bypass: false,
+  easy_cache_reuse_threshold: 0.3,
+  easy_cache_start_percent: 0.2,
+  easy_cache_end_percent: 0.9,
+  easy_cache_verbose: false,
+  sage_attention: "auto",
+  enable_fp16_accumulation: true,
+};
+
+const MINIMAX_H3_SAGE_ATTENTION_OPTIONS = [
+  { value: "disabled", label: "Disabled" },
+  { value: "auto", label: "Auto" },
+  { value: "sageattn_qk_int8_pv_fp16_cuda", label: "SageAttention 2 — FP16 CUDA" },
+  { value: "sageattn_qk_int8_pv_fp16_triton", label: "SageAttention 2 — FP16 Triton" },
+  { value: "sageattn_qk_int8_pv_fp8_cuda", label: "SageAttention 2 — FP8 CUDA" },
+  { value: "sageattn_qk_int8_pv_fp8_cuda++", label: "SageAttention 2 — FP8 CUDA++" },
+  { value: "sageattn3", label: "SageAttention 3" },
+  { value: "sageattn3_per_block_mean", label: "SageAttention 3 — Per-block mean" },
+];
+
+function normalizeMiniMaxH3Mode(value) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return MINIMAX_H3_MODE_OPTIONS.some((item) => item.value === clean) ? clean : "text_to_video";
+}
+
+function miniMaxH3ModeLabel(value) {
+  const mode = normalizeMiniMaxH3Mode(value);
+  return MINIMAX_H3_MODE_OPTIONS.find((item) => item.value === mode)?.label || "Text to Video";
+}
+
+function miniMaxH3InstructionKey(value) {
+  return MINIMAX_H3_INSTRUCTION_KEYS[normalizeMiniMaxH3Mode(value)] || MINIMAX_H3_INSTRUCTION_KEYS.text_to_video;
+}
+
+function normalizeMiniMaxH3VideoPurpose(value) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return MINIMAX_H3_VIDEO_REFERENCE_PURPOSES.some((item) => item.value === clean) ? clean : "continuation";
+}
+
+function cloneMiniMaxH3Settings(value = {}) {
+  const source = value && typeof value === "object" ? value : {};
+  return {
+    ...DEFAULT_MINIMAX_H3_SETTINGS,
+    ...source,
+    diffusion_model_name: String(source.diffusion_model_name || DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name),
+    clip_name: String(source.clip_name || DEFAULT_MINIMAX_H3_SETTINGS.clip_name),
+    video_vae_name: String(source.video_vae_name || DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name),
+    audio_vae_name: String(source.audio_vae_name || DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name),
+    aspect_ratio: String(source.aspect_ratio || DEFAULT_MINIMAX_H3_SETTINGS.aspect_ratio),
+    megapixels: Math.max(0.1, Number(source.megapixels ?? DEFAULT_MINIMAX_H3_SETTINGS.megapixels)),
+    seed: Number.isFinite(Number(source.seed)) ? Number(source.seed) : DEFAULT_MINIMAX_H3_SETTINGS.seed,
+    warmup_frames: Math.max(0, Math.trunc(Number(source.warmup_frames || 0))),
+    cooldown_frames: Math.max(0, Math.trunc(Number(source.cooldown_frames || 0))),
+    sampler_name: String(source.sampler_name || DEFAULT_MINIMAX_H3_SETTINGS.sampler_name),
+    scheduler: String(source.scheduler || DEFAULT_MINIMAX_H3_SETTINGS.scheduler),
+    steps: Math.max(1, Math.min(1000, Math.trunc(Number(source.steps ?? DEFAULT_MINIMAX_H3_SETTINGS.steps) || DEFAULT_MINIMAX_H3_SETTINGS.steps))),
+    denoise: Math.max(0, Math.min(1, Number(source.denoise ?? DEFAULT_MINIMAX_H3_SETTINGS.denoise))),
+    easy_cache_bypass: Boolean(source.easy_cache_bypass ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_bypass),
+    easy_cache_reuse_threshold: Math.max(0, Math.min(1, Number(source.easy_cache_reuse_threshold ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_reuse_threshold))),
+    easy_cache_start_percent: Math.max(0, Math.min(1, Number(source.easy_cache_start_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_start_percent))),
+    easy_cache_end_percent: Math.max(0, Math.min(1, Number(source.easy_cache_end_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_end_percent))),
+    easy_cache_verbose: Boolean(source.easy_cache_verbose ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_verbose),
+    sage_attention: MINIMAX_H3_SAGE_ATTENTION_OPTIONS.some((item) => item.value === source.sage_attention)
+      ? source.sage_attention
+      : DEFAULT_MINIMAX_H3_SETTINGS.sage_attention,
+    enable_fp16_accumulation: Boolean(source.enable_fp16_accumulation ?? DEFAULT_MINIMAX_H3_SETTINGS.enable_fp16_accumulation),
+  };
+}
 const LTX_MODEL_DOWNLOADS = [
   { label: "LTX GGUF", url: "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF/tree/main" },
   { label: "Video VAE", url: "https://huggingface.co/Kijai/LTX2.3_comfy/tree/main/vae" },
@@ -460,6 +562,10 @@ function normalizeVideoType(value) {
   if (["speaking", "short_film", "dialogue", "dialog"].includes(text)) return "speaking";
   if (["no_lip_sync", "nolipsync", "no_lipsync", "no_sync", "silent", "visual_only"].includes(text)) return "no_lip_sync";
   return "singing";
+}
+
+function normalizeProjectVideoEngine(value) {
+  return String(value || "").trim().toLowerCase() === "minimax_h3" ? "minimax_h3" : "ltx";
 }
 
 function makeVideoTypeSelect(value = "singing") {
@@ -1798,6 +1904,12 @@ function audioUrl(path) {
     enhance_prompt: "",
     i2v_prompt: "",
     i2v_prompt_origin: "manual",
+    minimax_h3_mode: "text_to_video",
+    minimax_h3_prompt: "",
+    minimax_h3_prompt_origin: "manual",
+    minimax_h3_reference_keys: null,
+    minimax_h3_use_scene_image_as_start_frame: false,
+    minimax_h3_video_references: [],
     ref_image_path: "",
     use_vision_reference: false,
     use_i2v_vision_reference: true,
@@ -1898,6 +2010,7 @@ function normalizeNotificationSettings(settings = {}) {
 }
 
 function openBuilder(node) {
+  setBuilderAutomaticMemoryCleanupEnabled(false);
   console.log(`[VRGDG Music Builder] UI version ${BUILDER_UI_VERSION}`);
   const overlay = document.createElement("div");
   let builderKeydownHandler = null;
@@ -3967,6 +4080,14 @@ function openBuilder(node) {
   const createSceneVideoButton = makeButton("Create Scene Video", "primary");
   const createSceneVideoButtons = [createSceneVideoButton];
   const gemmaThenCreateVideoButtons = [];
+  const miniMaxSceneVideoButton = makeButton("Create MiniMax H3 Scene Video", "primary");
+  miniMaxSceneVideoButton.title = "Render this scene with the MiniMax H3 hidden workflow and preserve the exact timeline duration.";
+  const miniMaxSceneVideoButtons = [miniMaxSceneVideoButton];
+  const miniMaxReferencesButton = makeButton("Choose MiniMax References (0/9)");
+  miniMaxReferencesButton.title = "Choose and order up to nine images from the existing Reference Builder for this scene.";
+  const miniMaxVideoReferencesButton = makeButton("Choose MiniMax Edit References (0/9)");
+  miniMaxVideoReferencesButton.title = "Choose character, location, background, prop, or style images to use alongside the Video to Video source.";
+  const miniMaxReferenceButtons = [miniMaxReferencesButton, miniMaxVideoReferencesButton];
   function wrapCreateSceneVideoActions(button) {
     const quickButton = makeButton("✨▶", "primary");
     quickButton.title = "Run Gemma for the current video mode, then immediately create the scene video without stopping for prompt review.";
@@ -4512,6 +4633,230 @@ function openBuilder(node) {
     idLoraIdentityGrid,
   ]);
   idLoraVoiceSettingsSection.style.display = "none";
+
+  const miniMaxEnginePanel = document.createElement("div");
+  miniMaxEnginePanel.style.cssText = "display:none;flex-direction:column;gap:10px;";
+  const miniMaxBanner = document.createElement("div");
+  miniMaxBanner.innerHTML = `<div style="font-size:14px;font-weight:900;color:#cffafe;">MiniMax H3 Project</div><div style="font-size:11px;color:#a5f3fc;margin-top:3px;">Choose the input mode independently for each scene. This panel uses only the MiniMax hidden workflow.</div>`;
+  miniMaxBanner.style.cssText = "border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;";
+  const miniMaxModeChooser = document.createElement("div");
+  miniMaxModeChooser.style.cssText = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px;";
+  const miniMaxModeButtons = MINIMAX_H3_MODE_OPTIONS.map((item) => {
+    const button = makeButton(item.label);
+    button.dataset.minimaxH3Mode = item.value;
+    miniMaxModeChooser.append(button);
+    return button;
+  });
+  const miniMaxDiffusionModelPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name);
+  const miniMaxClipPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.clip_name);
+  const miniMaxVideoVaePicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name);
+  const miniMaxAudioVaePicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name);
+  const miniMaxNoGgufNote = document.createElement("div");
+  miniMaxNoGgufNote.textContent = "MiniMax H3 currently uses the standard diffusion-model loader. GGUF is not enabled yet.";
+  miniMaxNoGgufNote.style.cssText = "font-size:11px;color:#fcd34d;line-height:1.4;";
+  const miniMaxAspectRatio = makeSelect([
+    "16:9 (Widescreen)",
+    "9:16 (Portrait Widescreen)",
+    "1:1 (Square)",
+    "2:3 (Portrait Photo)",
+    "3:2 (Photo)",
+    "4:3 (Standard)",
+    "3:4 (Portrait Standard)",
+    "21:9 (Ultrawide)",
+  ], DEFAULT_MINIMAX_H3_SETTINGS.aspect_ratio);
+  const miniMaxMegapixels = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.megapixels), "number");
+  miniMaxMegapixels.min = "0.1";
+  miniMaxMegapixels.max = "16";
+  miniMaxMegapixels.step = "0.1";
+  const miniMaxSeed = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.seed), "number");
+  miniMaxSeed.step = "1";
+  const miniMaxWarmupFrames = makeInput("0", "number");
+  miniMaxWarmupFrames.min = "0";
+  miniMaxWarmupFrames.step = "1";
+  const miniMaxCooldownFrames = makeInput("0", "number");
+  miniMaxCooldownFrames.min = "0";
+  miniMaxCooldownFrames.step = "1";
+  const miniMaxRenderSettingsGrid = document.createElement("div");
+  miniMaxRenderSettingsGrid.style.cssText = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;";
+  miniMaxRenderSettingsGrid.append(
+    makeField("Aspect ratio", miniMaxAspectRatio),
+    makeField("Megapixels", miniMaxMegapixels),
+    makeField("Seed", miniMaxSeed),
+    makeField("Warmup frames", miniMaxWarmupFrames),
+    makeField("Cooldown frames", miniMaxCooldownFrames),
+  );
+  const miniMaxSamplerName = makeSelect([
+    "res_multistep",
+    "euler",
+    "euler_ancestral",
+    "heun",
+    "dpmpp_2m",
+    "dpmpp_2m_sde",
+    "dpmpp_3m_sde",
+    "uni_pc",
+    "deis",
+  ], DEFAULT_MINIMAX_H3_SETTINGS.sampler_name);
+  const miniMaxScheduler = makeSelect([
+    "simple",
+    "normal",
+    "karras",
+    "exponential",
+    "sgm_uniform",
+    "ddim_uniform",
+    "beta",
+    "linear_quadratic",
+    "kl_optimal",
+  ], DEFAULT_MINIMAX_H3_SETTINGS.scheduler);
+  const miniMaxSteps = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.steps), "number");
+  miniMaxSteps.min = "1";
+  miniMaxSteps.max = "1000";
+  miniMaxSteps.step = "1";
+  const miniMaxDenoise = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.denoise), "number");
+  miniMaxDenoise.min = "0";
+  miniMaxDenoise.max = "1";
+  miniMaxDenoise.step = "0.01";
+  const miniMaxEasyCacheBypass = makeCheckbox("Bypass EasyCache", DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_bypass);
+  const miniMaxEasyCacheReuseThreshold = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_reuse_threshold), "number");
+  miniMaxEasyCacheReuseThreshold.min = "0";
+  miniMaxEasyCacheReuseThreshold.max = "1";
+  miniMaxEasyCacheReuseThreshold.step = "0.01";
+  const miniMaxEasyCacheStartPercent = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_start_percent), "number");
+  miniMaxEasyCacheStartPercent.min = "0";
+  miniMaxEasyCacheStartPercent.max = "1";
+  miniMaxEasyCacheStartPercent.step = "0.01";
+  const miniMaxEasyCacheEndPercent = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_end_percent), "number");
+  miniMaxEasyCacheEndPercent.min = "0";
+  miniMaxEasyCacheEndPercent.max = "1";
+  miniMaxEasyCacheEndPercent.step = "0.01";
+  const miniMaxEasyCacheVerbose = makeCheckbox("Verbose EasyCache logging", DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_verbose);
+  const miniMaxSageAttention = makeSelect(MINIMAX_H3_SAGE_ATTENTION_OPTIONS, DEFAULT_MINIMAX_H3_SETTINGS.sage_attention);
+  const miniMaxFp16Accumulation = makeCheckbox("Enable fp16 accumulation", DEFAULT_MINIMAX_H3_SETTINGS.enable_fp16_accumulation);
+  const miniMaxEasyCacheNote = document.createElement("div");
+  miniMaxEasyCacheNote.textContent = "Bypass sends the diffusion model directly to the scheduler and removes EasyCache from the queued workflow copy.";
+  miniMaxEasyCacheNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const miniMaxAdvancedSettings = makeSettingsSection("Advanced Settings", [
+    makeSettingsSection("Sampler", [
+      makeField("Sampler", miniMaxSamplerName),
+      makeField("Scheduler", miniMaxScheduler),
+      makeField("Steps", miniMaxSteps),
+      makeField("Denoise", miniMaxDenoise),
+    ]),
+    makeSettingsSection("EasyCache", [
+      miniMaxEasyCacheBypass.wrapper,
+      miniMaxEasyCacheNote,
+      makeField("Reuse threshold", miniMaxEasyCacheReuseThreshold),
+      makeField("Start percent", miniMaxEasyCacheStartPercent),
+      makeField("End percent", miniMaxEasyCacheEndPercent),
+      miniMaxEasyCacheVerbose.wrapper,
+    ]),
+    makeSettingsSection("Model Loader", [
+      makeField("Sage Attention", miniMaxSageAttention),
+      miniMaxFp16Accumulation.wrapper,
+    ]),
+  ], false);
+  const miniMaxTextModePanel = makeSettingsPanel([]);
+  const miniMaxTextModeNote = document.createElement("div");
+  miniMaxTextModeNote.textContent = "Text to Video sends no image or video references. The scene prompt and custom/project audio drive the shot.";
+  miniMaxTextModeNote.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;";
+  miniMaxTextModePanel.append(miniMaxTextModeNote);
+  const miniMaxImageModePanel = makeSettingsPanel([]);
+  const miniMaxImageModeSource = document.createElement("div");
+  miniMaxImageModeSource.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;overflow-wrap:anywhere;";
+  miniMaxImageModePanel.append(miniMaxImageModeSource);
+  const miniMaxReferenceModePanel = makeSettingsPanel([]);
+  const miniMaxReferenceModeNote = document.createElement("div");
+  miniMaxReferenceModeNote.textContent = "Uses ordered character, location, ingredients-sheet, or storyboard-grid images. Add and map the library from the existing Reference Builder button at the top of the Builder.";
+  miniMaxReferenceModeNote.style.cssText = miniMaxTextModeNote.style.cssText;
+  const miniMaxUseSceneImageAsStartFrame = makeCheckbox("Use scene image as exact start frame", false);
+  miniMaxUseSceneImageAsStartFrame.wrapper.title = "Prepends this scene's selected timeline image as Image 1. Character, location, and storyboard references follow in their saved order.";
+  const miniMaxStartFrameReferenceNote = document.createElement("div");
+  miniMaxStartFrameReferenceNote.textContent = "When enabled, Image 1 locks the exact opening composition. Character and location references begin at Image 2 and preserve identity or environment details that are not visible in the start frame.";
+  miniMaxStartFrameReferenceNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  miniMaxReferenceModePanel.append(miniMaxReferenceModeNote, miniMaxUseSceneImageAsStartFrame.wrapper, miniMaxStartFrameReferenceNote, miniMaxReferencesButton);
+  const miniMaxVideoModePanel = makeSettingsPanel([]);
+  const miniMaxVideoModeNote = document.createElement("div");
+  miniMaxVideoModeNote.textContent = "Add up to three source/reference videos. You can also choose ordered Reference Builder images to replace or preserve people, backgrounds, locations, props, or visual style during the edit.";
+  miniMaxVideoModeNote.style.cssText = miniMaxTextModeNote.style.cssText;
+  const miniMaxVideoReferenceRows = [];
+  for (let index = 0; index < 3; index += 1) {
+    const path = makeInput("");
+    path.placeholder = `Reference video ${index + 1} full path...`;
+    const start = makeInput("0", "number");
+    start.min = "0";
+    start.step = "0.01";
+    const duration = makeInput("0", "number");
+    duration.min = "0";
+    duration.step = "0.01";
+    const purpose = makeSelect(MINIMAX_H3_VIDEO_REFERENCE_PURPOSES, index === 0 ? "continuation" : "movement");
+    const useAudio = makeCheckbox("Use video audio", false);
+    const timing = document.createElement("div");
+    timing.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:7px;";
+    timing.append(makeField("Start seconds", start), makeField("Duration (0 = auto)", duration));
+    const row = makeSettingsSection(`Reference Video ${index + 1}`, [
+      makeField("Video path", path),
+      makeField("Reference purpose", purpose),
+      timing,
+      useAudio.wrapper,
+    ], index === 0);
+    miniMaxVideoReferenceRows.push({ path, start, duration, purpose, useAudio });
+    miniMaxVideoModePanel.append(row);
+  }
+  const miniMaxUseCurrentSceneVideoButton = makeButton("Use Current Scene Video as Reference 1");
+  miniMaxVideoModePanel.prepend(miniMaxVideoModeNote, miniMaxVideoReferencesButton, miniMaxUseCurrentSceneVideoButton);
+  const miniMaxModePanels = {
+    text_to_video: miniMaxTextModePanel,
+    image_to_video: miniMaxImageModePanel,
+    reference_to_video: miniMaxReferenceModePanel,
+    video_to_video: miniMaxVideoModePanel,
+  };
+  const miniMaxPrompt = document.createElement("textarea");
+  miniMaxPrompt.placeholder = "MiniMax H3 scene prompt...";
+  miniMaxPrompt.style.cssText = "min-height:190px;resize:vertical;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:9px;font-size:12px;line-height:1.4;";
+  ["keydown", "keypress", "keyup"].forEach((eventName) => miniMaxPrompt.addEventListener(eventName, (event) => event.stopPropagation()));
+  const miniMaxPromptActions = document.createElement("div");
+  miniMaxPromptActions.style.cssText = "display:grid;grid-template-columns:minmax(0,1.35fr) minmax(0,1fr);gap:8px;";
+  const miniMaxCreatePromptButton = makeButton("Create MiniMax H3 Prompt", "primary");
+  const miniMaxEditInstructionsButton = makeButton("Edit Text to Video Instructions");
+  miniMaxPromptActions.append(miniMaxCreatePromptButton, miniMaxEditInstructionsButton);
+  const miniMaxPromptRunnerNote = document.createElement("div");
+  miniMaxPromptRunnerNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const miniMaxAudioNote = document.createElement("div");
+  miniMaxAudioNote.textContent = "The current hidden workflow requires custom scene audio or project audio. Built-in MiniMax audio will be added with a separate workflow later.";
+  miniMaxAudioNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const miniMaxSubTabs = makeSubTabs([
+    {
+      label: "Models",
+      value: "models",
+      content: makeSettingsPanel([
+        miniMaxNoGgufNote,
+        makeField("Diffusion model", miniMaxDiffusionModelPicker.wrapper),
+        makeField("Text encoder / CLIP", miniMaxClipPicker.wrapper),
+        makeField("Video VAE", miniMaxVideoVaePicker.wrapper),
+        makeField("Audio VAE", miniMaxAudioVaePicker.wrapper),
+      ]),
+    },
+    {
+      label: "Video Settings",
+      value: "input",
+      content: makeSettingsPanel([
+        ...Object.values(miniMaxModePanels),
+        makeSettingsSection("Render Settings", [miniMaxRenderSettingsGrid]),
+        miniMaxAdvancedSettings,
+        miniMaxAudioNote,
+      ]),
+    },
+    {
+      label: "Prompt",
+      value: "prompt",
+      content: makeSettingsPanel([
+        miniMaxPromptRunnerNote,
+        miniMaxPromptActions,
+        makeField("MiniMax H3 prompt", miniMaxPrompt),
+      ]),
+    },
+  ]);
+  miniMaxEnginePanel.append(miniMaxBanner, miniMaxModeChooser, miniMaxSubTabs.wrapper, miniMaxSceneVideoButton);
+
   const videoSubTabs = makeSubTabs([
     {
       label: "Models",
@@ -4594,7 +4939,10 @@ function openBuilder(node) {
       ]),
     },
   ]);
-  videoPanel.append(videoModeChooser, importCustomVideoPanel, videoSubTabs.wrapper);
+  const ltxVideoPanel = document.createElement("div");
+  ltxVideoPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;";
+  ltxVideoPanel.append(videoModeChooser, importCustomVideoPanel, videoSubTabs.wrapper);
+  videoPanel.append(ltxVideoPanel, miniMaxEnginePanel);
   audioPanel.append(
     makeSettingsSection("Scene Audio", [
       audioSummary,
@@ -5249,6 +5597,8 @@ function openBuilder(node) {
     customModelsRoot: "",
     notificationSettings: defaultNotificationSettings(),
     videoType: "singing",
+    projectVideoEngine: "ltx",
+    miniMaxH3Settings: cloneMiniMaxH3Settings(),
     imageModelMode: "zimage",
     zimageSettings: defaultZImageSettings(),
     referenceKrea2Settings: { ...DEFAULT_KREA2_REFERENCE_SETTINGS },
@@ -5297,6 +5647,146 @@ function openBuilder(node) {
     isRestoringHistory: false,
     batchCancelled: false,
   };
+
+  function syncProjectVideoEngineUI() {
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    ltxVideoPanel.style.display = miniMaxProject ? "none" : "flex";
+    miniMaxEnginePanel.style.display = miniMaxProject ? "flex" : "none";
+    syncMiniMaxH3Panel();
+  }
+
+  function syncMiniMaxReferenceButtons() {
+    const segment = activeSegment();
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    if (!miniMaxProject) {
+      for (const button of miniMaxReferenceButtons) {
+        button.textContent = button === miniMaxVideoReferencesButton
+          ? "Choose MiniMax Edit References (0/9)"
+          : "Choose MiniMax References (0/9)";
+        button.disabled = true;
+      }
+      return;
+    }
+    const libraryCount = segment && typeof miniMaxReferenceKeysForSegment === "function"
+      ? miniMaxReferenceKeysForSegment(segment).length
+      : 0;
+    const orderedCount = segment && typeof miniMaxOrderedImageReferenceItemsForSegment === "function"
+      ? miniMaxOrderedImageReferenceItemsForSegment(segment, segment.minimax_h3_mode).length
+      : libraryCount;
+    const hasStartFrame = Boolean(
+      segment?.minimax_h3_use_scene_image_as_start_frame
+      && normalizeMiniMaxH3Mode(segment?.minimax_h3_mode) === "reference_to_video"
+      && (segmentImageSource(segment)?.path || segmentImageSource(segment)?.data)
+    );
+    for (const button of miniMaxReferenceButtons) {
+      button.textContent = button === miniMaxVideoReferencesButton
+        ? `Choose MiniMax Edit References (${orderedCount}/9)`
+        : hasStartFrame
+          ? `Choose MiniMax References (${orderedCount}/9 — start + ${Math.max(0, orderedCount - 1)})`
+          : `Choose MiniMax References (${libraryCount}/9)`;
+      button.disabled = !segment;
+    }
+  }
+
+  function saveMiniMaxH3SettingsFromPanel() {
+    state.miniMaxH3Settings = cloneMiniMaxH3Settings({
+      diffusion_model_name: miniMaxDiffusionModelPicker.input.value,
+      clip_name: miniMaxClipPicker.input.value,
+      video_vae_name: miniMaxVideoVaePicker.input.value,
+      audio_vae_name: miniMaxAudioVaePicker.input.value,
+      aspect_ratio: miniMaxAspectRatio.value,
+      megapixels: miniMaxMegapixels.value,
+      seed: miniMaxSeed.value,
+      warmup_frames: miniMaxWarmupFrames.value,
+      cooldown_frames: miniMaxCooldownFrames.value,
+      sampler_name: miniMaxSamplerName.value,
+      scheduler: miniMaxScheduler.value,
+      steps: miniMaxSteps.value,
+      denoise: miniMaxDenoise.value,
+      easy_cache_bypass: miniMaxEasyCacheBypass.input.checked,
+      easy_cache_reuse_threshold: miniMaxEasyCacheReuseThreshold.value,
+      easy_cache_start_percent: miniMaxEasyCacheStartPercent.value,
+      easy_cache_end_percent: miniMaxEasyCacheEndPercent.value,
+      easy_cache_verbose: miniMaxEasyCacheVerbose.input.checked,
+      sage_attention: miniMaxSageAttention.value,
+      enable_fp16_accumulation: miniMaxFp16Accumulation.input.checked,
+    });
+  }
+
+  function saveMiniMaxSceneInputsFromPanel() {
+    const segment = activeSegment();
+    if (!segment) return;
+    segment.minimax_h3_prompt = miniMaxPrompt.value || "";
+    segment.minimax_h3_use_scene_image_as_start_frame = Boolean(miniMaxUseSceneImageAsStartFrame.input.checked);
+    segment.minimax_h3_video_references = miniMaxVideoReferenceRows
+      .map((row) => ({
+        path: String(row.path.value || "").trim(),
+        start_seconds: Math.max(0, Number(row.start.value || 0)),
+        duration: Math.max(0, Number(row.duration.value || 0)),
+        purpose: normalizeMiniMaxH3VideoPurpose(row.purpose.value),
+        use_audio: Boolean(row.useAudio.input.checked),
+      }))
+      .filter((item) => item.path)
+      .slice(0, 3);
+  }
+
+  function syncMiniMaxH3Panel() {
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    const segment = activeSegment();
+    const settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    state.miniMaxH3Settings = settings;
+    miniMaxDiffusionModelPicker.input.value = settings.diffusion_model_name;
+    miniMaxClipPicker.input.value = settings.clip_name;
+    miniMaxVideoVaePicker.input.value = settings.video_vae_name;
+    miniMaxAudioVaePicker.input.value = settings.audio_vae_name;
+    miniMaxAspectRatio.value = settings.aspect_ratio;
+    miniMaxMegapixels.value = String(settings.megapixels);
+    miniMaxSeed.value = String(settings.seed);
+    miniMaxWarmupFrames.value = String(settings.warmup_frames);
+    miniMaxCooldownFrames.value = String(settings.cooldown_frames);
+    miniMaxSamplerName.value = settings.sampler_name;
+    miniMaxScheduler.value = settings.scheduler;
+    miniMaxSteps.value = String(settings.steps);
+    miniMaxDenoise.value = String(settings.denoise);
+    miniMaxEasyCacheBypass.input.checked = settings.easy_cache_bypass;
+    miniMaxEasyCacheReuseThreshold.value = String(settings.easy_cache_reuse_threshold);
+    miniMaxEasyCacheStartPercent.value = String(settings.easy_cache_start_percent);
+    miniMaxEasyCacheEndPercent.value = String(settings.easy_cache_end_percent);
+    miniMaxEasyCacheVerbose.input.checked = settings.easy_cache_verbose;
+    miniMaxSageAttention.value = settings.sage_attention;
+    miniMaxFp16Accumulation.input.checked = settings.enable_fp16_accumulation;
+    const mode = normalizeMiniMaxH3Mode(segment?.minimax_h3_mode);
+    const modeLabel = miniMaxH3ModeLabel(mode);
+    for (const button of miniMaxModeButtons) {
+      const active = button.dataset.minimaxH3Mode === mode;
+      button.style.background = active ? "#06b6d4" : "#27272a";
+      button.style.borderColor = active ? "#0891b2" : "#3f3f46";
+      button.style.color = active ? "#082f49" : "#f4f4f5";
+    }
+    for (const [panelMode, panel] of Object.entries(miniMaxModePanels)) {
+      panel.style.display = panelMode === mode ? "flex" : "none";
+    }
+    miniMaxPrompt.value = String(segment?.minimax_h3_prompt || segment?.i2v_prompt || "");
+    miniMaxCreatePromptButton.textContent = `Create MiniMax ${modeLabel} Prompt`;
+    miniMaxEditInstructionsButton.textContent = `Edit ${modeLabel} Instructions`;
+    miniMaxPromptRunnerNote.textContent = `Uses the existing ${gemmaRunnerLabel()} selection from LLM Runner. The result is saved only as this scene's MiniMax H3 prompt.`;
+    miniMaxUseSceneImageAsStartFrame.input.checked = Boolean(segment?.minimax_h3_use_scene_image_as_start_frame);
+    const imagePath = String(segment ? selectedSegmentImagePath(segment) || "" : "").trim();
+    miniMaxImageModeSource.textContent = imagePath
+      ? `Scene image input:\n${imagePath}`
+      : "This scene has no selected timeline image. Add or generate an image before using Image to Video.";
+    const videoReferences = Array.isArray(segment?.minimax_h3_video_references) ? segment.minimax_h3_video_references : [];
+    miniMaxVideoReferenceRows.forEach((row, index) => {
+      const item = videoReferences[index] || {};
+      row.path.value = item.path || "";
+      row.start.value = String(Math.max(0, Number(item.start_seconds || 0)));
+      row.duration.value = String(Math.max(0, Number(item.duration || 0)));
+      row.purpose.value = normalizeMiniMaxH3VideoPurpose(item.purpose || (index === 0 ? "continuation" : "movement"));
+      row.useAudio.input.checked = Boolean(item.use_audio);
+    });
+    miniMaxSceneVideoButton.disabled = !miniMaxProject || !segment;
+    syncMiniMaxReferenceButtons();
+  }
 
   function normalizeRenderLog(raw) {
     const value = raw && typeof raw === "object" ? raw : {};
@@ -8287,6 +8777,24 @@ function openBuilder(node) {
     if (segment.timeline_note == null) segment.timeline_note = "";
     if (segment.i2v_notes == null) segment.i2v_notes = "";
     segment.i2v_prompt_origin = normalizeVideoPromptOrigin(segment.i2v_prompt_origin);
+    segment.minimax_h3_mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    if (segment.minimax_h3_prompt == null) segment.minimax_h3_prompt = "";
+    segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(segment.minimax_h3_prompt_origin);
+    if (segment.minimax_h3_reference_keys != null) {
+      segment.minimax_h3_reference_keys = Array.isArray(segment.minimax_h3_reference_keys)
+        ? segment.minimax_h3_reference_keys.map((key) => String(key || "").trim()).filter(Boolean).slice(0, 9)
+        : null;
+    }
+    segment.minimax_h3_use_scene_image_as_start_frame = Boolean(segment.minimax_h3_use_scene_image_as_start_frame);
+    segment.minimax_h3_video_references = (Array.isArray(segment.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
+      .slice(0, 3)
+      .map((item) => ({
+        path: String(item?.path || "").trim(),
+        start_seconds: Math.max(0, Number(item?.start_seconds || 0)),
+        duration: Math.max(0, Number(item?.duration || 0)),
+        purpose: normalizeMiniMaxH3VideoPurpose(item?.purpose),
+        use_audio: Boolean(item?.use_audio),
+      }));
     if (!["global", "auto", "smooth", "morph"].includes(String(segment.flf_transition_type || ""))) segment.flf_transition_type = "global";
     if (segment.id == null || !String(segment.id).trim()) segment.id = createUniqueSegmentId();
     if (!Array.isArray(segment.image_history)) segment.image_history = [];
@@ -12140,7 +12648,7 @@ function openBuilder(node) {
     const segment = activeSegment();
     startInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
     const disabled = !segment;
-    for (const control of [labelInput, startInput, endInput, notesInput, ernieNotesInput, krea2TwoPassNotesInput, nbNotes, lyricTextInput, lyricSingersInput, i2vNotesInput, t2iPrompt, ernieT2IPrompt, krea2TwoPassT2IPrompt, nbPrompt, i2vPrompt, zEnhanceGemmaNotes, zEnhancePromptPreview, previewButton, ernieCreateButton, previewNBButton, deleteSegmentButton, createSceneVideoButton]) {
+    for (const control of [labelInput, startInput, endInput, notesInput, ernieNotesInput, krea2TwoPassNotesInput, nbNotes, lyricTextInput, lyricSingersInput, i2vNotesInput, t2iPrompt, ernieT2IPrompt, krea2TwoPassT2IPrompt, nbPrompt, i2vPrompt, zEnhanceGemmaNotes, zEnhancePromptPreview, previewButton, ernieCreateButton, previewNBButton, deleteSegmentButton, createSceneVideoButton, miniMaxSceneVideoButtons[0]]) {
       control.disabled = disabled;
     }
     loadCustomImageButton.disabled = disabled;
@@ -12264,6 +12772,7 @@ function openBuilder(node) {
     syncKrea2TwoPassPanel();
     syncZEnhanceSettingsPanel();
     syncVideoModePanel();
+    syncMiniMaxH3Panel();
     syncPreview(segment);
     updateAudioScrubbers();
   }
@@ -13239,6 +13748,280 @@ function openBuilder(node) {
       image: normalizedRefs.subject?.image || normalizedRefs.subjects?.[0]?.image || {},
     };
     return referenceBuilderSubjectHasImage(subject) || String(subject.name || subject.description || "").trim() ? [subject] : [];
+  }
+
+  function miniMaxReferenceBuilderCatalog(refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder)) {
+    const normalizedRefs = normalizeFluxReferenceBuilder(refs);
+    const catalog = [];
+    const add = (kind, item, fallbackLabel) => {
+      const id = String(item?.id || "").trim();
+      const image = item?.image && typeof item.image === "object" ? item.image : {};
+      if (!id || (!String(image.path || "").trim() && !String(image.data || "").trim())) return;
+      catalog.push({
+        key: `${kind}:${id}`,
+        kind,
+        label: String(item?.name || fallbackLabel || "Reference").trim() || "Reference",
+        description: String(item?.description || "").trim(),
+        image,
+      });
+    };
+    for (const subject of normalizedRefs.subjects || []) add("subject", subject, "Character reference");
+    for (const location of normalizedRefs.locations || []) add("location", location, "Location reference");
+    for (const sheet of normalizedRefs.ingredients_sheets || []) add("ingredients", sheet, "Ingredients sheet");
+    return catalog;
+  }
+
+  function miniMaxMappedReferenceKeysForSegment(segment, refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder)) {
+    if (!segment) return [];
+    const normalizedRefs = normalizeFluxReferenceBuilder(refs);
+    const catalogKeys = new Set(miniMaxReferenceBuilderCatalog(normalizedRefs).map((item) => item.key));
+    const keys = [];
+    const add = (key) => {
+      const clean = String(key || "").trim();
+      if (clean && catalogKeys.has(clean) && !keys.includes(clean) && keys.length < 9) keys.push(clean);
+    };
+    if (!segment.no_character_present) {
+      for (const subject of referenceBuilderSubjectItemsForSegment(normalizedRefs, segment)) {
+        add(`subject:${String(subject?.id || "").trim()}`);
+      }
+    }
+    const locationId = String(sceneReferenceMapValue(normalizedRefs.scene_map, segment) || "").trim();
+    if (locationId) add(`location:${locationId}`);
+    const sheetId = String(normalizedRefs.ingredients_scene_map?.[segment.id] || "").trim();
+    if (sheetId) add(`ingredients:${sheetId}`);
+    return keys;
+  }
+
+  function miniMaxReferenceKeysForSegment(segment, refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder)) {
+    if (!segment) return [];
+    const catalogKeys = new Set(miniMaxReferenceBuilderCatalog(refs).map((item) => item.key));
+    const source = Array.isArray(segment.minimax_h3_reference_keys)
+      ? segment.minimax_h3_reference_keys
+      : miniMaxMappedReferenceKeysForSegment(segment, refs);
+    const seen = new Set();
+    return source
+      .map((key) => String(key || "").trim())
+      .filter((key) => key && catalogKeys.has(key) && !seen.has(key) && seen.add(key))
+      .slice(0, 9);
+  }
+
+  function miniMaxReferenceBuilderImagePathsForSegment(segment, mode = segment?.minimax_h3_mode) {
+    return miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
+      .map((item) => String(item?.image?.path || "").trim())
+      .filter(Boolean)
+      .slice(0, 9);
+  }
+
+  function miniMaxPromptReferenceItemsForSegment(segment) {
+    const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+    const byKey = new Map(miniMaxReferenceBuilderCatalog(refs).map((item) => [item.key, item]));
+    return miniMaxReferenceKeysForSegment(segment, refs)
+      .map((key) => byKey.get(key))
+      .filter(Boolean)
+      .slice(0, 9);
+  }
+
+  function miniMaxOrderedImageReferenceItemsForSegment(segment, mode = segment?.minimax_h3_mode) {
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    const ordered = [];
+    if (normalizedMode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+      const startFrame = segmentImageSource(segment);
+      if (startFrame?.path || startFrame?.data) {
+        ordered.push({
+          key: "scene:start_frame",
+          kind: "start_frame",
+          label: "Scene start frame",
+          description: "Exact opening frame, composition, pose, camera angle, environment, and lighting anchor.",
+          image: {
+            path: String(startFrame.path || "").trim(),
+            data: String(startFrame.data || "").trim(),
+            name: String(startFrame.name || "start_frame.png"),
+          },
+        });
+      }
+    }
+    ordered.push(...miniMaxPromptReferenceItemsForSegment(segment));
+    const seen = new Set();
+    return ordered.filter((item) => {
+      const path = String(item?.image?.path || "").trim();
+      const data = String(item?.image?.data || "").trim();
+      const fingerprint = path ? `path:${mediaPathKey(path)}` : data ? `data:${data}` : "";
+      if (!fingerprint || seen.has(fingerprint)) return false;
+      seen.add(fingerprint);
+      return true;
+    }).slice(0, 9);
+  }
+
+  function miniMaxReferencePurposeText(item) {
+    if (item?.kind === "start_frame") return "exact start frame, opening composition, pose, camera angle, environment, and lighting anchor";
+    if (item?.kind === "subject") return "character identity, face, hair, clothing, and body-proportion reference";
+    if (item?.kind === "location") return "environment, location, architecture, layout, and atmosphere reference";
+    if (item?.kind === "ingredients") {
+      const searchable = `${item?.label || ""} ${item?.description || ""}`.toLowerCase();
+      return /storyboard|story board|grid|panel/.test(searchable)
+        ? "storyboard-grid reference whose panels are ordered visual beats"
+        : "ordered ingredients, props, identity, or visual-detail reference";
+    }
+    return "visual reference";
+  }
+
+  function openMiniMaxReferenceSelector() {
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) !== "minimax_h3") {
+      toast("Set this project's Video Engine to MiniMax H3 before choosing MiniMax references.", true);
+      return;
+    }
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+    const catalog = miniMaxReferenceBuilderCatalog(refs);
+    const startFrameReserved = normalizeMiniMaxH3Mode(segment.minimax_h3_mode) === "reference_to_video"
+      && Boolean(segment.minimax_h3_use_scene_image_as_start_frame)
+      && Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
+    const maxLibraryReferences = startFrameReserved ? 8 : 9;
+    let selectedKeys = miniMaxReferenceKeysForSegment(segment, refs).slice(0, maxLibraryReferences);
+    let useAutomaticMappings = !Array.isArray(segment.minimax_h3_reference_keys);
+
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:22px;box-sizing:border-box;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(1100px,calc(100vw - 44px));max-height:calc(100vh - 48px);overflow:hidden;border:1px solid #155e75;border-radius:8px;background:#0b1220;color:#f8fafc;display:flex;flex-direction:column;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:10px;padding:13px 15px;border-bottom:1px solid #155e75;background:#083344;";
+    const heading = document.createElement("div");
+    heading.textContent = `${sceneDisplayName(segment, segmentIndexInfo(segment).index)} — MiniMax H3 References`;
+    heading.style.cssText = "font-size:16px;font-weight:900;color:#cffafe;";
+    const close = makeButton("Cancel");
+    header.append(heading, close);
+    const note = document.createElement("div");
+    note.textContent = startFrameReserved
+      ? "The scene image is reserved as Image 1 and the exact start frame. Choose up to eight additional Reference Builder images; they become Image 2 through Image 9 in the exact order shown."
+      : "Choose up to nine existing Reference Builder images. The numbered order below is the exact order sent into MiniMax H3. Scene character/location mappings are used automatically until you save a custom selection.";
+    note.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;padding:11px 15px;border-bottom:1px solid #1e293b;";
+    const body = document.createElement("div");
+    body.style.cssText = "display:grid;grid-template-columns:minmax(0,1.25fr) minmax(320px,.75fr);gap:12px;padding:12px;overflow:auto;min-height:260px;";
+    const availablePanel = document.createElement("div");
+    const selectedPanel = document.createElement("div");
+    for (const panel of [availablePanel, selectedPanel]) panel.style.cssText = "border:1px solid #334155;border-radius:7px;background:#111827;padding:10px;display:flex;flex-direction:column;gap:9px;min-width:0;";
+    const availableTitle = document.createElement("div");
+    availableTitle.textContent = "Reference Builder Images";
+    availableTitle.style.cssText = "font-size:13px;font-weight:900;color:#a5f3fc;";
+    const selectedTitle = document.createElement("div");
+    selectedTitle.style.cssText = availableTitle.style.cssText;
+    const availableList = document.createElement("div");
+    availableList.style.cssText = "display:grid;grid-template-columns:repeat(auto-fill,minmax(145px,1fr));gap:8px;";
+    const selectedList = document.createElement("div");
+    selectedList.style.cssText = "display:flex;flex-direction:column;gap:7px;";
+    availablePanel.append(availableTitle, availableList);
+    selectedPanel.append(selectedTitle, selectedList);
+    body.append(availablePanel, selectedPanel);
+
+    const referenceThumb = (item) => {
+      const wrap = document.createElement("div");
+      wrap.style.cssText = "height:92px;border:1px solid #334155;border-radius:6px;background:#020617;overflow:hidden;display:flex;align-items:center;justify-content:center;";
+      const img = document.createElement("img");
+      img.alt = item.label || "Reference";
+      img.src = String(item.image?.data || "").trim() || makeEditorImageUrl(item.image?.path || "");
+      img.style.cssText = "width:100%;height:100%;object-fit:cover;";
+      wrap.append(img);
+      return wrap;
+    };
+    const kindLabel = (kind) => ({ subject: "Character", location: "Location", ingredients: "Ingredients" }[kind] || "Reference");
+    const renderLists = () => {
+      selectedKeys = selectedKeys.filter((key, index, list) => catalog.some((item) => item.key === key) && list.indexOf(key) === index).slice(0, maxLibraryReferences);
+      selectedTitle.textContent = `Selected Order (${selectedKeys.length}/${maxLibraryReferences})${startFrameReserved ? " — follows Image 1 start frame" : ""}${useAutomaticMappings ? " — Automatic Scene Mappings" : ""}`;
+      availableList.replaceChildren();
+      selectedList.replaceChildren();
+      if (!catalog.length) {
+        const empty = document.createElement("div");
+        empty.textContent = "No saved character, location, or ingredients-sheet images are available. Open Reference Builder and add images first.";
+        empty.style.cssText = "grid-column:1/-1;border:1px dashed #475569;border-radius:6px;color:#94a3b8;padding:18px;line-height:1.45;";
+        availableList.append(empty);
+      }
+      for (const item of catalog) {
+        const chosen = selectedKeys.includes(item.key);
+        const card = document.createElement("div");
+        card.style.cssText = `border:2px solid ${chosen ? "#0891b2" : "#334155"};border-radius:7px;background:${chosen ? "#083344" : "#0f172a"};padding:7px;display:flex;flex-direction:column;gap:6px;min-width:0;`;
+        card.append(referenceThumb(item));
+        const label = document.createElement("div");
+        label.textContent = item.label;
+        label.title = item.description || item.label;
+        label.style.cssText = "font-size:11px;font-weight:900;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
+        const type = document.createElement("div");
+        type.textContent = kindLabel(item.kind);
+        type.style.cssText = "font-size:10px;color:#94a3b8;text-transform:uppercase;";
+        const add = makeButton(chosen ? "Selected" : "Add");
+        add.disabled = chosen || selectedKeys.length >= maxLibraryReferences;
+        add.onclick = () => { useAutomaticMappings = false; selectedKeys.push(item.key); renderLists(); };
+        card.append(label, type, add);
+        availableList.append(card);
+      }
+      selectedKeys.forEach((key, index) => {
+        const item = catalog.find((entry) => entry.key === key);
+        if (!item) return;
+        const row = document.createElement("div");
+        row.style.cssText = "display:grid;grid-template-columns:34px 52px minmax(0,1fr) auto;gap:7px;align-items:center;border:1px solid #334155;border-radius:6px;background:#0f172a;padding:6px;";
+        const number = document.createElement("div");
+        number.textContent = String(index + 1 + (startFrameReserved ? 1 : 0));
+        number.style.cssText = "font-size:18px;font-weight:900;text-align:center;color:#67e8f9;";
+        const thumb = referenceThumb(item);
+        thumb.style.height = "46px";
+        const label = document.createElement("div");
+        label.innerHTML = `<div style="font-size:11px;font-weight:900;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(item.label)}</div><div style="font-size:9px;color:#94a3b8;text-transform:uppercase;margin-top:3px;">${escapeHtml(kindLabel(item.kind))}</div>`;
+        const controls = document.createElement("div");
+        controls.style.cssText = "display:flex;gap:4px;";
+        const up = makeButton("↑");
+        const down = makeButton("↓");
+        const remove = makeButton("×");
+        up.disabled = index === 0;
+        down.disabled = index === selectedKeys.length - 1;
+        up.onclick = () => { useAutomaticMappings = false; [selectedKeys[index - 1], selectedKeys[index]] = [selectedKeys[index], selectedKeys[index - 1]]; renderLists(); };
+        down.onclick = () => { useAutomaticMappings = false; [selectedKeys[index + 1], selectedKeys[index]] = [selectedKeys[index], selectedKeys[index + 1]]; renderLists(); };
+        remove.onclick = () => { useAutomaticMappings = false; selectedKeys.splice(index, 1); renderLists(); };
+        controls.append(up, down, remove);
+        row.append(number, thumb, label, controls);
+        selectedList.append(row);
+      });
+      if (!selectedKeys.length) {
+        const empty = document.createElement("div");
+        empty.textContent = startFrameReserved
+          ? "The scene start frame remains Image 1. No additional character, location, or storyboard references are selected."
+          : "No Reference Builder images selected.";
+        empty.style.cssText = "border:1px dashed #475569;border-radius:6px;color:#94a3b8;padding:14px;line-height:1.4;";
+        selectedList.append(empty);
+      }
+    };
+
+    const footer = document.createElement("div");
+    footer.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;padding:11px 15px;border-top:1px solid #1e293b;";
+    const utility = document.createElement("div");
+    utility.style.cssText = "display:flex;gap:7px;flex-wrap:wrap;";
+    const mappedDefaults = makeButton("Use Scene Mappings");
+    const clearSelection = makeButton("Clear Selection");
+    const openBuilder = makeButton("Open Reference Builder");
+    mappedDefaults.onclick = () => { useAutomaticMappings = true; selectedKeys = miniMaxMappedReferenceKeysForSegment(segment, refs); renderLists(); };
+    clearSelection.onclick = () => { useAutomaticMappings = false; selectedKeys = []; renderLists(); };
+    openBuilder.onclick = () => { backdrop.remove(); openReferenceBuilderTargetChooser(); };
+    utility.append(mappedDefaults, clearSelection, openBuilder);
+    const save = makeButton("Save MiniMax Reference Order", "primary");
+    save.onclick = async () => {
+      pushHistory();
+      segment.minimax_h3_reference_keys = useAutomaticMappings ? null : selectedKeys.slice(0, maxLibraryReferences);
+      backdrop.remove();
+      syncMiniMaxReferenceButtons();
+      await autoSaveSessionQuiet("MiniMax H3 scene references");
+      const savedCount = miniMaxReferenceKeysForSegment(segment).slice(0, maxLibraryReferences).length;
+      const totalCount = savedCount + (startFrameReserved ? 1 : 0);
+      toast(useAutomaticMappings
+        ? `MiniMax H3 will automatically follow this scene's Reference Builder mappings (${totalCount}/9 images${startFrameReserved ? ", including the start frame" : ""}).`
+        : `Saved ${totalCount} ordered MiniMax H3 image${totalCount === 1 ? "" : "s"}${startFrameReserved ? " including Image 1 as the exact start frame" : ""}.`);
+    };
+    footer.append(utility, save);
+    box.append(header, note, body, footer);
+    backdrop.append(box);
+    document.body.append(backdrop);
+    close.onclick = () => backdrop.remove();
+    backdrop.addEventListener("pointerdown", (event) => { if (event.target === backdrop) backdrop.remove(); });
+    renderLists();
   }
 
   function rtvReferencesForSegment(segment = activeSegment()) {
@@ -22079,8 +22862,20 @@ function openBuilder(node) {
   function openFluxReferenceBuilderModal(options = {}) {
     const wizardLocationMode = Boolean(options?.wizardMode || options?.wizard_location_mode);
     const referenceImagesEnabled = options?.textOnlyMode !== true;
-    const allowExtraSubjectReferences = referenceImagesEnabled && currentVideoMode() === "rtv";
-    const referenceBuilderTargetLabel = !referenceImagesEnabled ? "Gemma scene text mapping" : currentVideoMode() === "rtv" ? "LTX Reference to Video" : currentVideoMode() === "ingredients" ? "LTX Ingredients to Video" : "Gemma scene text mapping";
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    const miniMaxTargetMode = normalizeMiniMaxH3Mode(options?.miniMaxTargetMode || activeSegment()?.minimax_h3_mode);
+    const allowExtraSubjectReferences = referenceImagesEnabled && (currentVideoMode() === "rtv" || (miniMaxProject && ["reference_to_video", "video_to_video"].includes(miniMaxTargetMode)));
+    const referenceBuilderTargetLabel = !referenceImagesEnabled
+      ? "Gemma scene text mapping"
+      : miniMaxProject && miniMaxTargetMode === "video_to_video"
+        ? "MiniMax Video to Video"
+        : miniMaxProject && miniMaxTargetMode === "reference_to_video"
+          ? "MiniMax Reference to Video"
+          : currentVideoMode() === "rtv"
+            ? "LTX Reference to Video"
+            : currentVideoMode() === "ingredients"
+              ? "LTX Ingredients to Video"
+              : "Gemma scene text mapping";
     state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
     const refs = state.fluxReferenceBuilder;
     const backdrop = document.createElement("div");
@@ -22090,7 +22885,14 @@ function openBuilder(node) {
     const header = document.createElement("div");
     header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:12px;";
     const heading = document.createElement("div");
-    heading.innerHTML = `<div style="font-size:16px;font-weight:900;color:#cffafe;">Scene Reference Builder</div><div style="font-size:12px;color:#94a3b8;margin-top:3px;">${referenceImagesEnabled ? "Map character and location descriptions to scenes for Gemma prompt writing. Flux/Nano can also use attached images when those image modes are active." : "Map character and location descriptions to scenes for Gemma prompt writing. This text-only mode does not send reference images."}</div>`;
+    const referenceBuilderDescription = !referenceImagesEnabled
+      ? "Map character and location descriptions to scenes for LLM prompt writing. This text-only mode does not send reference images."
+      : miniMaxProject && miniMaxTargetMode === "video_to_video"
+        ? "Build and map character, background, location, prop, and style images that MiniMax can use alongside the source video for replacements and edits."
+        : miniMaxProject && miniMaxTargetMode === "reference_to_video"
+          ? "Build and map ordered character, location, prop, style, and storyboard images for MiniMax Reference to Video."
+          : "Map character and location descriptions to scenes for Gemma prompt writing. Flux/Nano can also use attached images when those image modes are active.";
+    heading.innerHTML = `<div style="font-size:16px;font-weight:900;color:#cffafe;">Scene Reference Builder</div><div style="font-size:12px;color:#94a3b8;margin-top:3px;">${referenceBuilderDescription}</div>`;
     const close = makeButton("Close");
     header.append(heading, close);
 
@@ -28764,12 +29566,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   function openReferenceBuilderTargetChooser() {
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const backdrop = document.createElement("div");
     backdrop.style.cssText = "position:fixed;inset:0;z-index:100006;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;";
     const box = document.createElement("div");
     box.style.cssText = "width:min(520px,calc(100vw - 32px));border:1px solid #155e75;border-radius:8px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
     const title = document.createElement("div");
-    title.innerHTML = `<div style="font-size:16px;font-weight:900;color:#cffafe;">Reference Builder Target</div><div style="font-size:12px;color:#94a3b8;margin-top:3px;">Choose text scene mapping or an image-reference video workflow.</div>`;
+    title.innerHTML = `<div style="font-size:16px;font-weight:900;color:#cffafe;">Reference Builder Target</div><div style="font-size:12px;color:#94a3b8;margin-top:3px;">${miniMaxProject ? "Choose how these references will be used by MiniMax H3." : "Choose text scene mapping or an image-reference LTX workflow."}</div>`;
     const choices = document.createElement("div");
     choices.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:10px;";
     const choiceCard = (button, description) => {
@@ -28783,21 +29586,41 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     };
     const textMappingButton = makeButton("I2V / T2V Text Mapping", "primary");
     const imageRefsButton = makeButton("Flux / Nano Image References", "primary");
-    const ltxRefsButton = makeButton("LTX Reference to Video", "primary");
+    const ltxRefsButton = makeButton(miniMaxProject ? "Reference to Video" : "LTX Reference to Video", "primary");
+    const videoToVideoRefsButton = makeButton("Video to Video", "primary");
     const ingredientsRefsButton = makeButton("Ingredients to Video", "primary");
     const idLoraRefsButton = makeButton("ID-LoRA Ref Builder", "primary");
     const close = makeButton("Cancel", "neutral");
     choices.append(
-      choiceCard(textMappingButton, "Text-only character/location mapping for Gemma image planning, I2V prompt writing, and T2V prompt writing. No reference images are sent."),
+      choiceCard(textMappingButton, "Text-only character/location mapping for LLM image planning, Image to Video prompt writing, and Text to Video prompt writing. No reference images are sent."),
       choiceCard(imageRefsButton, "Image reference setup for Flux/Klein and Nano B image generation. Use when those image modes should receive character/location images."),
-      choiceCard(ltxRefsButton, "LTX Reference-to-Video setup for the MSR LoRA workflow. Uses reference images for the video render."),
-      choiceCard(ingredientsRefsButton, "Ingredients-to-Video setup for the Ingredients LoRA workflow. Maps ingredients sheets/images to scenes."),
-      choiceCard(idLoraRefsButton, "Characters, voice samples, locations, dialogue, and auto duration for ID-LoRA I2V short film scenes."),
+      choiceCard(ltxRefsButton, miniMaxProject
+        ? "Build and map ordered character, location, prop, style, or storyboard images for MiniMax Reference to Video."
+        : "LTX Reference-to-Video setup for the MSR LoRA workflow. Uses reference images for the video render."),
     );
+    if (miniMaxProject) {
+      choices.append(choiceCard(
+        videoToVideoRefsButton,
+        "Use a source video together with character, background, location, prop, or style images for MiniMax video editing, including person and background replacement.",
+      ));
+    } else {
+      choices.append(
+        choiceCard(ingredientsRefsButton, "Ingredients-to-Video setup for the Ingredients LoRA workflow. Maps ingredients sheets/images to scenes."),
+        choiceCard(idLoraRefsButton, "Characters, voice samples, locations, dialogue, and auto duration for ID-LoRA I2V short film scenes."),
+      );
+    }
     box.append(title, choices, close);
     backdrop.append(box);
     const openAndClose = (target) => {
       backdrop.remove();
+      if (miniMaxProject && ["reference_to_video", "video_to_video"].includes(target)) {
+        const segment = activeSegment();
+        if (segment) segment.minimax_h3_mode = target;
+        syncMiniMaxH3Panel();
+        renderSegments();
+        openFluxReferenceBuilderModal({ miniMaxTargetMode: target });
+        return;
+      }
       if (target === "rtv") {
         state.videoModelMode = "rtv";
         syncVideoModePanel();
@@ -28809,7 +29632,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       openFluxReferenceBuilderModal({ textOnlyMode: true });
     };
     imageRefsButton.onclick = () => openAndClose("image");
-    ltxRefsButton.onclick = () => openAndClose("rtv");
+    ltxRefsButton.onclick = () => openAndClose(miniMaxProject ? "reference_to_video" : "rtv");
+    videoToVideoRefsButton.onclick = () => openAndClose("video_to_video");
     ingredientsRefsButton.onclick = () => {
       backdrop.remove();
       state.videoModelMode = "ingredients";
@@ -29642,6 +30466,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const themePanel = makeSettingsSection("Builder UI Theme", [
       themeControlMount,
     ], false);
+    const projectVideoEngineSelect = makeSelect([
+      { value: "ltx", label: "LTX (current Builder)" },
+      { value: "minimax_h3", label: "MiniMax H3" },
+    ], normalizeProjectVideoEngine(state.projectVideoEngine));
+    const projectVideoEngineNote = document.createElement("div");
+    projectVideoEngineNote.textContent = "This choice belongs to the whole project. LTX projects keep the existing scene renderer unchanged. MiniMax H3 projects use the separate MiniMax scene action and exact-timeline adapter.";
+    projectVideoEngineNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+    const projectVideoEnginePanel = makeSettingsSection("Project Video Engine", [
+      makeField("Video engine for this project", projectVideoEngineSelect),
+      projectVideoEngineNote,
+    ], true);
     const notificationSettings = normalizeNotificationSettings(state.notificationSettings);
     const notificationMode = makeSelect(["off", "errors", "batch", "complete", "all"], notificationSettings.mode);
     const successSound = makeSelect(["chime", "bell", "double_beep", "soft"], notificationSettings.success_sound);
@@ -29863,6 +30698,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     notificationVolume.addEventListener("input", saveNotificationSettings);
     successCustomFile.addEventListener("change", () => readCustomSound(successCustomFile.files?.[0], "success"));
     errorCustomFile.addEventListener("change", () => readCustomSound(errorCustomFile.files?.[0], "error"));
+    projectVideoEngineSelect.addEventListener("change", async () => {
+      state.projectVideoEngine = normalizeProjectVideoEngine(projectVideoEngineSelect.value);
+      syncProjectVideoEngineUI();
+      await autoSaveSessionQuiet("project video engine");
+      toast(state.projectVideoEngine === "minimax_h3"
+        ? "This project now uses the separate MiniMax H3 scene renderer."
+        : "This project now uses the existing LTX scene renderer.");
+    });
     clearSuccessSound.onclick = async () => {
       state.notificationSettings.success_custom_audio = "";
       state.notificationSettings.success_custom_name = "";
@@ -29879,7 +30722,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     testErrorSound.onclick = () => playBuilderNotification("error", true);
     syncCustomAudioLabels();
     syncContinuityModeVisibility();
-    box.append(header, pathGrid, actions, note, themePanel, autoChainPanel, notificationPanel);
+    box.append(header, pathGrid, actions, note, projectVideoEnginePanel, themePanel, autoChainPanel, notificationPanel);
     backdrop.append(box);
     document.body.append(backdrop);
     modalClose.onclick = () => backdrop.remove();
@@ -30303,6 +31146,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       timeline_zoom: state.timelineZoom,
       auto_save_enabled: state.autoSaveEnabled,
       video_type: normalizeVideoType(state.videoType),
+      video_engine: normalizeProjectVideoEngine(state.projectVideoEngine),
+      minimax_h3_settings: cloneMiniMaxH3Settings(state.miniMaxH3Settings),
       image_model_mode: state.imageModelMode,
       zimage_settings: state.zimageSettings,
       reference_krea2_settings: cloneKrea2ReferenceSettings(state.referenceKrea2Settings),
@@ -30558,6 +31403,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.timelineZoom = data.session.timeline_zoom || state.timelineZoom;
         state.autoSaveEnabled = data.session.auto_save_enabled ?? state.autoSaveEnabled;
         state.videoType = normalizeVideoType(data.session.video_type || data.session.videoType || state.videoType);
+        state.projectVideoEngine = normalizeProjectVideoEngine(data.session.video_engine ?? state.projectVideoEngine);
+        state.miniMaxH3Settings = cloneMiniMaxH3Settings(data.session.minimax_h3_settings || state.miniMaxH3Settings);
         state.imageModelMode = data.session.image_model_mode || data.session.flux_klein_settings?.image_model_mode || state.imageModelMode || "zimage";
         state.pxPerSecond = state.timelineZoom;
         waveformModeSelect.value = state.waveformMode;
@@ -30567,6 +31414,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         syncLyricNoteControls();
         autoSaveControl.input.checked = Boolean(state.autoSaveEnabled);
         syncVideoTypeControl();
+        syncProjectVideoEngineUI();
         syncLeftPanelTabs();
         applyLayoutSizes();
         state.zimageSettings = scrubGlobalImageToImageSourceForProject(cloneZImageSettings(data.session.zimage_settings || state.zimageSettings), state.projectFolder);
@@ -30881,6 +31729,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.timelineZoom = session.timeline_zoom || state.timelineZoom || 45;
       state.autoSaveEnabled = session.auto_save_enabled ?? state.autoSaveEnabled ?? true;
       state.videoType = normalizeVideoType(session.video_type || session.videoType || state.videoType);
+      state.projectVideoEngine = normalizeProjectVideoEngine(session.video_engine);
+      state.miniMaxH3Settings = cloneMiniMaxH3Settings(session.minimax_h3_settings || {});
       state.imageModelMode = session.image_model_mode || session.flux_klein_settings?.image_model_mode || state.imageModelMode || "zimage";
       state.pxPerSecond = state.timelineZoom;
       waveformModeSelect.value = state.waveformMode;
@@ -30890,6 +31740,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       syncLyricNoteControls();
       autoSaveControl.input.checked = Boolean(state.autoSaveEnabled);
       syncVideoTypeControl();
+      syncProjectVideoEngineUI();
       syncLeftPanelTabs();
       applyLayoutSizes();
       state.zimageSettings = scrubGlobalImageToImageSourceForProject(cloneZImageSettings(session.zimage_settings || state.zimageSettings), state.projectFolder);
@@ -33273,6 +34124,223 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
   }
 
+  function miniMaxH3PromptContextForSegment(segment, mode) {
+    const settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
+    const exactDuration = String(Number(duration.toFixed(3)));
+    const aspectRatio = String(settings.aspect_ratio || "16:9").match(/\d+\s*:\s*\d+/)?.[0]?.replace(/\s+/g, "") || "16:9";
+    const lyricText = isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const performanceMode = segmentUsesNoLipSyncPerformance(segment)
+      ? "no_lip_sync"
+      : normalizeVideoType(segment?.performance_mode || state.videoType);
+    const singerNames = (Array.isArray(segment?.lyric_singers)
+      ? segment.lyric_singers
+      : String(segment?.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const performerLabel = singerNames.length
+      ? singerNames.join(singerNames.length === 2 ? " and " : ", ")
+      : "the visible performer";
+    const parts = [
+      "MiniMax H3 Builder scene context:",
+      `Mode: ${miniMaxH3ModeLabel(mode)}`,
+      `Exact duration: ${exactDuration} seconds`,
+      `Timeline range: ${Number(segment?.start || 0).toFixed(3)}s to ${Number(segment?.end || 0).toFixed(3)}s`,
+      `Aspect ratio: ${aspectRatio}`,
+      "Visual style: follow the supplied scene/theme context; default to photorealistic when no style is specified.",
+    ];
+    if (segment?.no_character_present) {
+      parts.push(
+        "Vocal performance: NO VISIBLE CHARACTER / NO LIP SYNC.",
+        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing. Do not invent a visible singer or speaker.",
+      );
+    } else if (performanceMode === "no_lip_sync") {
+      parts.push(
+        "Vocal performance: VISUAL ONLY / NO LIP SYNC.",
+        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing, but do not show singing, speaking, or mouth synchronization.",
+      );
+    } else if (lyricText && performanceMode === "speaking") {
+      parts.push(
+        "Vocal performance: SPEAKING WITH EXACT DIALOGUE LIP SYNC.",
+        `Exact dialogue line: “${lyricText}”`,
+        `Audio 1 assignment: use as the exact voice, timing, and lip-sync reference. ${performerLabel} says the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that spoken line in Audio 1. Do not replace, alter, extend, or add words.`,
+      );
+    } else if (lyricText) {
+      parts.push(
+        "Vocal performance: SINGING WITH EXACT LYRIC LIP SYNC.",
+        `Exact lyric line to sing: “${lyricText}”`,
+        `Audio 1 assignment: use as the exact vocal, timing, and lip-sync reference. ${performerLabel} is singing the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that sung line in Audio 1. Every active vocal timestamp must visibly describe the singing and exact lip sync. Do not replace, alter, extend, or add vocals.`,
+      );
+    } else {
+      parts.push(
+        "Vocal performance: no exact lyric or dialogue is assigned to this scene.",
+        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for performance, movement, and camera timing. Do not invent lyrics, dialogue, or replacement audio.",
+      );
+    }
+    const add = (label, value) => {
+      const text = String(value || "").trim();
+      if (text) parts.push(`${label}:\n${text}`);
+    };
+    add("Scene idea / image prompt", sceneVideoConceptPromptText(segment));
+    add("Scene notes", segment?.notes || segment?.director_note);
+    add("Director timeline note", segment?.timeline_note);
+    add("Motion and camera request", segment?.i2v_notes);
+    add("Scene story beat", segment?.story_beat);
+    add("Exact supplied lyric or dialogue", lyricText);
+    add("Lyric section", segment?.lyric_section);
+    add("Visible character context", segment?.no_character_present ? "No main character is visible in this scene." : segmentMappedSubjectText(segment));
+    add("Location context", segmentMappedLocationText(segment));
+
+    if (mode === "image_to_video") {
+      parts.push("Ordered image assignment:\nImage 1: exact start frame and authoritative opening composition, character identity, clothing, location, lighting, and visual-state anchor.");
+    }
+    if (mode === "reference_to_video" || mode === "video_to_video") {
+      const items = miniMaxOrderedImageReferenceItemsForSegment(segment, mode);
+      const assignments = items.map((item, index) => {
+        const detail = [item.label, item.description].map((value) => String(value || "").trim()).filter(Boolean).join(" — ");
+        return `Image ${index + 1}: ${miniMaxReferencePurposeText(item)}${detail ? `. ${detail}` : ""}`;
+      });
+      if (assignments.length) parts.push(`${mode === "video_to_video" ? "Ordered supporting edit-image assignments" : "Ordered image assignments"} (exact connected order):\n${assignments.join("\n")}`);
+    }
+    if (mode === "video_to_video") {
+      const assignments = (Array.isArray(segment?.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
+        .filter((item) => String(item?.path || "").trim())
+        .slice(0, 3)
+        .map((item, index) => {
+          const purpose = normalizeMiniMaxH3VideoPurpose(item.purpose);
+          const purposeLabel = MINIMAX_H3_VIDEO_REFERENCE_PURPOSES.find((option) => option.value === purpose)?.label || "Continuation / Extension";
+          const timing = Number(item.start_seconds || 0) > 0 || Number(item.duration || 0) > 0
+            ? ` Use from ${Math.max(0, Number(item.start_seconds || 0))}s${Number(item.duration || 0) > 0 ? ` for ${Math.max(0, Number(item.duration || 0))}s` : " onward"}.`
+            : "";
+          const audio = item.use_audio ? " Its embedded audio is also supplied as a paired reference." : " Do not use its embedded audio.";
+          return `Video ${index + 1}: ${purposeLabel}.${timing}${audio}`;
+        });
+      if (assignments.length) parts.push(`Ordered video assignments (exact connected order):\n${assignments.join("\n")}`);
+    }
+    return parts.join("\n\n");
+  }
+
+  function miniMaxH3PromptVisionImages(segment, mode) {
+    if (mode === "image_to_video") {
+      const source = segmentImageSource(segment);
+      const path = String(source?.path || selectedSegmentImagePath(segment) || "").trim();
+      const data = String(source?.data || "").trim();
+      return path || data ? [{ path, data }] : [];
+    }
+    if (mode === "reference_to_video" || mode === "video_to_video") {
+      return miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
+        .map((item) => ({
+          path: String(item?.image?.path || "").trim(),
+          data: String(item?.image?.data || "").trim(),
+        }))
+        .filter((item) => item.path || item.data)
+        .slice(0, 9);
+    }
+    return [];
+  }
+
+  async function createMiniMaxH3PromptWithLLM() {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    updateActiveFromInputs();
+    saveMiniMaxSceneInputsFromPanel();
+    const mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    const modeLabel = miniMaxH3ModeLabel(mode);
+    const duration = Number(segment.end || 0) - Number(segment.start || 0);
+    if (!Number.isFinite(duration) || duration <= 0) {
+      toast("This scene needs valid start and end times before creating its MiniMax prompt.", true);
+      return;
+    }
+    const projectFolder = activeProjectFolderForSave();
+    if (!projectFolder) {
+      toast("Create or load a Builder project before creating MiniMax prompts.", true);
+      return;
+    }
+    const visionImages = miniMaxH3PromptVisionImages(segment, mode);
+    if (mode === "image_to_video" && !visionImages.length) {
+      toast("Image to Video needs a selected scene image before the LLM can create its MiniMax prompt.", true);
+      return;
+    }
+    if (mode === "reference_to_video" && !visionImages.length) {
+      toast("Reference to Video needs at least one ordered Reference Builder image.", true);
+      return;
+    }
+    const videoReferences = (Array.isArray(segment.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
+      .filter((item) => String(item?.path || "").trim());
+    if (mode === "video_to_video" && !videoReferences.length) {
+      toast("Video to Video needs at least one reference video path.", true);
+      return;
+    }
+    if (visionImages.length && state.textGemmaRunner === "llm_api" && !llmApiVisionModelSelected()) {
+      toast("MiniMax image/reference prompting needs a vision-capable API model selected in LLM Runner.", true);
+      return;
+    }
+    const context = miniMaxH3PromptContextForSegment(segment, mode);
+    const promptLyricText = isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
+    const promptSingerNames = (Array.isArray(segment.lyric_singers)
+      ? segment.lyric_singers
+      : String(segment.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    if (mode === "text_to_video" && !sceneVideoConceptPromptText(segment) && !String(segment.i2v_notes || segment.story_beat || segment.lyric_text || "").trim()) {
+      toast("Add a scene idea, notes, story beat, lyrics, or motion direction before creating a Text to Video prompt.", true);
+      return;
+    }
+
+    let progress = null;
+    try {
+      miniMaxCreatePromptButton.disabled = true;
+      miniMaxCreatePromptButton.textContent = "Creating...";
+      progress = createProgressWindow(`Creating MiniMax ${modeLabel} prompt`);
+      progress.set(`Autosaving this scene before LLM prompting...`, 8);
+      await autoSaveSessionQuiet(`MiniMax ${modeLabel} prompt`);
+      progress.set(`Running ${visionImages.length ? "vision-assisted" : "text-only"} MiniMax prompt direction...\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`, 42);
+      const data = await postJson("/vrgdg/music_builder/generate_t2v", {
+        ...textGemmaRunnerPayload(),
+        project_folder: projectFolder,
+        scene_id: segment.id || "",
+        builder_instruction_key: miniMaxH3InstructionKey(mode),
+        model_file: visionImages.length ? i2vGemmaModelSelect.value : i2vTextGemmaModelSelect.value,
+        repair_model_file: i2vTextGemmaModelSelect.value,
+        mmproj_file: visionImages.length ? i2vMmprojSelect.value : "",
+        t2i_prompt: context,
+        user_notes: "Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.",
+        subject_context: segment.no_character_present ? "" : segmentMappedSubjectText(segment),
+        location_context: segmentMappedLocationText(segment),
+        no_character_present: Boolean(segment.no_character_present),
+        image_references: visionImages,
+        performance_mode: effectiveVideoPerformanceModeForSegment(segment),
+        lyric_text: promptLyricText,
+        singers: promptSingerNames,
+        theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
+        story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
+        subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
+        unload_after: true,
+        temperature: 0.45,
+        top_p: 0.92,
+        max_new_tokens: 4000,
+      }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
+      const prompt = String(data.prompt || "").trim();
+      if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
+      pushHistory();
+      segment.minimax_h3_prompt = prompt;
+      segment.minimax_h3_prompt_origin = "gemma";
+      miniMaxPrompt.value = prompt;
+      render();
+      await autoSaveSessionQuiet(`MiniMax ${modeLabel} prompt complete`);
+      progress.set(`MiniMax ${modeLabel} prompt ready.`, 100);
+      progress.close(900);
+      toast(`Created the MiniMax ${modeLabel} prompt with ${gemmaRunnerLabel({ vision: Boolean(visionImages.length) })}.`);
+    } catch (error) {
+      const debugPath = error?.gemmaDebugPath || await saveGemmaJunkDebug(error, { label: `MiniMax ${modeLabel} prompt`, segment });
+      progress?.set(`Error:\n${String(error?.message || error)}${debugPath ? `\n\nRaw LLM output saved to:\n${debugPath}` : ""}`, 100);
+      toast(String(error?.message || error), true);
+    } finally {
+      miniMaxCreatePromptButton.disabled = false;
+      syncMiniMaxH3Panel();
+    }
+  }
+
   async function createI2VPromptWithGemma() {
     const segment = requireActiveSegment();
     if (!segment) return;
@@ -34132,7 +35200,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         const videoNotes = String(segment.video_notes || segment.i2v_notes || "").trim();
         const sceneNotes = String(segment.notes || segment.director_note || "").trim();
         const imagePrompt = storyboardPromptForSegment(segment);
-        const videoPrompt = String(segment.i2v_prompt || segment.t2v_prompt || "").trim();
+        const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+        const videoPrompt = String(miniMaxProject
+          ? (segment.minimax_h3_prompt || "")
+          : (segment.i2v_prompt || segment.t2v_prompt || "")).trim();
         const imageReference = getI2VImageReference(segment);
         const referenceData = storyboardReferenceDataForSegment(segment);
         const promptSummary = storyboardSummaryForSegment(segment, imagePrompt, videoPrompt, referenceData);
@@ -34163,6 +35234,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           facial_performance: String(segment.facial_performance || "").trim(),
           facial_performance_custom: String(segment.facial_performance_custom || "").trim(),
           performance_style: String(segment.performance_style || defaults.performance_style || "").trim(),
+          project_video_engine: normalizeProjectVideoEngine(state.projectVideoEngine),
+          minimax_h3_mode: normalizeMiniMaxH3Mode(segment.minimax_h3_mode),
+          timeline_start: Number(segment.start || 0),
+          timeline_end: Number(segment.end || 0),
+          exact_duration: Number(timelineSegmentDuration(segment).toFixed(3)),
           video_prompt_type: ["i2v", "id_lora", "t2v", "rtv", "ingredients", "flf"].includes(String(segment.video_prompt_type || "").trim())
             ? String(segment.video_prompt_type || "").trim()
             : currentVideoMode(),
@@ -34176,7 +35252,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           character_motion_speed: Number(defaults.character_motion_speed ?? 4),
           image_prompt: imagePrompt,
           video_prompt: videoPrompt,
-          video_prompt_origin: normalizeVideoPromptOrigin(segment.i2v_prompt_origin),
+          video_prompt_origin: miniMaxProject
+            ? normalizeVideoPromptOrigin(segment.minimax_h3_prompt_origin)
+            : normalizeVideoPromptOrigin(segment.i2v_prompt_origin),
           image_path: imageReference.path || selectedSegmentImagePath(segment),
           image_data: imageReference.data || "",
           notes: sceneNotes,
@@ -34191,6 +35269,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const promptMode = options.promptMode || "image";
     return {
       projectFolder: activeProjectFolderForSave(),
+      projectVideoEngine: normalizeProjectVideoEngine(state.projectVideoEngine),
       mode: promptMode === "video" ? "image_to_video_prep" : "storyboard_prompts",
       performanceMode: normalizeVideoType(state.videoType),
       videoType: normalizeVideoType(state.videoType),
@@ -34398,9 +35477,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           applied += 1;
         }
         if (videoPrompt) {
-          setSegmentPromptForEdit(segment, "i2v", videoPrompt, {
-            origin: scene.video_prompt_origin,
-          });
+          if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+            segment.minimax_h3_prompt = videoPrompt;
+            segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(scene.video_prompt_origin);
+            segment.minimax_h3_mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
+          } else {
+            setSegmentPromptForEdit(segment, "i2v", videoPrompt, {
+              origin: scene.video_prompt_origin,
+            });
+          }
           applied += 1;
         }
         if (["i2v", "id_lora", "t2v", "rtv", "ingredients"].includes(videoType)) segment.video_prompt_type = videoType;
@@ -34515,6 +35600,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           : String(segment.mapped_subjects || segment.subject || ""),
         facial_performance: String(scene.facial_performance ?? scene.facialPerformance ?? segment.facial_performance ?? "").trim(),
         facial_performance_custom: String(scene.facial_performance_custom ?? scene.facialPerformanceCustom ?? segment.facial_performance_custom ?? "").trim(),
+        performance_mode: String(scene.performance_mode || scene.performanceMode || segment.performance_mode || "").trim(),
         prompt_summary: String(scene.prompt_summary || scene.summary || segment.prompt_summary || segment.summary || "").trim(),
         summary: String(scene.prompt_summary || scene.summary || segment.prompt_summary || segment.summary || "").trim(),
       };
@@ -34548,6 +35634,71 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       if (!segment) throw new Error(`Scene ${scene.scene_number || ""}: matching Video Builder scene was not found.`);
       const workingSegment = storyboardSceneCloneForI2V(segment, scene);
       const extraUserNotes = storyboardVideoExtraNotes(scene, options.storyboardPayload || {});
+      if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+        workingSegment.i2v_notes = [String(workingSegment.i2v_notes || "").trim(), extraUserNotes]
+          .filter(Boolean)
+          .join("\n\n");
+        const mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
+        const modeLabel = miniMaxH3ModeLabel(mode);
+        workingSegment.minimax_h3_mode = mode;
+        workingSegment.minimax_h3_reference_keys = Array.isArray(segment.minimax_h3_reference_keys)
+          ? [...segment.minimax_h3_reference_keys]
+          : null;
+        workingSegment.minimax_h3_video_references = (Array.isArray(segment.minimax_h3_video_references)
+          ? segment.minimax_h3_video_references
+          : []).map((item) => ({ ...item }));
+        const visionImages = miniMaxH3PromptVisionImages(workingSegment, mode);
+        if (mode === "image_to_video" && !visionImages.length) {
+          throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Image to Video needs a selected scene image.`);
+        }
+        if (mode === "reference_to_video" && !visionImages.length) {
+          throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Reference to Video needs ordered Reference Builder images.`);
+        }
+        if (mode === "video_to_video" && !workingSegment.minimax_h3_video_references.some((item) => String(item?.path || "").trim())) {
+          throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Video to Video needs a reference video.`);
+        }
+        if (visionImages.length && state.textGemmaRunner === "llm_api" && !llmApiVisionModelSelected()) {
+          throw new Error("MiniMax image/reference prompting needs a vision-capable API model selected in LLM Runner.");
+        }
+        options.progress?.set(
+          `${options.progressLabel || scene.label || sceneDisplayName(segment, segmentIndexInfo(segment).index)}: creating MiniMax ${modeLabel} prompt with the scene's H3 instructions...\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`,
+          Math.min(92, Number(options.progressPercent || 35) + 18),
+        );
+        const data = await postJson("/vrgdg/music_builder/generate_t2v", {
+          ...textGemmaRunnerPayload(),
+          project_folder: activeProjectFolderForSave(),
+          scene_id: segment.id || "",
+          builder_instruction_key: miniMaxH3InstructionKey(mode),
+          model_file: visionImages.length ? i2vGemmaModelSelect.value : i2vTextGemmaModelSelect.value,
+          repair_model_file: i2vTextGemmaModelSelect.value,
+          mmproj_file: visionImages.length ? i2vMmprojSelect.value : "",
+          t2i_prompt: miniMaxH3PromptContextForSegment(workingSegment, mode),
+          user_notes: "Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.",
+          subject_context: workingSegment.no_character_present ? "" : segmentMappedSubjectText(workingSegment),
+          location_context: segmentMappedLocationText(workingSegment),
+          no_character_present: Boolean(workingSegment.no_character_present),
+          image_references: visionImages,
+          performance_mode: effectiveVideoPerformanceModeForSegment(workingSegment),
+          lyric_text: isInstrumentalLyricText(workingSegment.lyric_text) ? "" : flattenLyricForPrompt(workingSegment.lyric_text),
+          singers: Array.isArray(workingSegment.lyric_singers) ? workingSegment.lyric_singers : [],
+          theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
+          story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
+          subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
+          unload_after: options.unloadAfter !== false,
+          temperature: 0.45,
+          top_p: 0.92,
+          max_new_tokens: 4000,
+        }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
+        const prompt = String(data.prompt || "").trim();
+        if (!prompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
+        return {
+          ...data,
+          prompt,
+          already_finalized: true,
+          minimax_h3_mode: mode,
+          used_minimax_h3_instructions: true,
+        };
+      }
       const storyboardImageReference = getI2VImageReference(workingSegment);
       const forceTextOnly = currentVideoMode() === "i2v" && !storyboardImageReference.path && !storyboardImageReference.data;
       const request = buildI2VPromptRequestForSegment(workingSegment, {
@@ -34723,6 +35874,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     };
     window.VRGDGStoryboardBuilder.open({
       projectFolder: projectInput.value || state.projectFolder || "",
+      projectVideoEngine: normalizeProjectVideoEngine(state.projectVideoEngine),
       lineMappingLyrics: String(state.lyricMapper?.source_text || ""),
       imageMode: state.imageModelMode || "zimage",
       imageModeLabel: imageModeDisplayLabel(state.imageModelMode || "zimage"),
@@ -36327,6 +37479,250 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return segment.video_path;
   }
 
+  async function renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, options = {}) {
+    const progressBase = Number(options.progressBase ?? 0);
+    const progressSpan = Number(options.progressSpan ?? 100);
+    const batchLabel = options.batchLabel ? `${options.batchLabel}\n` : "";
+    const pct = (value) => Math.min(100, progressBase + (progressSpan * value / 100));
+    const slotNumber = sceneSlotNumber(segment);
+    const projectFolder = String(projectInput.value || "").trim();
+    const timelineStart = Number(segment?.start);
+    const timelineEnd = Number(segment?.end);
+    const sceneDuration = timelineEnd - timelineStart;
+    const mode = normalizeMiniMaxH3Mode(options.mode ?? segment?.minimax_h3_mode);
+    const miniMaxSettings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
+    if (!projectFolder) throw new Error("Save or select a project folder before rendering MiniMax H3.");
+    if (!Number.isFinite(timelineStart) || !Number.isFinite(timelineEnd) || sceneDuration <= 0) {
+      throw new Error(`${sceneDisplayName(segment, sceneIndex)} has invalid timeline boundaries.`);
+    }
+
+    const prompt = String(
+      options.prompt
+      ?? (segment?.minimax_h3_prompt || segment?.i2v_prompt || "")
+    ).trim();
+    if (!prompt) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a MiniMax H3 prompt.`);
+
+    const sourceAudioPath = String(
+      options.audioPath
+      ?? (segment?.custom_audio_path || currentProjectAudioPath() || audioInput.value || "")
+    ).trim();
+    if (!sourceAudioPath) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs source audio for MiniMax H3.`);
+    const sourceStartSeconds = Number(
+      options.sourceStartSeconds
+      ?? (segment?.custom_audio_path ? audioSourceStart(segment) : timelineStart)
+    );
+    const sourceDurationSeconds = Number(
+      options.sourceDurationSeconds
+      ?? audioSourceDurationForScene(segment)
+      ?? 0
+    );
+
+    if (["reference_to_video", "video_to_video"].includes(mode) && miniMaxReferenceKeysForSegment(segment).length) {
+      progress?.set(`${batchLabel}Preparing MiniMax H3 Reference Builder images...`, pct(4));
+      await persistIngredientsSheetImages(projectFolder);
+    }
+
+    const normalizePathList = (value) => (Array.isArray(value) ? value : [])
+      .map((item) => String(item?.path || item?.file || item || "").trim())
+      .filter(Boolean);
+    const usesReferenceBuilderImages = ["reference_to_video", "video_to_video"].includes(mode);
+    const referenceBuilderImagePaths = usesReferenceBuilderImages && options.imagePaths === undefined
+      ? miniMaxReferenceBuilderImagePathsForSegment(segment)
+      : [];
+    const configuredImagePaths = normalizePathList(
+      options.imagePaths !== undefined
+        ? options.imagePaths
+        : (segment?.minimax_h3_image_paths ?? segment?.minimax_image_paths ?? [])
+    );
+    const seenImagePaths = new Set();
+    let imagePaths = usesReferenceBuilderImages ? [...referenceBuilderImagePaths, ...configuredImagePaths]
+      .filter((path) => {
+        const key = mediaPathKey(path);
+        if (!key || seenImagePaths.has(key)) return false;
+        seenImagePaths.add(key);
+        return true;
+      })
+      .slice(0, 9) : [];
+    if (mode === "image_to_video") {
+      const selectedImage = String(selectedSegmentImagePath(segment) || "").trim();
+      if (selectedImage) imagePaths = [selectedImage];
+    }
+    const rawVideoReferences = options.videoReferences
+      ?? segment?.minimax_h3_video_references
+      ?? segment?.minimax_video_references
+      ?? [];
+    const videoReferences = mode === "video_to_video" && Array.isArray(rawVideoReferences) ? rawVideoReferences : [];
+    if (mode === "image_to_video" && !imagePaths.length) {
+      throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a selected scene image for MiniMax Image to Video.`);
+    }
+    if (mode === "reference_to_video" && !imagePaths.length) {
+      throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs at least one ordered Reference Builder image.`);
+    }
+    if (mode === "video_to_video" && !videoReferences.some((item) => String(item?.path || "").trim())) {
+      throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs at least one reference video path.`);
+    }
+    const warmupFrames = Math.max(0, Math.trunc(Number(
+      options.warmupFrames
+      ?? segment?.minimax_h3_warmup_frames
+      ?? miniMaxSettings.warmup_frames
+    ) || 0));
+    const cooldownFrames = Math.max(0, Math.trunc(Number(
+      options.cooldownFrames
+      ?? segment?.minimax_h3_cooldown_frames
+      ?? miniMaxSettings.cooldown_frames
+    ) || 0));
+
+    state.activeId = segment.id;
+    segment.video_status = "running";
+    renderList();
+    progress?.set(`${batchLabel}Preparing exact MiniMax H3 scene timing and audio...`, pct(8));
+
+    try {
+      const payload = {
+        project_folder: projectFolder,
+        scene_number: slotNumber,
+        audio_path: sourceAudioPath,
+        prompt,
+        timeline_start_seconds: timelineStart,
+        timeline_end_seconds: timelineEnd,
+        source_start_seconds: Number.isFinite(sourceStartSeconds) ? Math.max(0, sourceStartSeconds) : timelineStart,
+        pre_frames: warmupFrames,
+        tail_loss_frames: cooldownFrames,
+        seed: Number(options.seed ?? segment?.minimax_h3_seed ?? miniMaxSettings.seed),
+        aspect_ratio: String(options.aspectRatio ?? segment?.minimax_h3_aspect_ratio ?? miniMaxSettings.aspect_ratio),
+        megapixels: Number(options.megapixels ?? segment?.minimax_h3_megapixels ?? miniMaxSettings.megapixels),
+        diffusion_model_name: miniMaxSettings.diffusion_model_name,
+        clip_name: miniMaxSettings.clip_name,
+        video_vae_name: miniMaxSettings.video_vae_name,
+        audio_vae_name: miniMaxSettings.audio_vae_name,
+        sampler_name: miniMaxSettings.sampler_name,
+        scheduler: miniMaxSettings.scheduler,
+        steps: miniMaxSettings.steps,
+        denoise: miniMaxSettings.denoise,
+        easy_cache_bypass: miniMaxSettings.easy_cache_bypass,
+        easy_cache_reuse_threshold: miniMaxSettings.easy_cache_reuse_threshold,
+        easy_cache_start_percent: miniMaxSettings.easy_cache_start_percent,
+        easy_cache_end_percent: miniMaxSettings.easy_cache_end_percent,
+        easy_cache_verbose: miniMaxSettings.easy_cache_verbose,
+        sage_attention: miniMaxSettings.sage_attention,
+        enable_fp16_accumulation: miniMaxSettings.enable_fp16_accumulation,
+        image_paths: imagePaths,
+        video_references: videoReferences,
+      };
+      if (Number.isFinite(sourceDurationSeconds) && sourceDurationSeconds > 0) {
+        payload.source_duration_seconds = sourceDurationSeconds;
+      }
+
+      const built = await postJson(
+        "/vrgdg/workflow_runner/build_minimax_h3_prompt",
+        payload,
+        180000,
+      );
+      const timing = built?.timing || {};
+      const postTrim = built?.post_render_trim || {};
+      const finalDuration = Number(postTrim.duration);
+      if (!Number.isFinite(finalDuration) || Math.abs(finalDuration - sceneDuration) > 0.001) {
+        throw new Error(
+          `MiniMax H3 timing verification failed for ${sceneDisplayName(segment, sceneIndex)}. `
+          + `Timeline: ${sceneDuration.toFixed(6)}s; adapter: ${Number.isFinite(finalDuration) ? finalDuration.toFixed(6) : "missing"}s.`
+        );
+      }
+
+      progress?.set(
+        `${batchLabel}Queueing MiniMax H3...\n`
+        + `Timeline: ${sceneDuration.toFixed(3)}s\n`
+        + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`,
+        pct(30),
+      );
+      const queued = await queueWorkflowPrompt(built.prompt);
+      const promptId = queued?.prompt_id;
+      if (!promptId) throw new Error("ComfyUI queued MiniMax H3 but did not return a prompt_id.");
+      const videos = await waitForVideos(
+        promptId,
+        (message) => progress?.set(`${batchLabel}${message}\nPrompt ID: ${promptId}`, pct(62)),
+        () => state.batchCancelled,
+        null,
+        {
+          timeoutMessage: () => sceneVideoTimeoutMessage({
+            promptId,
+            sceneLabel: sceneDisplayName(segment, sceneIndex),
+            modeLabel: "MiniMax H3",
+            outputFolder: built.output_folder || "",
+            projectFolder,
+            finalFolder: collectedSceneVideoFolder(),
+          }),
+        },
+      );
+      const video = videos[videos.length - 1] || null;
+      const alignedVideoPath = resolveComfyVideoPath(video);
+      if (!alignedVideoPath) {
+        throw new Error("MiniMax H3 finished, but no aligned video path was found in history.");
+      }
+
+      progress?.set(`${batchLabel}Trimming MiniMax H3 to the exact timeline boundaries...`, pct(82));
+      const trimmed = await postJson("/vrgdg/workflow_runner/trim_scene_video", {
+        source_path: alignedVideoPath,
+        project_folder: projectFolder,
+        scene_number: slotNumber,
+        start: Number(postTrim.start || 0),
+        duration: finalDuration,
+        label: "minimax_exact",
+        mark_as_audio_video: true,
+      }, 240000);
+      const exactVideoPath = String(trimmed.video_path || "").trim();
+      if (!exactVideoPath) throw new Error("MiniMax H3 exact trimming did not return a video path.");
+
+      progress?.set(`${batchLabel}Collecting exact MiniMax H3 scene video...`, pct(92));
+      const collected = await postJson("/vrgdg/workflow_runner/collect_scene_video", {
+        source_path: exactVideoPath,
+        project_folder: projectFolder,
+        scene_number: slotNumber,
+        existing_action: options.existingVideoAction || "overwrite",
+      }, 120000);
+
+      pushHistory();
+      if (collected.backup_path) {
+        if (!Array.isArray(segment.video_backup_paths)) segment.video_backup_paths = [];
+        if (!segment.video_backup_paths.some((item) => mediaPathKey(item) === mediaPathKey(collected.backup_path))) {
+          segment.video_backup_paths.push(collected.backup_path);
+        }
+      }
+      if (collected.backup_thumbnail_path) {
+        if (!Array.isArray(segment.video_backup_thumbnail_paths)) segment.video_backup_thumbnail_paths = [];
+        if (!segment.video_backup_thumbnail_paths.some((item) => mediaPathKey(item) === mediaPathKey(collected.backup_thumbnail_path))) {
+          segment.video_backup_thumbnail_paths.push(collected.backup_thumbnail_path);
+        }
+      }
+      segment.video_output = video;
+      segment.video_source_path = alignedVideoPath;
+      segment.minimax_h3_timing = timing;
+      activateSegmentVideoPath(
+        segment,
+        collected.video_path || exactVideoPath,
+        collected.thumbnail_path || trimmed.thumbnail_path || "",
+      );
+      segment.video_cache_bust = Date.now();
+      segment.video_folder = collected.video_folder || collectedSceneVideoFolder();
+      segment.preview_mode = "video";
+      segment.video_status = "done";
+      syncPreview(segment);
+      render();
+      if (options.autoSaveAfter !== false) {
+        await autoSaveSessionQuiet(options.autoSaveReason || "MiniMax H3 scene video complete");
+      }
+      progress?.set(
+        `${batchLabel}MiniMax H3 scene ready.\n${segment.video_path}\n`
+        + `Exact duration: ${finalDuration.toFixed(3)}s`,
+        pct(100),
+      );
+      return segment.video_path;
+    } catch (error) {
+      segment.video_status = "error";
+      renderList();
+      throw error;
+    }
+  }
+
   async function stitchRenderedScenes(progress, options = {}) {
     const baseSegments = Array.isArray(options.segments) && options.segments.length ? options.segments : state.segments;
     const overlaySegments = state.overlayTrack.enabled
@@ -36505,6 +37901,91 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     } finally {
       setButtonGroupState(createSceneVideoButtons, { disabled: false, text: "Create Scene Video" });
       setButtonGroupState(gemmaThenCreateVideoButtons, { disabled: false });
+    }
+  }
+
+  async function createMiniMaxSceneVideo() {
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) !== "minimax_h3") {
+      toast("Set this project's Video Engine to MiniMax H3 in Builder Settings first.", true);
+      return;
+    }
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    updateActiveFromInputs();
+    saveMiniMaxH3SettingsFromPanel();
+    saveMiniMaxSceneInputsFromPanel();
+    const info = segmentIndexInfo(segment);
+    const sceneIndex = info.index;
+    if (sceneIndex < 0) return;
+
+    const missing = [];
+    if (!String(projectInput.value || state.projectFolder || "").trim()) missing.push("Project folder is missing.");
+    if (!String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
+      missing.push("Load global audio or add custom audio for this scene.");
+    }
+    if (!String(segment.minimax_h3_prompt || segment.i2v_prompt || "").trim()) {
+      missing.push("Enter a MiniMax H3 prompt in the scene video prompt box.");
+    }
+    if (!Number.isFinite(Number(segment.start)) || !Number.isFinite(Number(segment.end)) || Number(segment.end) <= Number(segment.start)) {
+      missing.push("The scene needs valid timeline start and end times.");
+    }
+    const mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    if (mode === "image_to_video" && !String(selectedSegmentImagePath(segment) || "").trim()) {
+      missing.push("Image to Video needs a selected scene image.");
+    }
+    if (mode === "reference_to_video" && segment.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
+      missing.push("Reference to Video is set to use the scene image as its start frame, but this scene has no saved image.");
+    }
+    if (mode === "reference_to_video" && !miniMaxOrderedImageReferenceItemsForSegment(segment, mode).length) {
+      missing.push("Reference to Video needs a start frame or at least one ordered Reference Builder image.");
+    }
+    if (mode === "video_to_video" && !(segment.minimax_h3_video_references || []).some((item) => String(item?.path || "").trim())) {
+      missing.push("Video to Video needs at least one reference-video path.");
+    }
+    if (missing.length) {
+      toast(missing.join("\n"), true);
+      return;
+    }
+
+    let existingVideoAction = "overwrite";
+    if (String(segment.video_path || "").trim()) {
+      existingVideoAction = await askExistingSceneVideoAction(segment, sceneIndex);
+      if (existingVideoAction === "cancel") return;
+    }
+    let renderTarget = segment;
+    let renderIndex = sceneIndex;
+    if (existingVideoAction === "overlay" && segmentTrack(segment) !== "overlay") {
+      renderTarget = cloneSceneAsOverlay(
+        segment,
+        () => `seg_${Date.now()}_${Math.floor(Math.random() * 10000)}`,
+        nextOverlaySlotNumber(),
+      );
+      pushHistory();
+      state.overlaySegments.push(renderTarget);
+      sortSegments(state.overlaySegments);
+      setActiveSegment(renderTarget);
+      renderIndex = segmentIndexInfo(renderTarget).index;
+      existingVideoAction = "overwrite";
+    }
+
+    let progress = null;
+    try {
+      state.batchCancelled = false;
+      setButtonGroupState(miniMaxSceneVideoButtons, { disabled: true, text: "Creating MiniMax H3..." });
+      progress = createProgressWindow("Creating MiniMax H3 scene video");
+      const videoPath = await renderMiniMaxSceneVideoWithProgress(renderTarget, renderIndex, progress, {
+        existingVideoAction,
+      });
+      progress.close(900);
+      toast(`MiniMax H3 scene video ready:\n${videoPath}`);
+    } catch (error) {
+      const stopped = /stopped by user/i.test(String(error?.message || error));
+      renderTarget.video_status = stopped ? "none" : "error";
+      progress?.set(stopped ? "MiniMax H3 scene video creation stopped by user." : `Error:\n${String(error?.message || error)}`, 100);
+      toast(stopped ? "MiniMax H3 scene video creation stopped." : String(error?.message || error), !stopped);
+      renderList();
+    } finally {
+      setButtonGroupState(miniMaxSceneVideoButtons, { disabled: false, text: "Create MiniMax H3 Scene Video" });
     }
   }
 
@@ -39530,6 +41011,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     state.idLoraReferenceBuilder = defaultIdLoraReferenceBuilder();
     state.zEnhanceSettings = defaultZEnhanceSettings();
     state.videoType = "singing";
+    state.projectVideoEngine = "ltx";
+    state.miniMaxH3Settings = cloneMiniMaxH3Settings();
     state.videoModelMode = "i2v";
     state.i2vVideoSettings = defaultI2VVideoSettings();
     state.promptToolsHintPrefs = {};
@@ -39562,6 +41045,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     syncKrea2TwoPassPanel();
     syncZEnhanceSettingsPanel();
     syncVideoTypeControl();
+    syncProjectVideoEngineUI();
     syncI2VVideoSettingsPanel();
     syncVideoModePanel();
     syncInspector();
@@ -42475,7 +43959,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const videoKeys = ["video_path", "video_folder", "video_thumbnail_path", "video_history", "video_thumbnail_history", "video_backup_paths", "video_backup_thumbnail_paths", "video_history_index", "video_output", "video_original_path", "video_original_thumbnail_path"];
     const noteKeys = ["timeline_note", "notes", "i2v_notes", "flux_notes", "nb_notes", "enhance_notes"];
     const promptKeys = ["t2i_prompt", "flux_prompt", "nb_prompt", "enhance_prompt", "i2v_prompt", "flow_gpt_prompt"];
-    const mappingKeys = ["subject_ids", "location_id", "reference_subject_ids", "reference_location_id", "flux_image_ingredients", "nb_image_ingredients"];
+    const mappingKeys = ["subject_ids", "location_id", "reference_subject_ids", "reference_location_id", "flux_image_ingredients", "nb_image_ingredients", "minimax_h3_reference_keys"];
     const cleanSegment = (raw) => {
       const segment = typeof structuredClone === "function" ? structuredClone(raw) : JSON.parse(JSON.stringify(raw));
       if (!keep.lyrics) segment.lyric_text = "";
@@ -43529,6 +45013,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const runWizardStoryboardGemmaAll = async () => {
       updateActiveFromInputs();
       saveI2VVideoSettingsFromPanel();
+      const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
       const videoMode = currentVideoMode();
       const segments = allEditableSegments()
         .slice()
@@ -43554,7 +45039,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       };
       const runnerName = promptRunnerActionName();
       const runnerGenericName = runnerName === "Gemma" ? "Gemma" : "LLM";
-      const progress = createProgressWindow(`Storyboard ${runnerName} All (${videoModeDisplayLabel(videoMode, true)})`, { zIndex: 100012 });
+      const progress = createProgressWindow(`Storyboard ${runnerName} All (${miniMaxProject ? "MiniMax H3 per-scene modes" : videoModeDisplayLabel(videoMode, true)})`, { zIndex: 100012 });
       let created = 0;
       try {
         progress.set(`Starting Storyboard ${runnerName} All...\nScenes: ${scenes.length}\nUsing the same prompt writer as Storyboard Builder.`, 5);
@@ -43564,20 +45049,36 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           const base = 8 + Math.round((index / Math.max(1, scenes.length)) * 84);
           const label = `Storyboard ${runnerName} All ${index + 1}/${scenes.length}: ${scene.label || `Scene ${scene.scene_number || index + 1}`}`;
           progress.set(`${label}\nCreating storyboard video prompt...`, base);
-          const data = await postJson("/vrgdg/storyboard/gemma_video_prompt", {
-            ...(storyboardState.gemmaSettings || {}),
-            unload_after: index === scenes.length - 1,
-            storyboard_payload: storyboardGptPayload(storyboardState, [scene]),
-            max_new_tokens: 1400,
-            temperature: 0.35,
-            top_p: 0.90,
-          }, 240000);
-          const finalizedPrompt = segment ? finalizeVideoPromptDraftOnly(segment, data.prompt) : String(data.prompt || "").trim();
-          const prompt = applyWizardStoryboardTriggerPhrases(finalizedPrompt, scene);
+          const data = miniMaxProject
+            ? await createStoryboardVideoPromptViaBuilder(scene, {
+              unloadAfter: index === scenes.length - 1,
+              storyboardPayload: storyboardGptPayload(storyboardState, [scene]),
+              progress,
+              progressPercent: base,
+              progressLabel: label,
+            })
+            : await postJson("/vrgdg/storyboard/gemma_video_prompt", {
+              ...(storyboardState.gemmaSettings || {}),
+              unload_after: index === scenes.length - 1,
+              storyboard_payload: storyboardGptPayload(storyboardState, [scene]),
+              max_new_tokens: 1400,
+              temperature: 0.35,
+              top_p: 0.90,
+            }, 240000);
+          const finalizedPrompt = miniMaxProject
+            ? String(data.prompt || "").trim()
+            : segment ? finalizeVideoPromptDraftOnly(segment, data.prompt) : String(data.prompt || "").trim();
+          const prompt = miniMaxProject ? finalizedPrompt : applyWizardStoryboardTriggerPhrases(finalizedPrompt, scene);
           if (!prompt) throw new Error(`${scene.label || `Scene ${index + 1}`}: ${runnerGenericName} returned an empty Storyboard video prompt.`);
           if (segment) {
-            setSegmentPromptForEdit(segment, "i2v", prompt, { origin: "gemma" });
-            segment.video_prompt_type = videoMode;
+            if (miniMaxProject) {
+              segment.minimax_h3_prompt = prompt;
+              segment.minimax_h3_prompt_origin = "gemma";
+              segment.minimax_h3_mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || segment.minimax_h3_mode);
+            } else {
+              setSegmentPromptForEdit(segment, "i2v", prompt, { origin: "gemma" });
+              segment.video_prompt_type = videoMode;
+            }
           }
           scene.video_prompt = prompt;
           scene.video_prompt_origin = "gemma";
@@ -43608,6 +45109,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       ]));
       return {
         projectFolder: String(projectInput.value || state.projectFolder || "").trim(),
+        projectVideoEngine: normalizeProjectVideoEngine(state.projectVideoEngine),
         audioPath: String(audioInput.value || state.audioPath || "").trim(),
         wizardFolder: String(projectInput.value || state.projectFolder || "").trim() ? `${String(projectInput.value || state.projectFolder || "").trim()}\\wizard` : "",
         sceneCount: allEditableSegments().length,
@@ -43864,7 +45366,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         await flowGptImageAllScenes({ imageRunMode: "resume_missing" });
       },
       runGemmaVideoAll: async () => {
-        if (["i2v", "rtv"].includes(currentVideoMode())) await runWizardStoryboardGemmaAll();
+        if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" || ["i2v", "rtv"].includes(currentVideoMode())) await runWizardStoryboardGemmaAll();
         else await confirmAndRunGemmaVideoAll();
       },
       buildFullVideo: async () => {
@@ -44735,6 +46237,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   editRTVInstructionsButton.onclick = () => openBuilderInstructionEditor("rtv");
   editIngredientsInstructionsButton.onclick = () => openBuilderInstructionEditor("ingredients");
   editT2VInstructionsButton.onclick = () => openBuilderInstructionEditor("t2v");
+  miniMaxCreatePromptButton.onclick = createMiniMaxH3PromptWithLLM;
+  miniMaxEditInstructionsButton.onclick = () => {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    openBuilderInstructionEditor(miniMaxH3InstructionKey(segment.minimax_h3_mode));
+  };
   sendT2IPromptToEnhanceButton.onclick = () => sendPromptToEnhance("T2I", t2iPrompt.value);
   ernieSendT2IPromptToEnhanceButton.onclick = () => sendPromptToEnhance("T2I", ernieT2IPrompt.value);
   krea2TwoPassSendT2IPromptToEnhanceButton.onclick = () => sendPromptToEnhance("T2I", krea2TwoPassT2IPrompt.value);
@@ -44747,6 +46255,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   flowGptCreatePromptButton.onclick = createFlowGptPromptWithGemma;
   editFlowGptT2IInstructionsButton.onclick = () => openBuilderInstructionEditor("flow_gpt_t2i");
   for (const button of createSceneVideoButtons) button.onclick = createSceneVideo;
+  for (const button of miniMaxSceneVideoButtons) button.onclick = createMiniMaxSceneVideo;
+  for (const button of miniMaxReferenceButtons) button.onclick = openMiniMaxReferenceSelector;
   for (const button of gemmaThenCreateVideoButtons) button.onclick = runGemmaThenCreateSceneVideo;
   loadCustomImageButton.onclick = loadCustomImage;
   importImageFolderButton.onclick = () => {
@@ -45585,6 +47095,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const current = BAD_I2V_UNET_ALIASES.has(picker.input.value) ? "" : picker.input.value;
       picker.input.value = chooseModelValue(values, current, preferredList);
     };
+    const setMiniMaxOptions = (picker, options, fallback) => {
+      const values = Array.from(new Set((options || []).filter((item) => String(item || "").trim())));
+      picker.options = values;
+      const current = String(picker.input.value || fallback || "").trim();
+      const exactOrSameBase = values.find((item) => item === current || basenameOnly(item) === basenameOnly(current));
+      picker.input.value = exactOrSameBase || current || fallback;
+    };
     setOptions(i2vUnetPicker, data.video_gguf_unets || data.unets, DEFAULT_I2V_UNET);
     setOptions(i2vDiffusionModelPicker, data.video_diffusion_models || data.unets, DEFAULT_I2V_DIFFUSION_MODEL);
     setOptions(i2vVaePicker, data.vae, "LTX23_video_vae_bf16.safetensors");
@@ -45592,6 +47109,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     setOptions(i2vClip2Picker, data.clip, "ltx-2.3_text_projection_bf16.safetensors");
     setOptions(i2vUpscalePicker, data.upscale_models, "ltx-2.3-spatial-upscaler-x2-1.1.safetensors");
     setOptions(i2vAudioVaePicker, data.vae, "LTX23_audio_vae_bf16.safetensors");
+    const miniMaxDiffusionChoices = (data.video_diffusion_models || data.unets || [])
+      .filter((item) => !/\.gguf$/i.test(String(item || "").trim()));
+    setMiniMaxOptions(miniMaxDiffusionModelPicker, miniMaxDiffusionChoices, DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name);
+    setMiniMaxOptions(miniMaxClipPicker, data.clip, DEFAULT_MINIMAX_H3_SETTINGS.clip_name);
+    setMiniMaxOptions(miniMaxVideoVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name);
+    setMiniMaxOptions(miniMaxAudioVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name);
+    saveMiniMaxH3SettingsFromPanel();
     setOptions(fluxUnetPicker, data.unets, ["flux\\flux-2-klein-4b-fp8.safetensors", "flux-2-klein-4b-fp8.safetensors"]);
     setOptions(fluxClipPicker, data.clip, ["qwen_3_4b.safetensors", "flux\\qwen_3_4b.safetensors"]);
     setOptions(fluxVaePicker, data.vae, ["flux\\flux2-vae.safetensors", "flux2-vae.safetensors"]);
@@ -45711,6 +47235,81 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     wireSearchablePicker(picker, saveI2VVideoSettingsFromPanel);
     picker.input.addEventListener("change", saveI2VVideoSettingsFromPanel);
   }
+  const persistMiniMaxSettings = () => {
+    saveMiniMaxH3SettingsFromPanel();
+    autoSaveSessionQuiet("MiniMax H3 project settings").catch(() => null);
+  };
+  for (const picker of [miniMaxDiffusionModelPicker, miniMaxClipPicker, miniMaxVideoVaePicker, miniMaxAudioVaePicker]) {
+    wireSearchablePicker(picker, saveMiniMaxH3SettingsFromPanel);
+    picker.input.addEventListener("change", persistMiniMaxSettings);
+  }
+  for (const control of [
+    miniMaxAspectRatio,
+    miniMaxMegapixels,
+    miniMaxSeed,
+    miniMaxWarmupFrames,
+    miniMaxCooldownFrames,
+    miniMaxSamplerName,
+    miniMaxScheduler,
+    miniMaxSteps,
+    miniMaxDenoise,
+    miniMaxEasyCacheBypass.input,
+    miniMaxEasyCacheReuseThreshold,
+    miniMaxEasyCacheStartPercent,
+    miniMaxEasyCacheEndPercent,
+    miniMaxEasyCacheVerbose.input,
+    miniMaxSageAttention,
+    miniMaxFp16Accumulation.input,
+  ]) {
+    control.addEventListener("input", saveMiniMaxH3SettingsFromPanel);
+    control.addEventListener("change", persistMiniMaxSettings);
+  }
+  for (const button of miniMaxModeButtons) {
+    button.onclick = async () => {
+      const segment = requireActiveSegment();
+      if (!segment) return;
+      pushHistory();
+      segment.minimax_h3_mode = normalizeMiniMaxH3Mode(button.dataset.minimaxH3Mode);
+      syncMiniMaxH3Panel();
+      await autoSaveSessionQuiet("MiniMax H3 scene mode");
+    };
+  }
+  miniMaxPrompt.addEventListener("input", saveMiniMaxSceneInputsFromPanel);
+  miniMaxPrompt.addEventListener("change", () => autoSaveSessionQuiet("MiniMax H3 scene prompt").catch(() => null));
+  miniMaxUseSceneImageAsStartFrame.input.addEventListener("change", async () => {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    pushHistory();
+    saveMiniMaxSceneInputsFromPanel();
+    syncMiniMaxReferenceButtons();
+    await autoSaveSessionQuiet("MiniMax H3 start frame reference");
+    toast(miniMaxUseSceneImageAsStartFrame.input.checked
+      ? "The scene image will be sent as Image 1 and the exact MiniMax start frame."
+      : "The scene image will no longer be forced as the MiniMax start frame.");
+  });
+  for (const row of miniMaxVideoReferenceRows) {
+    for (const control of [row.path, row.start, row.duration, row.purpose, row.useAudio.input]) {
+      control.addEventListener("input", saveMiniMaxSceneInputsFromPanel);
+      control.addEventListener("change", () => {
+        saveMiniMaxSceneInputsFromPanel();
+        autoSaveSessionQuiet("MiniMax H3 video references").catch(() => null);
+      });
+    }
+  }
+  miniMaxUseCurrentSceneVideoButton.onclick = async () => {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    const path = String(selectedSegmentVideoPath(segment) || "").trim();
+    if (!path) {
+      toast("This scene does not have a selected video to use as a MiniMax reference.", true);
+      return;
+    }
+    pushHistory();
+    miniMaxVideoReferenceRows[0].path.value = path;
+    saveMiniMaxSceneInputsFromPanel();
+    syncMiniMaxH3Panel();
+    await autoSaveSessionQuiet("MiniMax H3 current scene video reference");
+  };
   makePanelResize(leftResizeHandle, "left");
   makePanelResize(rightResizeHandle, "right");
   makePanelResize(timelineResizeHandle, "timeline");

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -1329,6 +1329,17 @@ function normalizeStoryboardPerformanceMode(value = "") {
   return "singing";
 }
 
+function normalizeStoryboardProjectVideoEngine(value = "") {
+  return String(value || "").trim().toLowerCase() === "minimax_h3" ? "minimax_h3" : "ltx";
+}
+
+function normalizeStoryboardMiniMaxH3Mode(value = "") {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return ["text_to_video", "image_to_video", "reference_to_video", "video_to_video"].includes(clean)
+    ? clean
+    : "text_to_video";
+}
+
 function storyboardStillFacialDirection(value = "") {
   return String(value || "")
     .replace(/\bsubtle natural eye movement\b/gi, "clear eye direction")
@@ -1389,6 +1400,11 @@ function normalizeScene(scene = {}, index = 0) {
     trigger_phrase: String(scene.trigger_phrase || scene.trigger || scene.Trigger || ""),
     trigger_position: String(scene.trigger_position || scene.triggerPosition || scene.trigger_placement || "start") === "end" ? "end" : "start",
     video_prompt_type: videoPromptType,
+    project_video_engine: normalizeStoryboardProjectVideoEngine(scene.project_video_engine || scene.projectVideoEngine),
+    minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(scene.minimax_h3_mode || scene.minimaxH3Mode),
+    timeline_start: Number(scene.timeline_start ?? scene.start ?? 0),
+    timeline_end: Number(scene.timeline_end ?? scene.end ?? 0),
+    exact_duration: Math.max(0, Number(scene.exact_duration ?? scene.duration ?? 0)),
     shot_type: scene.shot_type || "",
     camera_motion: scene.camera_motion || scene.motion_preset || "",
     character_motion: scene.character_motion || scene.character_motion_preset || scene.subject_motion || "",
@@ -1471,6 +1487,11 @@ function scenesFromBuilderPayload(payload = {}) {
     subject_refs: scene.subject_refs || [],
     setting: scene.location || scene.location_ref?.description || scene.location_ref?.name || "",
     location_ref: scene.location_ref || null,
+    project_video_engine: scene.project_video_engine || scene.projectVideoEngine || payload.project_video_engine || payload.projectVideoEngine || "",
+    minimax_h3_mode: scene.minimax_h3_mode || scene.minimaxH3Mode || "",
+    timeline_start: scene.timeline_start ?? scene.start ?? 0,
+    timeline_end: scene.timeline_end ?? scene.end ?? 0,
+    exact_duration: scene.exact_duration ?? scene.duration ?? 0,
     video_prompt_type: scene.video_prompt_type || scene.video_type || "",
       shot_type: scene.shot_type || "",
       camera_motion: scene.camera_motion || scene.motion_preset || "",
@@ -1670,6 +1691,7 @@ function mergeStoryLayers(primary = {}, fallback = {}) {
 function slimStoryboardForRequest(state) {
   return {
     mode: state.mode,
+    project_video_engine: normalizeStoryboardProjectVideoEngine(state.projectVideoEngine),
     performance_mode: normalizeStoryboardPerformanceMode(state.performanceMode || state.performance_mode),
     camera_flow: state.cameraFlow || "balanced",
     image_shot_flow: state.imageShotFlow || "intimate",
@@ -1716,6 +1738,10 @@ function storyboardReferenceForGpt(ref, options = {}) {
 
 function storyboardVideoPromptTypeLabel(type) {
   const key = String(type || "").toLowerCase();
+  if (key === "text_to_video") return "MiniMax H3 text to video";
+  if (key === "image_to_video") return "MiniMax H3 image to video";
+  if (key === "reference_to_video") return "MiniMax H3 reference to video";
+  if (key === "video_to_video") return "MiniMax H3 video to video";
   if (key === "id_lora") return "ID-LoRA image to video";
   if (key === "ingredients") return "ingredients to video";
   if (key === "t2v") return "text to video";
@@ -1798,6 +1824,11 @@ function storyboardScenesForGpt(state) {
       scene_number: normalized.scene_number,
       label: normalized.label,
       prompt_type: imageMode ? "text to image" : storyboardVideoPromptTypeLabel(normalized.video_prompt_type),
+      project_video_engine: normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine),
+      minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(normalized.minimax_h3_mode),
+      exact_duration: Number(normalized.exact_duration || 0),
+      timeline_start: Number(normalized.timeline_start || 0),
+      timeline_end: Number(normalized.timeline_end || 0),
       performance_mode: performanceMode,
       lyric_line_to_sing: shouldLipSync && performanceMode === "singing" ? lyricText : "",
       line_to_say: shouldLipSync && performanceMode === "speaking" ? lyricText : "",
@@ -1991,6 +2022,7 @@ async function copyTextToClipboard(text) {
 
 function openStoryboardBuilder(payload = {}) {
   const projectFolder = String(payload.projectFolder || payload.project_folder || "").trim();
+  const projectVideoEngine = normalizeStoryboardProjectVideoEngine(payload.projectVideoEngine || payload.project_video_engine);
   const payloadVideoPromptType = ["i2v", "id_lora", "t2v", "rtv", "ingredients", "flf"].includes(String(payload.videoPromptType || payload.video_prompt_type || "").trim())
     ? String(payload.videoPromptType || payload.video_prompt_type || "").trim()
     : "";
@@ -1998,6 +2030,7 @@ function openStoryboardBuilder(payload = {}) {
   const payloadPerformanceMode = normalizeStoryboardPerformanceMode(payload.performanceMode || payload.performance_mode || payload.videoType || payload.video_type);
   const state = {
     projectFolder,
+    projectVideoEngine,
     lineMappingLyrics: String(payload.lineMappingLyrics || payload.line_mapping_lyrics || payload.lyricMapper?.source_text || payload.lyric_mapper?.source_text || ""),
     mode: "storyboard_prompts",
     scenes: scenesFromBuilderPayload(payload).map((scene) => ({
@@ -3361,6 +3394,10 @@ function openStoryboardBuilder(payload = {}) {
   }
 
   const videoPromptTypeLabel = (type) => {
+    if (type === "text_to_video") return "H3 T2V";
+    if (type === "image_to_video") return "H3 I2V";
+    if (type === "reference_to_video") return "H3 Reference";
+    if (type === "video_to_video") return "H3 V2V";
     if (type === "id_lora") return "ID-LoRA I2V";
     if (type === "t2v") return "T2V";
     if (type === "rtv") return "RTV";
@@ -3427,6 +3464,10 @@ function openStoryboardBuilder(payload = {}) {
   };
 
   const videoPromptTypeHint = (type) => {
+    if (type === "text_to_video") return "MiniMax H3 Text to Video uses scene text and <Audio 1> without picture or video references.";
+    if (type === "image_to_video") return "MiniMax H3 Image to Video uses the scene image as <Picture 1> and the authoritative opening frame.";
+    if (type === "reference_to_video") return "MiniMax H3 Reference to Video uses this scene's ordered Reference Builder pictures and their exact <Picture N> tags.";
+    if (type === "video_to_video") return "MiniMax H3 Video to Video uses the reference-video paths and purposes configured for this scene in Video Builder.";
     if (type === "id_lora") {
       return "ID-LoRA uses a scene image plus per-scene dialogue and a character voice sample from the ID-LoRA Ref Builder.";
     }
@@ -3757,13 +3798,19 @@ function openStoryboardBuilder(payload = {}) {
     noCharacterInput.type = "checkbox";
     noCharacterInput.checked = Boolean(scene.no_character_present);
     noCharacterLabel.append(noCharacterInput, document.createTextNode("No character present"));
-    const videoPromptType = makeSelect([
+    const miniMaxProject = state.projectVideoEngine === "minimax_h3";
+    const videoPromptType = makeSelect(miniMaxProject ? [
+      { value: "text_to_video", label: "MiniMax H3 — Text to Video" },
+      { value: "image_to_video", label: "MiniMax H3 — Image to Video" },
+      { value: "reference_to_video", label: "MiniMax H3 — Reference to Video" },
+      { value: "video_to_video", label: "MiniMax H3 — Video to Video" },
+    ] : [
       { value: "i2v", label: "Image to Video" },
       { value: "id_lora", label: "ID-LoRA I2V" },
       { value: "t2v", label: "Text to Video" },
       { value: "rtv", label: "Reference to Video" },
       { value: "ingredients", label: "Ingredients to Video" },
-    ], scene.video_prompt_type || "i2v");
+    ], miniMaxProject ? normalizeStoryboardMiniMaxH3Mode(scene.minimax_h3_mode) : (scene.video_prompt_type || "i2v"));
     const subjects = makeInput((scene.subjects || []).join(", "), "Subjects, comma separated");
     const subjectDetails = makeTextarea(
       (Array.isArray(scene.subject_refs) ? scene.subject_refs : [])
@@ -4073,11 +4120,14 @@ function openStoryboardBuilder(payload = {}) {
     closeEditor.onclick = () => editorBackdrop.remove();
     const refreshShotPresetForVideoType = () => {
       const type = videoPromptType.value || "i2v";
-      const options = isImagePrepMode ? IMAGE_SHOT_TYPES : (type === "i2v" ? VIDEO_SHOT_TYPES : Array.from(new Set([...IMAGE_SHOT_TYPES, ...VIDEO_SHOT_TYPES])));
+      const imageToVideoType = type === "i2v" || type === "image_to_video";
+      const textToVideoType = type === "t2v" || type === "text_to_video";
+      const referenceToVideoType = type === "rtv" || type === "reference_to_video";
+      const options = isImagePrepMode ? IMAGE_SHOT_TYPES : (imageToVideoType ? VIDEO_SHOT_TYPES : Array.from(new Set([...IMAGE_SHOT_TYPES, ...VIDEO_SHOT_TYPES])));
       const current = shot.value || scene.shot_type || "";
       shotPreset.replaceChildren();
       for (const option of [
-        { value: "", label: isImagePrepMode ? "Choose shot / composition preset..." : (type === "i2v" ? "Choose camera/motion preset..." : "Choose starting shot preset...") },
+        { value: "", label: isImagePrepMode ? "Choose shot / composition preset..." : (imageToVideoType ? "Choose camera/motion preset..." : "Choose starting shot preset...") },
         ...options.map((item) => ({ value: item, label: item })),
         { value: "__custom__", label: "Custom / keep typed value" },
       ]) {
@@ -4087,23 +4137,25 @@ function openStoryboardBuilder(payload = {}) {
         shotPreset.append(item);
       }
       shotPreset.value = options.includes(current) ? current : "__custom__";
-      shotPresetField.firstChild.textContent = isImagePrepMode ? "Shot / composition preset" : (type === "i2v" ? "Camera / motion preset" : "Starting shot preset");
-      shotCustomField.firstChild.textContent = isImagePrepMode ? "Custom shot / composition" : (type === "i2v" ? "Custom camera / motion" : "Custom starting shot");
+      shotPresetField.firstChild.textContent = isImagePrepMode ? "Shot / composition preset" : (imageToVideoType ? "Camera / motion preset" : "Starting shot preset");
+      shotCustomField.firstChild.textContent = isImagePrepMode ? "Custom shot / composition" : (imageToVideoType ? "Custom camera / motion" : "Custom starting shot");
       videoTypeHint.textContent = videoPromptTypeHint(type);
       motionField.firstChild.textContent = isImagePrepMode
         ? "Still photography notes"
-        : type === "i2v"
+        : imageToVideoType
           ? "Motion Notes / LLM Direction"
-          : type === "rtv"
+          : referenceToVideoType
             ? "Motion Notes / LLM Direction (with references)"
             : "Motion Notes / LLM Direction";
-      t2iPromptField.style.display = isImagePrepMode || (type !== "t2v" && type !== "rtv") ? "flex" : "none";
-      imagePathField.style.display = isVideoPrepMode && type !== "t2v" && type !== "rtv" ? "flex" : "none";
+      t2iPromptField.style.display = isImagePrepMode || (!textToVideoType && !referenceToVideoType) ? "flex" : "none";
+      imagePathField.style.display = isVideoPrepMode && !textToVideoType && !referenceToVideoType ? "flex" : "none";
       videoPrompt.style.display = isVideoPrepMode ? "" : "none";
-      videoPrompt.placeholder = type === "t2v"
+      videoPrompt.placeholder = textToVideoType
         ? "Full text-to-video prompt..."
-        : type === "rtv"
+        : referenceToVideoType
           ? "Full reference-to-video prompt..."
+          : type === "video_to_video"
+            ? "Full video-to-video prompt..."
           : "Full image-to-video prompt...";
     };
     refreshShotPresetForVideoType();
@@ -4191,7 +4243,12 @@ function openStoryboardBuilder(payload = {}) {
       propagateFlfEndStateToNextScene(scene);
       scene.prompt_summary = isVideoPrepMode ? summary.value.trim() : "";
       scene.motion_summary = motion.value.trim();
-      scene.video_prompt_type = isVideoPrepMode ? (videoPromptType.value || "i2v") : "i2v";
+      if (isVideoPrepMode && miniMaxProject) {
+        scene.minimax_h3_mode = normalizeStoryboardMiniMaxH3Mode(videoPromptType.value);
+        scene.project_video_engine = "minimax_h3";
+      } else {
+        scene.video_prompt_type = isVideoPrepMode ? (videoPromptType.value || "i2v") : "i2v";
+      }
       scene.no_character_present = Boolean(noCharacterInput.checked);
       scene.subjects = scene.no_character_present ? [] : subjects.value.split(/[,;\n]+/).map((item) => item.trim()).filter(Boolean);
       scene.setting = setting.value.trim();
@@ -4364,7 +4421,7 @@ function openStoryboardBuilder(payload = {}) {
       const miniRefButtonStyle = "margin-top:7px;border:1px dashed #155e75;border-radius:6px;background:#07111f;color:#a5f3fc;padding:5px 7px;font-size:11px;font-weight:900;cursor:pointer;";
       const subjectCell = `<div>${subjectRefsHtml(scene)}</div><button data-action="load-subject-ref" title="Choose subjects from Reference Builder or upload a new subject image" style="${miniRefButtonStyle}">+ Subject</button>`;
       const settingCell = `<div>${settingRefHtml(scene)}</div><button data-action="load-location-ref" title="Load a location image for this scene" style="${miniRefButtonStyle}">+ Location</button>`;
-      const videoType = videoPromptTypeLabel(scene.video_prompt_type || "i2v");
+      const videoType = videoPromptTypeLabel(state.projectVideoEngine === "minimax_h3" ? scene.minimax_h3_mode : (scene.video_prompt_type || "i2v"));
       const shotCell = `<div style="display:flex;flex-direction:column;gap:4px;"><span style="align-self:flex-start;border:1px solid #155e75;border-radius:999px;background:#0f172a;color:#a5f3fc;font-size:11px;font-weight:900;padding:2px 7px;">${escapeHtml(videoType)}</span><strong style="color:#f8fafc;">${escapeHtml(scene.shot_type || "-")}</strong></div>`;
       const storyPreview = `${scene.lyric_section ? `<div style="margin-top:5px;color:#67e8f9;font-size:11px;font-weight:900;">${escapeHtml(scene.lyric_section)}</div>` : ""}${scene.story_beat ? `<div style="margin-top:5px;color:#94a3b8;font-size:11px;">Beat: ${escapeHtml(truncate(scene.story_beat, 90))}</div>` : ""}`;
       if (mode === "image_to_video_prep") {
@@ -4448,6 +4505,7 @@ function openStoryboardBuilder(payload = {}) {
       const incomingScenes = state.scenes.map((scene) => normalizeScene(scene));
       const data = await postJson("/vrgdg/storyboard/load", { project_folder: state.projectFolder });
       const saved = data.storyboard || {};
+      state.projectVideoEngine = normalizeStoryboardProjectVideoEngine(saved.project_video_engine || saved.projectVideoEngine || state.projectVideoEngine);
       const savedReferences = normalizeReferenceBuilderCatalog(saved.reference_builder || saved.referenceBuilder || {});
       const currentHasSubjects = Array.isArray(state.referenceBuilder?.subjects) && state.referenceBuilder.subjects.length > 0;
       const currentHasLocations = Array.isArray(state.referenceBuilder?.locations) && state.referenceBuilder.locations.length > 0;
@@ -4483,6 +4541,11 @@ function openStoryboardBuilder(payload = {}) {
             scene_number: fresh.scene_number || normalized.scene_number,
             label: fresh.label || normalized.label,
             video_prompt_type: payloadVideoPromptType || fresh.video_prompt_type || normalized.video_prompt_type,
+            project_video_engine: state.projectVideoEngine,
+            minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(fresh.minimax_h3_mode || normalized.minimax_h3_mode),
+            timeline_start: Number(fresh.timeline_start ?? normalized.timeline_start ?? 0),
+            timeline_end: Number(fresh.timeline_end ?? normalized.timeline_end ?? 0),
+            exact_duration: Math.max(0, Number(fresh.exact_duration ?? normalized.exact_duration ?? 0)),
             lyrics: fresh.lyrics || normalized.lyrics,
             lyric_section: fresh.lyric_section || normalized.lyric_section,
             story_beat: fresh.story_beat || normalized.story_beat,
@@ -4569,7 +4632,7 @@ function openStoryboardBuilder(payload = {}) {
     try {
       syncStoryLayerFromInputs();
       state.scenes.forEach((scene) => {
-        if (String(scene.video_prompt || "").trim() && normalizeVideoPromptOrigin(scene.video_prompt_origin) === "gemma") {
+        if (state.projectVideoEngine !== "minimax_h3" && String(scene.video_prompt || "").trim() && normalizeVideoPromptOrigin(scene.video_prompt_origin) === "gemma") {
           scene.video_prompt = enforceStoryboardVideoFacialRequirements(scene.video_prompt, scene);
         }
       });
@@ -4596,7 +4659,7 @@ function openStoryboardBuilder(payload = {}) {
     try {
       state.scenes.forEach((scene) => {
         if (String(scene.image_prompt || "").trim()) scene.image_prompt = ensureStoryboardReferenceOpening(scene.image_prompt, scene, state.imageMode);
-        if (String(scene.video_prompt || "").trim() && normalizeVideoPromptOrigin(scene.video_prompt_origin) === "gemma") {
+        if (state.projectVideoEngine !== "minimax_h3" && String(scene.video_prompt || "").trim() && normalizeVideoPromptOrigin(scene.video_prompt_origin) === "gemma") {
           scene.video_prompt = enforceStoryboardVideoFacialRequirements(scene.video_prompt, scene);
         }
       });
@@ -4901,6 +4964,9 @@ function openStoryboardBuilder(payload = {}) {
     try {
       progress?.set(`${progressLabel || normalized.label || `Scene ${normalized.scene_number}`}: sending scene card to ${runnerName}...\nThis can take a minute depending on runner/model speed.`, progressPercent);
       const callbackPayload = storyboardGptPayload(state, [scene]);
+      if (state.projectVideoEngine === "minimax_h3" && !state.onCreateVideoPrompt) {
+        throw new Error("Open Storyboard Builder from the Video Builder so MiniMax can use the scene's H3 mode, ordered references, exact timing, and LLM instructions.");
+      }
       const data = state.onCreateVideoPrompt
         ? await state.onCreateVideoPrompt(scene, {
           unloadAfter,


### PR DESCRIPTION
## Summary

Adds the first MiniMax H3 testing path to the existing Video Builder while leaving the LTX renderer and LTX project defaults unchanged. MiniMax mode, models, and video settings are project-global by default, with an explicit per-scene lock for intentional overrides. It also includes the approved Builder automatic RAM/VRAM cleanup control.

## What changed

- adds a project-level LTX / MiniMax H3 engine selection
- adds project-global MiniMax Text to Video, Image to Video, Reference to Video, and Video to Video modes
- adds a per-scene lock that snapshots the current MiniMax mode, models, render settings, and advanced settings for that scene
- makes Reference Builder, LLM prompting, Storyboard All, validation, and rendering consistently use each scene's effective global or locked MiniMax mode
- adds MiniMax model, resolution, timing, sampler, EasyCache, Sage Attention, and FP16 controls
- adds exact MiniMax frame planning, warmup/cooldown context, custom-audio preparation, and exact post-render timeline trimming
- adds MiniMax Render All support for resuming missing clips or backing up and redoing target clips from existing Storyboard prompts
- validates every MiniMax scene's effective mode inputs before the batch starts, renders it through the MiniMax hidden workflow, records its mode in the render log, and stitches all-scenes runs afterward
- prevents stale LTX mode, post-processing, canvas, and embedded-audio settings from leaking into MiniMax batches while leaving the LTX Render All path unchanged
- adds ordered Reference Builder images, optional exact scene-image start frames, and reference-video inputs
- adds a Builder-compatible MiniMax reference-media custom node
- adds MiniMax-specific LLM instructions, lyric/audio formatting, and Storyboard prompting
- adds the single hidden API workflow used by the Builder
- adds a Builder Settings checkbox for automatic RAM/VRAM cleanup
- when automatic cleanup is disabled, embedded cleanup nodes and automatic post-task cache clearing are bypassed while manual Clear Memory remains available
- adds a testing-build entry to the update banner

## Current testing limitations

- requires project audio or custom scene audio
- uses non-GGUF diffusion models
- built-in MiniMax audio is not included yet
- MiniMax post-processing workflows are not included yet

## Scope controls

This PR intentionally excludes:

- all test files
- backup files
- generated media and temporary files
- workflow-generation scripts
- experimental or unused MiniMax/LTX workflows

## Validation

- both modified JavaScript modules pass syntax checks
- all modified Python modules compile
- the hidden MiniMax API workflow parses as valid JSON
- the complete local development suite passes: 143 tests, 4 skipped
- the existing clean-branch tracked suite passes: 30 tests, 4 skipped
- final PR scope audit confirms no `tests/` paths are included