### PR TITLE
Fix TorchCodec failures in audio transcription

### DIFF
--- a/HumoAutomationExtra2.py
+++ b/HumoAutomationExtra2.py
@@ -9,6 +9,7 @@ import numpy as np
 import os
 import tempfile
 import difflib
+import wave
 from folder_paths import get_output_directory
 from transformers import (
     WhisperProcessor,
@@ -82,6 +83,27 @@ def _whisper_generate_with_dtype_fallback(model, input_features, fallback_device
             fallback_device,
         )
         return model.generate(aligned_features, **kwargs)
+
+
+def _save_waveform_as_pcm16_wav(file_path, waveform, sample_rate):
+    """Write a temporary WAV without Torchaudio/TorchCodec dependencies."""
+    audio = torch.as_tensor(waveform).detach().cpu().float()
+    if audio.ndim == 3:
+        audio = audio[0]
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    if audio.ndim != 2:
+        raise ValueError(f"Expected audio shaped [C,T], got {tuple(audio.shape)}")
+
+    audio = torch.nan_to_num(audio, nan=0.0, posinf=1.0, neginf=-1.0).clamp(-1.0, 1.0)
+    pcm = (audio * 32767.0).round().to(torch.int16)
+    interleaved = pcm.transpose(0, 1).contiguous().numpy().tobytes()
+
+    with wave.open(file_path, "wb") as wav_file:
+        wav_file.setnchannels(int(audio.shape[0]))
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(int(sample_rate))
+        wav_file.writeframes(interleaved)
 
 
 class VRGDG_ManualLyricsExtractor:
@@ -1873,7 +1895,7 @@ class VRGDG_ManualLyricsExtractor_SRT_Advanced:
             tmp_wav_path = tmp.name
 
         try:
-            torchaudio.save(tmp_wav_path, mono.unsqueeze(0), sample_rate)
+            _save_waveform_as_pcm16_wav(tmp_wav_path, mono.unsqueeze(0), sample_rate)
 
             use_reference = bool(reference_lyrics and reference_lyrics.strip())
             reference_lines = self._split_reference_lyrics(reference_lyrics) if use_reference else []
@@ -3018,7 +3040,7 @@ class VRGDG_TimestampedLyricsExtractor(VRGDG_ManualLyricsExtractor_SRT_Advanced)
             tmp_wav_path = tmp.name
 
         try:
-            torchaudio.save(tmp_wav_path, mono.unsqueeze(0), sample_rate)
+            _save_waveform_as_pcm16_wav(tmp_wav_path, mono.unsqueeze(0), sample_rate)
             reference_lines = self._split_reference_lyrics(reference_lyrics) if str(reference_lyrics or "").strip() else []
             cleaned_reference_lyrics = "\n".join(reference_lines)
             segment_mode = str(segment_mode or "whisper_chunks")

--- a/VRGDG_AudioNodes.py
+++ b/VRGDG_AudioNodes.py
@@ -14,6 +14,11 @@ except Exception:
     torchaudio = None
 
 try:
+    from comfy_extras.nodes_audio import load as comfy_load_audio
+except Exception:
+    comfy_load_audio = None
+
+try:
     from demucs import pretrained
     from demucs.apply import apply_model
 except Exception:
@@ -108,14 +113,33 @@ class VRGDG_GetStems:
         if waveform is not None:
             return waveform, sample_rate
 
-        if torchaudio is None:
-            raise ImportError("torchaudio is required to load audio_file_path.")
-
         resolved = self._resolve_audio_path(audio_file_path)
         if not resolved:
             raise ValueError("Provide a valid AUDIO input or audio_file_path.")
 
-        wav, sr = torchaudio.load(resolved)
+        comfy_error = None
+        if comfy_load_audio is not None:
+            try:
+                wav, sr = comfy_load_audio(resolved)
+                if wav.ndim == 1:
+                    wav = wav.unsqueeze(0)
+                if wav.ndim != 2:
+                    raise ValueError(
+                        f"ComfyUI audio loader returned unexpected shape {tuple(wav.shape)}"
+                    )
+                return wav.unsqueeze(0).float(), int(sr)
+            except Exception as exc:
+                comfy_error = exc
+
+        if torchaudio is None:
+            detail = f" ComfyUI audio loader error: {comfy_error}" if comfy_error else ""
+            raise ImportError(f"No compatible audio-file loader is available.{detail}")
+
+        try:
+            wav, sr = torchaudio.load(resolved)
+        except Exception as exc:
+            detail = f" ComfyUI audio loader error: {comfy_error}" if comfy_error else ""
+            raise RuntimeError(f"Unable to decode audio file: {resolved}.{detail}") from exc
         return wav.unsqueeze(0).float(), int(sr)
 
     @classmethod


### PR DESCRIPTION
## What changed

- Load audio-file paths in `VRGDG_GetStems` through ComfyUI's built-in PyAV decoder first.
- Retain `torchaudio.load()` as a compatibility fallback for older ComfyUI environments.
- Replace both transcription-side `torchaudio.save()` calls with a native PCM16 WAV writer.
- Preserve existing `AUDIO` tensor inputs, Demucs resampling, Stable Whisper alignment, and timestamp behavior.
- Report a clearer combined error if neither audio decoder can open an input file.

## Root cause

Current Torchaudio 2.9 routes both `torchaudio.load()` and `torchaudio.save()` through TorchCodec. On Windows portable installations with a static FFmpeg build, TorchCodec cannot load the shared FFmpeg DLLs.

This affected two separate stages:

1. `VRGDG_GetStems` failed while reading the source audio.
2. After that was fixed, `VRGDG_TimestampedLyricsExtractor` failed while writing its temporary WAV for Stable Whisper.

The hotfix removes TorchCodec from both stages without requiring users to install a separate full-shared FFmpeg package.

## User impact

Audio transcription, timestamped lyric extraction, and stem preparation can process MP3 inputs again on current ComfyUI portable builds, including the audio preparation used by the Video Builder.

## Validation

- `VRGDG_AudioNodes.py` and `HumoAutomationExtra2.py` compile successfully.
- Confirmed `VRGDG_GetStems._load_waveform()` loads `Circle of Flames 5444445.mp3` as stereo float32 audio at 48 kHz.
- Confirmed the decoded waveform resamples successfully through Torchaudio's functional resampler.
- Confirmed the new native writer produces a stereo 48 kHz PCM WAV that ComfyUI decodes back successfully.
- PR contains only the two required source files; no tests, workflows, backups, or unrelated files are included.