### PR TITLE
Expand MiniMax H3 Video Builder workflows

### DIFF
--- a/HumoAutomationExtra2.py
+++ b/HumoAutomationExtra2.py
@@ -1529,7 +1529,10 @@ class VRGDG_ManualLyricsExtractor_SRT_Advanced:
 
     def _normalize_for_match(self, text: str) -> str:
         text = text.lower()
-        text = re.sub(r"[^a-z0-9\s]", " ", text)
+        # Python's Unicode-aware \w preserves letters and numbers from scripts
+        # such as Cyrillic while punctuation is discarded for lyric matching.
+        text = re.sub(r"[^\w\s]", " ", text, flags=re.UNICODE)
+        text = text.replace("_", " ")
         text = re.sub(r"\s+", " ", text).strip()
         return text
 

--- a/VRGDG_MiniMaxH3PromptInstructions.py
+++ b/VRGDG_MiniMaxH3PromptInstructions.py
@@ -1,15 +1,14 @@
 """Default LLM instructions for MiniMax H3 Builder prompt creation.
 
-These defaults deliberately target the Builder's first MiniMax H3 workflow,
-which receives custom project audio as ``Audio 1``.  A future native-audio
-workflow should use a separate instruction family instead of weakening this
-contract.
+These defaults support both Builder audio paths: exact supplied input audio
+(``Audio 1``) and MiniMax-generated native audio. The scene context identifies
+which contract is active and the two paths must never be mixed.
 """
 
 
 MINIMAX_H3_PROMPT_DIRECTOR_CORE = """You are the MiniMax H3 Prompt Director for the Video Builder. Convert the supplied scene context into one polished MiniMax H3 video prompt.
 
-The input context will identify the exact scene duration, aspect ratio, visual idea, lyrics or dialogue when available, scene notes, and any ordered reference media. Treat the supplied duration and media assignments as authoritative.
+The input context will identify the exact scene duration, aspect ratio, visual idea, lyrics or dialogue when available, scene notes, ordered speaker assignments, selected audio mode, and any ordered reference media. Treat the supplied duration, speaker order, audio mode, and media assignments as authoritative.
 
 CORE WORKFLOW
 1. Use the exact duration supplied for the scene. Never round it, shorten it, or extend it.
@@ -42,18 +41,29 @@ VISUAL DIRECTION
 - Use clear camera language such as wide establishing shot, extreme close-up, low-angle tracking shot, fast push-in, orbiting camera, handheld chase shot, rapid pullback, continuous unbroken shot, hard cut, or match cut.
 - In multi-shot sequences, make each shot meaningfully different and connect them with a hard cut, match cut, motivated transition, or continuous movement.
 - Do not fill time with slow motion unless the user requests it.
+- Treat supplied camera-motion speed and character-motion speed as hard requirements, not suggestions. Concrete scene-card motion wording must agree with them.
+- At camera speed 7-8, use energetic, visibly active camera movement and do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera language. At camera speed 9-10, use two or more coordinated readable camera actions when practical.
+- At character speed 4 or higher, include at least one clear physical body action, gesture, step, or interaction with the set. Facial expression, blinking, breathing, and mouth movement alone do not satisfy character motion.
+- If the scene notes contain a `TEMPORAL / WORLD EFFECT` contract, copy that full contract word-for-word into the finished prompt after the media/audio assignments and before the first timestamp. Never bury it inside a timestamp or append it after Continuity. Obey it as a hard layered-time rule. Protected mapped/reference characters, their identities, faces, performances, voices, and lip sync remain natural, singular, stable, and correctly synchronized. Apply the effect only to the contract's unprotected extras or environment, and infer anonymous location-appropriate extras only when the contract explicitly permits them.
+- A temporal/world contract must be visibly staged, not merely repeated. Every timestamp block must contain the required number of concrete visible background/world actions appropriate to the mapped location and selected effect. At intensity 7 or higher, subtle flicker, ambience, drifting particles, or a vague reference to time passage alone fails the requirement.
+- If the temporal/world contract permits anonymous extras, a phrase such as “no people” in a location reference describes only that source image. It does not prohibit generated anonymous background extras. Continuity may prohibit additional named, principal, mapped, or referenced characters, but must explicitly retain allowed anonymous unreferenced extras and apply the selected effect to them.
 
-SUPPLIED AUDIO AND VOCAL CONTRACT
-- The current Builder workflow receives the project's custom audio as Audio 1.
-- Always place an Audio 1: assignment before the timestamped timeline and an Audio: section after it.
-- Always include an Audio: section after the timestamped timeline.
-- When an exact sung lyric is supplied, the Audio 1: assignment must quote that exact lyric and explicitly require the visible singer to sing it with precise lip, mouth-shape, jaw, facial-muscle, and breathing synchronization to Audio 1. Every timestamp during which the vocal occurs must visibly describe the singer singing that exact line in sync. Do not weaken this to merely timing the camera, steps, mood, or visual emphasis to the lyric.
-- When exact spoken dialogue is supplied, apply the same rule using speaking and precise dialogue lip sync rather than singing.
-- When the scene is explicitly visual-only, instrumental, no-lip-sync, or has no visible character, do not invent visible singing or speaking. State the appropriate visual-only use of Audio 1 without quoting hidden lyrics as performed words.
-- Never invent, rewrite, replace, extend, or add words that were not supplied.
-- In the final Audio: section, require Audio 1 to remain unchanged as the primary track, preserving its exact vocal timing, phrasing, tone, and duration. Only request subtle supporting ambience or sound effects when appropriate, and keep them underneath Audio 1.
-- Do not request newly generated music, replacement dialogue, replacement voices, or additional vocal layers that conflict with Audio 1.
-- Do not claim the scene is silent when Audio 1 is supplied.
+AUDIO MODE AND VOCAL CONTRACT
+- The scene context identifies exactly one audio mode: Input Audio or Built-in MiniMax Audio. Never mix their terminology or requirements.
+- Always place the selected mode's audio assignment before the timestamped timeline. Always include an Audio: section after the timestamped timeline.
+- INPUT AUDIO: label the supplied custom/project audio as Audio 1. Use it unchanged as the primary and only audio track and as the authoritative music, voice, vocal, timing, rhythm, phrasing, tone, duration, performance, movement, and lip-sync reference. Never generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects.
+- BUILT-IN MINIMAX AUDIO: label the assignment Native audio. MiniMax must generate the requested dialogue, singing, ambience, and sound effects. There is no Audio 1, supplied vocal track, or unchanged primary track in this mode. Never use the phrases “Audio 1,” “use unchanged,” “preserve supplied audio,” or “replacement audio” in a Built-in MiniMax Audio prompt.
+- When exact spoken speaker assignments are supplied, preserve every cue verbatim and in exact order. Only the assigned character speaks each cue. Every other visible character remains silent with their mouth closed and reacts naturally until assigned their own cue.
+- For Built-in MiniMax Audio dialogue, put the exact quoted dialogue script only once in the entire finished prompt: inside the Native audio assignment. Timestamp blocks must refer to the assigned cue without quoting it again, and the final Audio section must not repeat the script.
+- Generate speech only in the same language used by the exact supplied dialogue. Never translate it, switch languages, invent foreign-language speech, or add phonetic substitutions, babble, gibberish, invented syllables, filler, repeated phrases, or extra vocalizations.
+- Begin the first spoken cue within the first 0.15 seconds, pace the supplied words naturally across the available clip, and land the final spoken word approximately 0.15-0.30 seconds before the clip ends. Never finish early and then invent speech; never restart a cue or repeat its opening words to fill time.
+- Never turn the list of characters who speak somewhere in the scene into a direction for all of them to say the complete combined dialogue. Never repeat the complete dialogue in every timestamp.
+- Each speaking timestamp must name only its assigned speaker and refer to that speaker's assigned cue without quoting the words again. Do not merge, overlap, transfer, reorder, rewrite, repeat, improvise, omit, or add words.
+- When an exact sung lyric is supplied, require the assigned visible singer to perform it with precise lip, mouth-shape, jaw, facial-muscle, and breathing synchronization to the selected audio mode.
+- For Input Audio singing, quote the exact lyric only once in the Audio 1 assignment. Timestamp blocks must say the singer begins, continues, or completes the currently audible portion of the assigned lyric without quoting the lyric again. Never paste the entire lyric or a generic full-line lip-sync paragraph into every timestamp.
+- For Input Audio, describe singing only during the portion of each timestamp where the vocal is actually audible in Audio 1. Never stretch, restart, or repeat the full lyric across every timestamp. After the supplied vocal ends, close or relax the mouth naturally and fill remaining time with physical action or reaction, not invented vocals.
+- When the scene is explicitly visual-only, instrumental, no-lip-sync, or has no visible character, do not invent visible singing or speaking. In Input Audio mode, Audio 1 remains unchanged as the primary and only audio track; preserve all of it exactly, use the instrumental/no-lip-sync marker only to keep visible mouths naturally relaxed or closed, and never add ambience or sound effects. In Built-in MiniMax Audio mode, generate only the requested ambience and sound effects.
+- In the final Audio: section, restate only the active audio contract. For Input Audio, preserve Audio 1 unchanged as the primary and only audio track and prohibit all generated or added audio. For Built-in MiniMax Audio, generate the ordered dialogue or lyric with the assigned voices and add only subtle requested ambience or sound effects underneath.
 
 CONTINUITY
 - Add a Continuity: section only when identity, clothing, objects, locations, or spatial relationships must remain consistent.
@@ -71,7 +81,10 @@ Generate a [duration]-second [aspect ratio] [visual style] video.
 
 [One separate Image N: or Video N: assignment paragraph for each supplied visual reference. Omit this block only for text-to-video.]
 
-Audio 1: [exact custom-audio assignment; include the exact supplied sung lyric or dialogue and the explicit lip-sync contract when applicable.]
+[Input Audio only] Audio 1: [exact supplied-audio assignment and lip-sync contract.]
+[Built-in MiniMax Audio only] Native audio: [exact generated dialogue/lyric speaker order, voice, silence, and lip-sync contract.]
+
+[When supplied] TEMPORAL / WORLD EFFECT — [copy the complete exact contract here before the first timestamp.]
 
 [0s–...s]
 [Visible action, performance, camera, and environment for this interval.]
@@ -79,17 +92,17 @@ Audio 1: [exact custom-audio assignment; include the exact supplied sung lyric o
 [next timestamp]
 [Visible action, performance, camera, and environment for this interval.]
 
-Audio: [how Audio 1 remains unchanged and how the entire result synchronizes to it.]
+Audio: [the selected mode's final audio contract; never combine Input Audio and Built-in MiniMax Audio wording.]
 
 Continuity: [identity, clothing, environment, spatial, and no-new-elements requirements.]
 
 - Put each timestamp header on its own line.
 - Put a blank line before every media assignment, timestamp block, Audio: section, and Continuity: section.
 - Never collapse the result into one paragraph.
-- Refer to media naturally as Image 1, Image 2, Video 1, and Audio 1. Do not print angle-bracket media tags in the finished prompt.
+- Refer to visual media naturally as Image 1, Image 2, and Video 1. Use Audio 1 only for Input Audio. Use Native audio only for Built-in MiniMax Audio. Do not print angle-bracket media tags in the finished prompt.
 
 SILENT QUALITY CHECK
-Before answering, verify that the timeline starts at 0 seconds, ends at the exact requested duration, contains no gaps or overlaps, gives every action enough time, follows Audio 1, preserves required continuity, visibly performs the exact supplied lyric or dialogue when lip sync is requested, and ends with a deliberate payoff rather than stopping randomly.
+Before answering, verify that the timeline starts at 0 seconds, ends at the exact requested duration, contains no gaps or overlaps, gives every action and dialogue cue enough time, follows only the selected audio mode, preserves required continuity, assigns every exact cue only to its named speaker, keeps non-speaking characters silent, and ends with a deliberate payoff rather than stopping randomly.
 
 OUTPUT RULES
 - Return only the finished MiniMax H3 prompt as plain text.
@@ -104,7 +117,7 @@ _MINIMAX_H3_TEXT_TO_VIDEO_MODE = """MODE: TEXT TO VIDEO
 - Do not claim that an image or video reference exists and do not use Image N or Video N labels.
 - Preserve named subjects, wardrobe, setting, mood, and story requirements from the input.
 - Infer only missing visual and camera details needed to make the scene complete.
-- The only required media label for this custom-audio workflow is Audio 1.
+- Use only the audio label required by the selected audio mode.
 """
 
 
@@ -115,7 +128,7 @@ _MINIMAX_H3_IMAGE_TO_VIDEO_MODE = """MODE: IMAGE TO VIDEO
 - Preserve the visible subject's face, hairstyle, age, body proportions, clothing, accessories, location, and major composition details unless the user explicitly requests a visible transformation.
 - Do not treat Image 1 as a cutaway, a later insert, or a loose style suggestion.
 - Do not invent additional image or video labels.
-- Use Audio 1 only according to the supplied-audio and vocal contract.
+- Follow only the selected audio-mode and vocal contract.
 """
 
 
@@ -125,10 +138,12 @@ _MINIMAX_H3_REFERENCE_TO_VIDEO_MODE = """MODE: REFERENCE TO VIDEO
 - Never assume a fixed purpose from slot number. The supplied ordered assignments are authoritative.
 - Preserve character and location identity from the pictures assigned to those purposes without copying an unwanted pose, crop, camera angle, panel layout, or collage.
 - When a picture is identified as a storyboard grid, interpret its panels as ordered visual beats and composition guidance. Do not generate the grid, borders, panels, labels, or a collage as the output video.
+- A character/person picture may be a multi-view character sheet, turnaround sheet, or contact sheet. All portraits and body views inside that one reference picture depict the same single person. Use the views only to learn that person's identity, face, hair, clothing, and proportions.
+- Render exactly one on-screen instance of each distinct named subject. Never interpret alternate views in a character sheet as additional people, and never duplicate, clone, twin, multiply, or add background copies of a referenced subject unless the user explicitly requests duplicates.
 - When start and end pictures are assigned, begin from the start picture and arrive coherently at the end picture. Follow the user's requested transition behavior, including surreal morph, cinematic non-morphing continuation, or longer action between the endpoints.
 - When Image 1 is assigned as the exact start frame and later images are character references, Image 1 controls only the opening composition, pose, camera angle, environment, and lighting. The character-reference images remain authoritative for face, hair, clothing, body proportions, and identity details that are hidden in Image 1. Use those identity details to keep the character correct when they turn around, change angle, become partially occluded, or move into a different framing.
 - Do not mention any image label that was not supplied.
-- Use Audio 1 only according to the supplied-audio and vocal contract.
+- Follow only the selected audio-mode and vocal contract.
 """
 
 
@@ -139,7 +154,7 @@ _MINIMAX_H3_VIDEO_TO_VIDEO_MODE = """MODE: VIDEO TO VIDEO
 - For continuation or extension, begin coherently from the supplied video's ending state and preserve identity, clothing, location, object positions, movement direction, and camera logic unless the user requests a transition.
 - If ordered image references are also supplied, use their exact Image N labels and stated purposes without overriding the assigned role of the video references.
 - Do not mention image or video labels that were not supplied.
-- Audio 1 is the authoritative custom project audio. Do not treat audio embedded in a reference video as the soundtrack unless the input context explicitly assigns that audio a purpose.
+- Follow only the selected audio-mode contract. Do not treat audio embedded in a reference video as the soundtrack unless the input context explicitly assigns that audio a purpose.
 """
 
 
@@ -173,4 +188,38 @@ MINIMAX_H3_INSTRUCTION_KEYS_BY_MODE = {
     "image_to_video": "minimax_h3_image_to_video",
     "reference_to_video": "minimax_h3_reference_to_video",
     "video_to_video": "minimax_h3_video_to_video",
+}
+
+
+MINIMAX_H3_SHORT_FILM_GUIDED_CONTRACT = """SHORT FILM — GUIDED FILM AUTOMATION
+- Treat this as a dialogue-first narrative film scene, not a music-video performance unless the scene card explicitly says otherwise.
+- Use the supplied premise, scene story beat, ordered speaker assignments, character references, location reference, acting direction, shot, camera direction, audio direction, and continuity to construct a clear dramatic beat.
+- Preserve every supplied dialogue cue verbatim and in its exact speaker order. Never transfer words between characters, merge turns, repeat a line, or add dialogue.
+- The ordered speaker assignments are authoritative for who speaks. Other visible characters remain silent unless they have their own cue, and should react naturally.
+- The planner may fill only genuinely missing visual connective details needed to stage a coherent shot. It must not replace the user's plot, casting, dialogue, setting, or requested action.
+- Use natural short-film vocabulary: blocking, eyelines, reaction shots, motivated camera movement, screen direction, physical business, subtext, and continuity where useful.
+- Do not output ID-LoRA sections, LTX syntax, [VISUAL]/[SPEECH]/[SOUNDS] labels, workflow terminology, or model metadata.
+"""
+
+
+MINIMAX_H3_SHORT_FILM_CUSTOM_CONTRACT = """SHORT FILM — FULLY CUSTOM / MANUAL SOURCE CONTRACT
+- Every populated scene-card field is locked, authoritative source material: ordered dialogue and speakers, story beat, action, performance, facial direction, shot/framing, camera movement, setting, character and location references, audio direction, continuity, and notes.
+- Your only creative task is to format those exact instructions into the required MiniMax H3 prompt structure and timestamp them across the exact supplied duration.
+- Do not invent, rewrite, polish, paraphrase, reorder, merge, omit, replace, or contradict any supplied dialogue, speaker, action, story beat, camera choice, setting, sound, or continuity detail.
+- Never add dialogue, narration, lyrics, a new speaker, a new character, a new action, a new plot beat, a new location, or an unrequested camera move.
+- If the user leaves a field blank, leave that decision unspecified. Do not fill the blank with an inferred story choice.
+- Preserve ordered dialogue cues word-for-word and assign each cue only to its named speaker. Use silence, breathing, reactions, held expressions, existing action, and requested ambience—not invented speech—when dialogue finishes before the clip ends.
+- Do not output ID-LoRA sections, LTX syntax, [VISUAL]/[SPEECH]/[SOUNDS] labels, workflow terminology, or model metadata.
+"""
+
+
+MINIMAX_H3_SHORT_FILM_GUIDED_INSTRUCTIONS_BY_MODE = {
+    mode: instructions + "\n" + MINIMAX_H3_SHORT_FILM_GUIDED_CONTRACT
+    for mode, instructions in MINIMAX_H3_INSTRUCTIONS_BY_MODE.items()
+}
+
+
+MINIMAX_H3_SHORT_FILM_CUSTOM_INSTRUCTIONS_BY_MODE = {
+    mode: instructions + "\n" + MINIMAX_H3_SHORT_FILM_CUSTOM_CONTRACT
+    for mode, instructions in MINIMAX_H3_INSTRUCTIONS_BY_MODE.items()
 }

--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -40,6 +40,8 @@ from .VRGDG_MiniMaxH3PromptInstructions import (
     MINIMAX_H3_REFERENCE_TO_VIDEO_INSTRUCTIONS,
     MINIMAX_H3_TEXT_TO_VIDEO_INSTRUCTIONS,
     MINIMAX_H3_VIDEO_TO_VIDEO_INSTRUCTIONS,
+    MINIMAX_H3_SHORT_FILM_GUIDED_INSTRUCTIONS_BY_MODE,
+    MINIMAX_H3_SHORT_FILM_CUSTOM_INSTRUCTIONS_BY_MODE,
 )
 
 
@@ -518,8 +520,9 @@ def _open_tk_picker(kind):
                     ("All files", "*.*"),
                 ],
             )
-        elif kind == "project_folder":
-            path = filedialog.askdirectory(title="Choose project folder")
+        elif kind in {"project_folder", "project_root"}:
+            title = "Choose projects root folder" if kind == "project_root" else "Choose project folder"
+            path = filedialog.askdirectory(title=title)
         else:
             raise ValueError(f"Unknown picker type: {kind}")
         return str(path or "")
@@ -565,6 +568,13 @@ if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console
 Add-Type -AssemblyName System.Windows.Forms
 $dialog = New-Object System.Windows.Forms.FolderBrowserDialog
 $dialog.Description = 'Choose project folder'
+if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Write($dialog.SelectedPath) }
+"""
+    elif kind == "project_root":
+        script = r"""
+Add-Type -AssemblyName System.Windows.Forms
+$dialog = New-Object System.Windows.Forms.FolderBrowserDialog
+$dialog.Description = 'Choose projects root folder'
 if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Write($dialog.SelectedPath) }
 """
     else:
@@ -627,6 +637,11 @@ def _project_target_from_payload(payload, preferred_key="project_folder"):
         raw = f"VRGDG_Project_{time.strftime('%Y%m%d_%H%M%S')}"
     if os.path.isabs(raw) or os.path.dirname(raw):
         return os.path.abspath(raw)
+    project_root = str(payload.get("project_root", "") or "").strip().strip('"')
+    if project_root:
+        if not os.path.isabs(project_root):
+            raise ValueError("Custom project root must be a full absolute folder path.")
+        return os.path.join(os.path.abspath(project_root), _safe_project_name(raw))
     return os.path.join(folder_paths.get_output_directory(), _safe_project_name(raw))
 
 
@@ -890,6 +905,10 @@ _BUILDER_INSTRUCTION_DEFAULTS = {
     "t2v": _T2V_INSTRUCTIONS,
     "zimage_t2i": _STANDARD_IMAGE_T2I_INSTRUCTIONS,
 }
+for _minimax_mode, _instructions in MINIMAX_H3_SHORT_FILM_GUIDED_INSTRUCTIONS_BY_MODE.items():
+    _BUILDER_INSTRUCTION_DEFAULTS[f"minimax_h3_short_film_guided_{_minimax_mode}"] = _instructions
+for _minimax_mode, _instructions in MINIMAX_H3_SHORT_FILM_CUSTOM_INSTRUCTIONS_BY_MODE.items():
+    _BUILDER_INSTRUCTION_DEFAULTS[f"minimax_h3_short_film_custom_{_minimax_mode}"] = _instructions
 
 _BUILDER_INSTRUCTION_LABELS = {
     "flux_klein_t2i": "Flux/Klein Text to Image",
@@ -908,6 +927,10 @@ _BUILDER_INSTRUCTION_LABELS = {
     "t2v": "Text to Video",
     "zimage_t2i": "ZImage Text to Image",
 }
+for _minimax_mode in MINIMAX_H3_SHORT_FILM_GUIDED_INSTRUCTIONS_BY_MODE:
+    _mode_label = _minimax_mode.replace("_", " ").title()
+    _BUILDER_INSTRUCTION_LABELS[f"minimax_h3_short_film_guided_{_minimax_mode}"] = f"MiniMax H3 Guided Short Film - {_mode_label}"
+    _BUILDER_INSTRUCTION_LABELS[f"minimax_h3_short_film_custom_{_minimax_mode}"] = f"MiniMax H3 Fully Custom Short Film - {_mode_label}"
 
 _BUILDER_INSTRUCTION_PRESET_GROUPS = {
     "ernie_t2i": "standard_image_t2i",
@@ -3526,17 +3549,35 @@ def _clean_lm_studio_plain_text(text):
 
 
 def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
-    """Keep H3 prompts readable and make exact custom-audio lip sync explicit."""
+    """Keep H3 prompts readable and enforce the selected MiniMax audio contract."""
     payload = payload if isinstance(payload, dict) else {}
     cleaned = _clean_lm_studio_plain_text(text).replace("\r\n", "\n").replace("\r", "\n")
     cleaned = re.sub(r"<\s*Picture\s+(\d+)\s*>", r"Image \1", cleaned, flags=re.IGNORECASE)
     cleaned = re.sub(r"<\s*Video\s+(\d+)\s*>", r"Video \1", cleaned, flags=re.IGNORECASE)
     cleaned = re.sub(r"<\s*Audio\s+1\s*>", "Audio 1", cleaned, flags=re.IGNORECASE)
 
+    raw_audio_mode = str(payload.get("audio_mode") or payload.get("minimax_h3_audio_mode") or "input_audio").strip().lower().replace("-", "_").replace(" ", "_")
+    native_audio = raw_audio_mode in {"built_in_audio", "native_audio", "generated_audio"}
+    speaker_assignments_raw = payload.get("speaker_assignments") or payload.get("minimax_speaker_assignments") or payload.get("dialogue_cues") or []
+    if isinstance(speaker_assignments_raw, str):
+        try:
+            speaker_assignments_raw = json.loads(speaker_assignments_raw)
+        except Exception:
+            speaker_assignments_raw = []
+    speaker_assignments = []
+    if isinstance(speaker_assignments_raw, list):
+        for item in speaker_assignments_raw:
+            if not isinstance(item, dict):
+                continue
+            speaker_name = str(item.get("speaker_name") or item.get("speaker") or item.get("name") or "").strip()
+            cue_text = str(item.get("text") or item.get("dialogue") or item.get("line") or "").strip()
+            if cue_text:
+                speaker_assignments.append({"speaker_name": speaker_name or "The assigned speaker", "text": cue_text})
+
     timestamp_pattern = r"\[\s*\d+(?:\.\d+)?s?\s*[-\u2013\u2014]\s*\d+(?:\.\d+)?s?\s*\]"
-    section_pattern = rf"(?:Image\s+\d+|Video\s+\d+|Audio\s+1|Audio|Continuity)\s*:|{timestamp_pattern}"
+    section_pattern = rf"(?:Image\s+\d+|Video\s+\d+|Audio\s+1|Native\s+audio|Audio|Continuity)\s*:|{timestamp_pattern}"
     cleaned = re.sub(rf"[ \t]*(?={section_pattern})", "\n\n", cleaned, flags=re.IGNORECASE)
-    cleaned = re.sub(rf"({timestamp_pattern})[ \t]*", r"\1\n", cleaned)
+    cleaned = re.sub(rf"({timestamp_pattern})[ \t]*(?:\n[ \t]*)?", r"\1\n", cleaned)
     cleaned = re.sub(r"\n[ \t]+", "\n", cleaned)
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
@@ -3553,6 +3594,7 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
     else:
         singer_names = []
     performer = " and ".join(singer_names[:2]) if singer_names else "the visible performer"
+    ordered_native_dialogue = bool(native_audio and performance_mode == "speaking" and speaker_assignments)
 
     def insert_before_first_timeline(block):
         nonlocal cleaned
@@ -3562,7 +3604,70 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
         else:
             cleaned = f"{cleaned.rstrip()}\n\n{block}"
 
-    if instruction_key == "minimax_h3_image_to_video" and not re.search(r"(?im)^Image\s+1\s*:", cleaned):
+    def insert_before_continuity(block):
+        nonlocal cleaned
+        match = re.search(r"(?im)^Continuity\s*:", cleaned)
+        if match:
+            cleaned = f"{cleaned[:match.start()].rstrip()}\n\n{block}\n\n{cleaned[match.start():].lstrip()}"
+        else:
+            cleaned = f"{cleaned.rstrip()}\n\n{block}"
+
+    def enforce_visual_only_timeline():
+        """Remove positive vocal actions from H3 timestamps and add a final B-roll contract."""
+        nonlocal cleaned
+        positive_vocal = re.compile(
+            r"\b(?:sing(?:s|ing)?|sang|sung|rap(?:s|ping)?|lip[ -]?sync(?:s|ing)?|"
+            r"speak(?:s|ing)?|say(?:s|ing)?|said|mouth(?:s|ed|ing)?|whisper(?:s|ing)?|"
+            r"perform(?:s|ing)?\s+(?:the\s+)?(?:saved\s+|exact\s+)?(?:lyric|dialogue|words?))\b",
+            flags=re.IGNORECASE,
+        )
+        negative_safety = re.compile(
+            r"\b(?:no|not|never|without|does\s+not|do\s+not|must\s+not|cannot|can['’]t|don['’]t)\b",
+            flags=re.IGNORECASE,
+        )
+        timeline_block_pattern = re.compile(
+            rf"({timestamp_pattern}\n)(.*?)(?=\n\n(?:{timestamp_pattern}|Audio\s*:|Continuity\s*:)|$)",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+
+        def clean_timeline_block(match):
+            parts = [
+                part.strip()
+                for part in re.split(r"(?<=[.!?])\s+|\n+", match.group(2).strip())
+                if part.strip()
+            ]
+            kept = [
+                part for part in parts
+                if not (positive_vocal.search(part) and not negative_safety.search(part))
+            ]
+            if not kept:
+                kept.append("Continue the requested visual action, camera movement, and environmental motion naturally.")
+            kept.append(
+                "All visible subjects remain silent and do not sing, speak, rap, mouth words, or lip-sync; "
+                "every mouth stays naturally relaxed or closed."
+            )
+            return f"{match.group(1)}{' '.join(kept)}"
+
+        cleaned = timeline_block_pattern.sub(clean_timeline_block, cleaned)
+        safety_block = (
+            "VISUAL-ONLY B-ROLL / NO-LIP-SYNC SAFETY — MANDATORY AND FINAL:\n"
+            "This scene is explicitly B-roll / visual-only. This safety block overrides any conflicting lyric, singer, "
+            "speaker, dialogue, voice, timestamp, facial-performance, or mouth instruction elsewhere in the prompt.\n"
+            "No visible subject sings, speaks, raps, whispers, lip-syncs, mouths words, or performs the saved lyric. "
+            "Keep every visible mouth naturally relaxed or closed and use only visual acting, physical action, dancing "
+            "without vocal performance, camera motion, and environmental motion.\n"
+            + (
+                "Built-in MiniMax Audio: generate only requested environmental ambience and sound effects. Do not "
+                "generate speech, singing, dialogue, lyrics, narration, voices, or vocal layers."
+                if native_audio else
+                "Input Audio: preserve Audio 1 completely unchanged as the soundtrack and timing reference, including "
+                "any audible vocals, but treat those vocals as off-screen soundtrack only. No visible subject may synchronize to them."
+            )
+            + "\nTreat the saved lyric only as hidden mood/story context; never quote it as dialogue or describe anyone performing it."
+        )
+        insert_before_first_timeline(safety_block)
+
+    if instruction_key.endswith("image_to_video") and not re.search(r"(?im)^Image\s+1\s*:", cleaned):
         image_assignment = (
             "Image 1: use as the exact start frame, character appearance and clothing reference, "
             "environment reference, lighting reference, and composition reference."
@@ -3573,28 +3678,77 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
         else:
             insert_before_first_timeline(image_assignment)
 
-    if not re.search(r"(?im)^Audio\s+1\s*:", cleaned):
+    if native_audio:
+        native_assignment_pattern = re.compile(
+            rf"(?ims)^(?:Audio\s+1|Native\s+audio)\s*:.*?(?=\n\n(?:{timestamp_pattern}|Image\s+\d+\s*:|Video\s+\d+\s*:|Audio\s*:|Continuity\s*:)|\Z)"
+        )
+        cleaned = native_assignment_pattern.sub("", cleaned).strip()
+        if ordered_native_dialogue:
+            ordered_cues = "; ".join(
+                f'{cue["speaker_name"]} says exactly “{cue["text"]}”'
+                for cue in speaker_assignments
+            )
+            native_assignment = (
+                f"Native audio: Generate spoken dialogue in this exact order: {ordered_cues}. "
+                "Only the assigned speaker speaks during each cue. Every other visible character remains silent with their mouth closed and reacts naturally. "
+                "Synchronize each assigned speaker’s lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that speaker’s generated words. "
+                "Speak only in the same language used by the exact supplied dialogue; do not translate or switch languages. "
+                "Pronounce every supplied word clearly at a natural measured pace. Do not generate gibberish, babble, invented syllables, filler, phonetic substitutions, repeated phrases, or extra vocalizations. "
+                "Begin the first cue within the first 0.15 seconds, pace the exact words naturally across the available clip, and land the final word approximately 0.15-0.30 seconds before the clip ends. Never finish early and fill time with invented speech. "
+                "Do not merge speakers, overlap or reorder cues, transfer words, rewrite, restart, repeat, improvise, omit, or add dialogue."
+            )
+        elif lyric_text and not no_lip_sync:
+            action = "speaking" if performance_mode == "speaking" else "singing"
+            native_assignment = (
+                f"Native audio: Generate {performer} {action} the exact line “{lyric_text}”. "
+                "Synchronize the visible performance precisely to the generated words and preserve the exact wording without additions, repetition, or replacement."
+            )
+        elif no_lip_sync:
+            native_assignment = (
+                "Native audio: Generate only the requested environmental ambience and sound effects. "
+                "Do not generate speech, singing, lyrics, dialogue, voices, or visible mouth synchronization."
+            )
+        else:
+            native_assignment = (
+                "Native audio: Generate only appropriate environmental ambience and requested sound effects. "
+                "Do not invent speech, singing, lyrics, dialogue, or voices."
+            )
+        insert_before_first_timeline(native_assignment)
+    else:
         if lyric_text and not no_lip_sync:
             action = "says" if performance_mode == "speaking" else "is singing"
             vocal_kind = "spoken" if performance_mode == "speaking" else "sung"
             audio_assignment = (
-                f"Audio 1: use as the exact vocal, timing, and lip-sync reference. {performer} {action} the exact line "
+                "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, "
+                f"rhythm, phrasing, tone, and duration, and use it as the exact vocal, timing, and lip-sync reference. "
+                f"{performer} {action} the exact line "
                 f"“{lyric_text}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely "
-                f"to that {vocal_kind} line in Audio 1. Do not replace, alter, extend, or add vocals."
+                f"to that {vocal_kind} line in Audio 1. Do not generate, add, replace, remix, or extend any music, "
+                "ambience, dialogue, vocals, or sound effects."
             )
         elif no_lip_sync:
             audio_assignment = (
-                "Audio 1: use unchanged as the exact timing reference. This scene is visual-only; do not show singing, "
-                "speaking, or mouth synchronization."
+                "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, "
+                "rhythm, phrasing, tone, and duration. This portion contains no vocal line for the visible character, "
+                "so the character does not sing, speak, or lip-sync; keep the mouth naturally relaxed or closed. "
+                "Do not generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects."
             )
         else:
             audio_assignment = (
-                "Audio 1: use unchanged as the exact performance, movement, and timing reference. "
-                "Do not invent lyrics, dialogue, replacement music, or replacement vocals."
+                "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, "
+                "rhythm, phrasing, tone, and duration. Use it as the exact performance and movement reference. "
+                "Do not generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects."
             )
+        input_audio_assignment_pattern = re.compile(
+            rf"(?ims)^Audio\s+1\s*:.*?(?=\n\n(?:{timestamp_pattern}|Image\s+\d+\s*:|Video\s+\d+\s*:|Audio\s*:|Continuity\s*:|REFERENCE\s+SUBJECT\s+COUNT\b)|\Z)"
+        )
+        cleaned = input_audio_assignment_pattern.sub("", cleaned).strip()
         insert_before_first_timeline(audio_assignment)
 
-    if lyric_text and not no_lip_sync:
+    if no_lip_sync:
+        enforce_visual_only_timeline()
+
+    if lyric_text and not no_lip_sync and not ordered_native_dialogue:
         lines = cleaned.split("\n")
         exact_line_lower = lyric_text.casefold()
         for index, line in enumerate(lines):
@@ -3626,37 +3780,62 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
             if visibly_performed:
                 return f"{header}{body}"
             required_action = (
-                f"Throughout this interval, {performer} {vocal_verb} “{lyric_text}” with precise lip, mouth-shape, jaw, "
-                f"facial-muscle, and breathing synchronization to the {sync_kind} in Audio 1."
+                f"During only the portion of this interval where the {sync_kind} is audible in Audio 1, {performer} "
+                f"{vocal_verb} “{lyric_text}” with precise lip, mouth-shape, jaw, facial-muscle, and breathing synchronization. "
+                "When the supplied vocal ends, the mouth closes or relaxes naturally; never stretch, restart, or repeat the line to fill the interval."
             )
             return f"{header}{body.rstrip()} {required_action}".strip()
 
         cleaned = timeline_block_pattern.sub(ensure_vocal_in_timeline, cleaned)
 
-    if not re.search(r"(?im)^Audio\s*:", cleaned):
-        if lyric_text and not no_lip_sync:
+    if native_audio:
+        native_summary_pattern = re.compile(
+            r"(?ims)^Audio\s*:.*?(?=\n\n(?:Continuity\s*:|MINIMAX\s+NATIVE\s+VOICE\s+IDENTITY\b)|\Z)"
+        )
+        cleaned = native_summary_pattern.sub("", cleaned).strip()
+        if ordered_native_dialogue:
             audio_summary = (
-                f"Audio: Use Audio 1 unchanged as the primary audio track. Preserve its exact voice, timing, phrasing, tone, "
-                f"and duration, and keep the lip sync exact to “{lyric_text}”. Do not add replacement music, dialogue, or vocal layers."
+                "Audio: Generate the ordered spoken dialogue as the primary audio track using each character’s assigned voice. "
+                "Preserve every word and speaker turn exactly, keep the visible speaker’s lip sync precise, and keep all non-speaking characters silent. "
+                "Add only subtle low-level requested ambience and sound effects underneath. Do not add narration, extra dialogue, music, or vocal layers."
+            )
+        elif lyric_text and not no_lip_sync:
+            vocal_kind = "spoken line" if performance_mode == "speaking" else "sung lyric"
+            audio_summary = (
+                f"Audio: Generate the exact {vocal_kind} “{lyric_text}” as the primary audio track and synchronize the visible performance precisely to it. "
+                "Add only subtle low-level requested ambience and sound effects underneath. Do not add replacement words, extra dialogue, or vocal layers."
             )
         else:
             audio_summary = (
-                "Audio: Use Audio 1 unchanged as the primary audio track and preserve its exact timing and duration. "
-                "Do not add replacement music, dialogue, or vocal layers."
+                "Audio: Generate only the requested environmental ambience and sound effects. "
+                "Do not add speech, singing, dialogue, lyrics, narration, or vocal layers."
             )
-        cleaned = f"{cleaned.rstrip()}\n\n{audio_summary}"
-    elif lyric_text and not no_lip_sync:
-        lines = cleaned.split("\n")
-        for index, line in enumerate(lines):
-            if re.match(r"^Audio\s*:", line, flags=re.IGNORECASE):
-                if lyric_text.casefold() not in line.casefold() or "lip" not in line.casefold():
-                    lines[index] = (
-                        f"{line.rstrip()} Use Audio 1 unchanged as the primary audio track, preserve its exact voice, timing, "
-                        f"phrasing, tone, and duration, and keep the lip sync exact to “{lyric_text}”. "
-                        "Do not add replacement music, dialogue, or vocal layers."
-                    )
-                break
-        cleaned = "\n".join(lines)
+        insert_before_continuity(audio_summary)
+    else:
+        if lyric_text and not no_lip_sync:
+            audio_summary = (
+                "Audio: Audio 1 remains unchanged as the primary and only audio track. Preserve its exact music, vocals, "
+                f"timing, rhythm, phrasing, tone, and duration, and keep the lip sync exact to “{lyric_text}”. "
+                "Do not generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects."
+            )
+        elif no_lip_sync:
+            audio_summary = (
+                "Audio: Audio 1 remains unchanged as the primary and only audio track. Preserve its exact music, vocals, "
+                "timing, rhythm, phrasing, tone, and duration. The visible character does not sing, speak, or lip-sync "
+                "during this non-vocal portion and keeps the mouth naturally relaxed or closed. Do not generate, add, "
+                "replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects."
+            )
+        else:
+            audio_summary = (
+                "Audio: Audio 1 remains unchanged as the primary and only audio track. Preserve its exact music, vocals, "
+                "timing, rhythm, phrasing, tone, and duration. Do not generate, add, replace, remix, or extend any music, "
+                "ambience, dialogue, vocals, or sound effects."
+            )
+        input_audio_summary_pattern = re.compile(
+            r"(?ims)^Audio\s*:.*?(?=\n\n(?:Audio\s+1\s*:|Continuity\s*:|REFERENCE\s+SUBJECT\s+COUNT\b)|\Z)"
+        )
+        cleaned = input_audio_summary_pattern.sub("", cleaned).strip()
+        insert_before_continuity(audio_summary)
 
     if not re.search(r"(?im)^Continuity\s*:", cleaned):
         continuity = (
@@ -3664,6 +3843,91 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
             "relationships throughout. Do not introduce new characters, objects, text, logos, captions, or scene changes unless explicitly requested."
         )
         cleaned = f"{cleaned.rstrip()}\n\n{continuity}"
+
+    if native_audio:
+        cleaned = re.sub(r"\bAudio\s+1\b", "the generated native audio", cleaned, flags=re.IGNORECASE)
+
+    if ordered_native_dialogue:
+        # Keep the exact dialogue script in one authoritative place. Repeating a full
+        # quoted cue in timeline/summary sections can make H3 restart or repeat it.
+        native_block = re.search(
+            rf"(?ims)^Native\s+audio\s*:.*?(?=\n\n{timestamp_pattern}|\Z)",
+            cleaned,
+        )
+        if native_block:
+            prefix = cleaned[:native_block.end()]
+            suffix = cleaned[native_block.end():]
+            for cue in speaker_assignments:
+                cue_text = str(cue.get("text") or "").strip()
+                if not cue_text:
+                    continue
+                escaped = re.escape(cue_text)
+                suffix = re.sub(
+                    rf"[\u201c\"]\s*{escaped}\s*[\u201d\"]",
+                    "the assigned cue",
+                    suffix,
+                    flags=re.IGNORECASE,
+                )
+                suffix = re.sub(escaped, "the assigned cue", suffix, flags=re.IGNORECASE)
+            cleaned = prefix + suffix
+
+    try:
+        camera_speed = max(0.0, min(10.0, float(payload.get("camera_motion_speed", 4))))
+    except Exception:
+        camera_speed = 4.0
+    try:
+        character_speed = max(0.0, min(10.0, float(payload.get("character_motion_speed", 4))))
+    except Exception:
+        character_speed = 4.0
+
+    if camera_speed >= 7:
+        camera_replacements = [
+            (r"\bslow cinematic drift\b", "energetic cinematic tracking drift"),
+            (r"\bslow orbit\b", "energetic orbit"),
+            (r"\bslow (left|right) orbit\b", r"energetic \1 orbit"),
+            (r"\bslow zoom out\b", "brisk pull-back reveal"),
+            (r"\bslow (left|right|side|lateral) drift\b", r"brisk \1 tracking drift"),
+            (r"\bslow (pan|tilt|track|tracking|pull[ -]?back|drift)\b", r"brisk \1"),
+            (r"\bgentle lateral drift\b", "energetic lateral tracking"),
+            (r"\bgentle pan reveal\b", "brisk pan reveal"),
+            (r"\bgentle (pan|tilt|orbit|drift|camera movement)\b", r"brisk \1"),
+            (r"\bsubtle handheld movement\b", "active handheld tracking"),
+            (r"\bsubtle handheld camera\b", "active handheld camera"),
+            (r"\bsubtle handheld follow\b", "energetic handheld follow"),
+            (r"\bsubtle rack focus\b", "quick rack focus"),
+            (r"\bsubtle energetic orbit\b", "energetic orbit"),
+            (r"\bsubtle settling pause\b", "active reframing beat"),
+            (r"\bsubtle orbit movement\b", "energetic orbit movement"),
+            (r"\b(?:quiet handheld hold|locked-off reaction hold|locked-off shot)\b", "active handheld reaction tracking"),
+            (r"\brestrained pan\b", "brisk pan"),
+        ]
+        for pattern, replacement in camera_replacements:
+            cleaned = re.sub(pattern, replacement, cleaned, flags=re.IGNORECASE)
+        if not re.search(r"\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|pull-back|push|dolly|handheld|reveal)\b", cleaned, flags=re.IGNORECASE):
+            first_timeline = re.search(rf"(?ims)({timestamp_pattern}\n)(.*?)(?=\n\n(?:{timestamp_pattern}|Audio\s*:|Continuity\s*:)|$)", cleaned)
+            if first_timeline:
+                body = first_timeline.group(2).rstrip()
+                replacement = f"{first_timeline.group(1)}{body} The camera uses energetic tracking throughout this interval and never settles into a static hold."
+                cleaned = cleaned[:first_timeline.start()] + replacement + cleaned[first_timeline.end():]
+
+    if character_speed >= 4 and not no_visible_character:
+        physical_action_pattern = r"\b(?:walks?|steps?|strides?|runs?|sprints?|dances?|crosses?|lunges?|reaches?|pushes?|pulls?|climbs?|fights?|brushes?|sweeps?|gestures?|interacts?|grabs?|lifts?|paces?)\b"
+        timeline_text = "\n".join(
+            match.group(2)
+            for match in re.finditer(
+                rf"(?ims)({timestamp_pattern}\n)(.*?)(?=\n\n(?:{timestamp_pattern}|Audio\s*:|Continuity\s*:)|$)",
+                cleaned,
+            )
+        )
+        if not re.search(physical_action_pattern, timeline_text, flags=re.IGNORECASE):
+            first_timeline = re.search(rf"(?ims)({timestamp_pattern}\n)(.*?)(?=\n\n(?:{timestamp_pattern}|Audio\s*:|Continuity\s*:)|$)", cleaned)
+            if first_timeline:
+                body = first_timeline.group(2).rstrip()
+                replacement = (
+                    f"{first_timeline.group(1)}{body} The visible subject performs a clear physical action with the body, hands, "
+                    "or surrounding set instead of relying on facial movement alone."
+                )
+                cleaned = cleaned[:first_timeline.start()] + replacement + cleaned[first_timeline.end():]
 
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
     return cleaned
@@ -8076,6 +8340,58 @@ def _save_builder_session(payload):
     segments = session.get("segments", [])
     if not isinstance(segments, list):
         segments = []
+    # A stale browser inspector/autosave must never be able to erase most of a
+    # populated transcription in one ordinary save. Preserve blanked lyric
+    # fields when the incoming session contains the same scene IDs but suddenly
+    # loses at least half of two or more existing lyric lines. A deliberate bulk
+    # clearing tool can opt out explicitly; normal one-line edits remain valid.
+    session_path = _session_path(project_folder)
+    if not bool(session.get("allow_bulk_lyric_clear")) and os.path.isfile(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8-sig") as handle:
+                existing_session = json.load(handle)
+            existing_segments = existing_session.get("segments", []) if isinstance(existing_session, dict) else []
+            existing_by_id = {
+                str(item.get("id") or "").strip(): item
+                for item in existing_segments
+                if isinstance(item, dict) and str(item.get("id") or "").strip()
+            }
+            matched = [
+                (item, existing_by_id.get(str(item.get("id") or "").strip()))
+                for item in segments
+                if isinstance(item, dict)
+            ]
+            matched = [(incoming, existing) for incoming, existing in matched if isinstance(existing, dict)]
+            existing_nonblank = [
+                (incoming, existing)
+                for incoming, existing in matched
+                if str(existing.get("lyric_text") or "").strip()
+            ]
+            erased = [
+                (incoming, existing)
+                for incoming, existing in existing_nonblank
+                if not str(incoming.get("lyric_text") or "").strip()
+            ]
+            catastrophic = (
+                len(existing_nonblank) >= 2
+                and len(erased) >= 2
+                and len(erased) * 2 >= len(existing_nonblank)
+            )
+            if catastrophic:
+                lyric_fields = (
+                    "lyric_text", "lyric_no_lip_sync", "lyric_section",
+                    "lyric_singers", "performance_mode", "no_character_present",
+                )
+                for incoming, existing in erased:
+                    for key in lyric_fields:
+                        if key in existing:
+                            incoming[key] = existing[key]
+                print(
+                    "[VRGDG Music Builder] Prevented accidental bulk lyric clearing: "
+                    f"restored {len(erased)} of {len(existing_nonblank)} populated scene lines."
+                )
+        except Exception as exc:
+            print(f"[VRGDG Music Builder] Lyric save safety check skipped: {exc}")
     overlay_segments = session.get("overlay_segments", [])
     if not isinstance(overlay_segments, list):
         overlay_segments = []
@@ -9050,39 +9366,54 @@ def _load_builder_session(project_folder):
     }
 
 
-def _list_builder_projects():
+def _list_builder_projects(project_root=""):
     output_dir = os.path.abspath(folder_paths.get_output_directory())
     projects = []
-    if not os.path.isdir(output_dir):
-        return {"projects": projects, "output_dir": output_dir}
-    for name in os.listdir(output_dir):
-        folder = os.path.join(output_dir, name)
-        if not os.path.isdir(folder):
+    roots = [output_dir]
+    custom_root = str(project_root or "").strip().strip('"')
+    if custom_root and os.path.isabs(custom_root):
+        custom_root = os.path.abspath(custom_root)
+        if os.path.normcase(custom_root) != os.path.normcase(output_dir):
+            roots.append(custom_root)
+    seen = set()
+    for root in roots:
+        if not os.path.isdir(root):
             continue
-        session_path = _session_path(folder)
-        if not os.path.isfile(session_path):
-            continue
-        try:
-            mtime = os.path.getmtime(session_path)
-        except OSError:
-            mtime = 0
-        scene_count = 0
-        try:
-            with open(session_path, "r", encoding="utf-8-sig") as handle:
-                session = json.load(handle)
-            segments = session.get("segments", []) if isinstance(session, dict) else []
-            scene_count = len(segments) if isinstance(segments, list) else 0
-        except Exception:
+        for name in os.listdir(root):
+            folder = os.path.abspath(os.path.join(root, name))
+            folder_key = os.path.normcase(folder)
+            if folder_key in seen or not os.path.isdir(folder):
+                continue
+            session_path = _session_path(folder)
+            if not os.path.isfile(session_path):
+                continue
+            seen.add(folder_key)
+            try:
+                mtime = os.path.getmtime(session_path)
+            except OSError:
+                mtime = 0
             scene_count = 0
-        projects.append({
-            "name": name,
-            "project_folder": os.path.abspath(folder),
-            "session_path": os.path.abspath(session_path),
-            "updated": mtime,
-            "scene_count": scene_count,
-        })
+            try:
+                with open(session_path, "r", encoding="utf-8-sig") as handle:
+                    session = json.load(handle)
+                segments = session.get("segments", []) if isinstance(session, dict) else []
+                scene_count = len(segments) if isinstance(segments, list) else 0
+            except Exception:
+                scene_count = 0
+            try:
+                can_delete = os.path.commonpath([output_dir, folder]) == output_dir
+            except ValueError:
+                can_delete = False
+            projects.append({
+                "name": name,
+                "project_folder": folder,
+                "session_path": os.path.abspath(session_path),
+                "updated": mtime,
+                "scene_count": scene_count,
+                "can_delete": can_delete,
+            })
     projects.sort(key=lambda item: item.get("updated", 0), reverse=True)
-    return {"projects": projects, "output_dir": output_dir}
+    return {"projects": projects, "output_dir": output_dir, "project_roots": roots}
 
 
 def _delete_builder_project(payload):
@@ -9697,7 +10028,7 @@ def _ensure_music_builder_routes():
     @server_instance.routes.get("/vrgdg/music_builder/list_projects")
     async def vrgdg_music_builder_list_projects(request):
         try:
-            result = _list_builder_projects()
+            result = _list_builder_projects(request.query.get("project_root", ""))
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -73,10 +73,12 @@ Rules:
 * Do not copy still-image pose language, stillness language, gentle/poised/static wording, or photography-only wording from `text_to_image_prompt` into the video motion plan.
 * User motion fields, `character_motion_guidance`, `camera_motion_speed_guidance`, `camera_guidance`, `performance_direction`, and scene story beat control animation, body action, camera movement, and performance energy.
 * If motion speed guidance is high, it overrides calm, poised, subtle, static, steady, restrained, quiet, or hold wording from the image prompt or first frame.
-* For camera speed 9-10, include two or more coordinated camera actions in the same scene when readable; do not end with "then holds", "holds on", "settles into a hold", "static hold", or "steady hold" unless the user explicitly asks for a hold.
-* For character motion speed 9-10, make the subject perform a clear full-body action such as striding, turning, crossing the space, forceful gestures, dancing, running, fighting, climbing, or interacting with the set; avoid describing the subject as only poised, still, standing, subtle, quiet, or steady.
+* For camera speed 7-8, use energetic, visibly active camera movement; do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera wording. For camera speed 9-10, include two or more coordinated camera actions in the same scene when readable.
+* For character motion speed 4 or higher, include at least one clear physical body action, gesture, step, or interaction with the set. Facial expression, blinking, breathing, and mouth movement alone do not count. For speed 9-10, prefer clear full-body action such as striding, crossing the space, forceful gestures, dancing, running, fighting, climbing, or interacting with the set.
 * Use `shot_type` from the scene when available.
+* Follow `camera_flow_guidance` when present. Treat its framing limits as hard constraints for the entire shot, including every camera move and the ending composition.
 * If `starting_shot.required` is true, the first sentence must explicitly state that the video begins with `starting_shot.selected_starting_shot`. Do not merely imply this framing or move it to the middle or end of the prompt.
+* The selected starting shot describes the literal first generated frame. Do not begin with a wide, distant, establishing, or full-body lead-in and then move into the selected framing.
 * For an `eyes shot`, explicitly say that the video begins with an extreme close-up of the subject's eyes.
 * Begin the selected `camera_motion` from the required starting-shot framing; it may widen, orbit, track, or otherwise move afterward.
 * If `motion_summary` is non-empty, it is the authoritative custom motion and camera direction. Ignore `camera_motion` rather than combining the two.
@@ -87,11 +89,16 @@ Rules:
 * If `camera_motion` names a non-inward move such as pull back, track backward, side-follow, pan, tilt, crane, reveal, orbit, handheld follow, rack focus, or drift, preserve that motion and do not add a zoom-in or push-in afterward.
 * Vary camera behavior between scenes. Avoid repeating the same inward camera language across multiple prompts.
 * If `global_consistency_phrase` is present, include it in the final video prompt. Preserve its wording as much as possible, but lightly adapt grammar if needed so it fits the scene naturally.
+* If `video_style_verbiage` is present, copy that exact text word-for-word into the final prompt. Do not paraphrase, shorten, rename, or omit it. Treat it only as the governing visual-appearance contract for lighting, color, texture, materials, production design, grading, and image finish. It must not select, replace, or modify camera motion, character motion, shot timing, editing, or transitions.
+* If `temporal_world_effect_verbiage` is present, copy that exact text word-for-word into the final prompt before the first timestamp. Do not place it inside a timestamp or after Continuity. Do not paraphrase, shorten, or omit it. It is a hard temporal-layer contract: every protected mapped/reference character, their face, performance, voice, dialogue/singing timing, and lip sync remain natural and stable while only the explicitly unprotected background/world elements receive the temporal effect. Anonymous extras may be added only when the contract allows them, and must fit `location_ref` without replacing or duplicating a mapped character.
+* A temporal/world contract must be enacted, not merely copied. Every timestamp block must contain the contract's required number of concrete visible background/world actions. At intensity 7 or higher, subtle flicker, ambience, particles, or vague time-passage language alone is invalid. Use visibly accelerated, frozen, reversed, looping, delayed, season-changing, light-changing, crowd, traffic, weather, reflection, shadow, or location activity appropriate to the selected effect and mapped location.
+* When a temporal/world contract permits anonymous extras, wording such as `no people` in `location_ref` describes the source reference image only and is not an output prohibition. In Continuity, prohibit only additional named, principal, mapped, or referenced characters; explicitly preserve the contract's permission for anonymous unreferenced background extras.
 * Use `performance_style` and `performance_direction` to choose body language, gesture intensity, and camera energy. In singing mode, rap/hip-hop may describe rapping with rhythmic energy, hand gestures, head nods, and confident body language instead of soft singing. In speaking mode, remove music-video wording and use grounded short-film acting language.
 * Follow `character_motion_guidance` when present. Low values mean still/subtle body language; high values mean energetic or fast physical action when it fits the scene.
 * Use `facial_performance` and `facial_performance_direction` as the main source for facial emotion, eyes, brows, cheeks, jaw, gaze, mouth behavior, and blinking.
 * If `story_layer` exists, use `song_story_brief`, `user_story_arc`, `lyric_section`, and `scene_story_beat` as narrative guidance for emotion, symbolic action, continuity, and visual motivation. Do not quote the story layer or explain it; weave it into the scene naturally.
 * If `performance_mode` is `singing` and the scene is singing, use the exact lyric line from `vocal_status.lyric_text`.
+* For Input Audio singing, quote the exact lyric only once in the Audio 1 assignment. Do not paste the full lyric or the complete lip-sync boilerplate into every timestamp. Timestamp blocks must say that the assigned singer begins, continues, or completes the currently audible portion of the assigned lyric without quoting it again, restarting it, or extending it into silence.
 * If `performance_mode` is `speaking` and the scene has a line, use the exact line from `vocal_status.lyric_text` only inside "as she says \"...\"", "as he says \"...\"", or "as [subject label] says \"...\"".
 * In speaking mode, do not use alternate verbs for the dialogue line or any wording that could be interpreted as a physical handoff action. Use "says" only.
 * In speaking mode, do not mention music, singing, rapping, vocals, lyrics, song, beat, performing vocals, or lip-syncing to music.
@@ -320,10 +327,20 @@ def _normalize_reference_image(value):
 def _normalize_reference_item(value, fallback_name="Reference", fallback_id="ref"):
     item = value if isinstance(value, dict) else {}
     trigger_position = str(item.get("trigger_position") or item.get("triggerPosition") or item.get("trigger_placement") or "start").strip().lower()
+    raw_voice = item.get("minimax_voice") or item.get("miniMaxVoice") or {}
+    if not isinstance(raw_voice, dict):
+        raw_voice = {}
+    minimax_voice = {
+        "preset_id": _clean_scene_text(raw_voice.get("preset_id") or raw_voice.get("presetId") or raw_voice.get("preset") or "none", 120),
+        "gender": _clean_scene_text(raw_voice.get("gender") or "", 40),
+        "preset_name": _clean_scene_text(raw_voice.get("preset_name") or raw_voice.get("presetName") or raw_voice.get("name") or "", 240),
+        "description": _clean_scene_text(raw_voice.get("description") or raw_voice.get("voice_description") or raw_voice.get("voiceDescription") or "", 2000),
+    }
     return {
         "id": _clean_scene_text(item.get("id") or fallback_id, 160),
         "name": _clean_scene_text(item.get("name") or fallback_name, 240),
         "description": _clean_scene_text(item.get("description") or "", 4000),
+        "minimax_voice": minimax_voice,
         "trigger_phrase": _clean_scene_text(item.get("trigger_phrase") or item.get("trigger") or item.get("Trigger") or "", 1200),
         "trigger_position": "end" if trigger_position == "end" else "start",
         "image": _normalize_reference_image(item.get("image") if isinstance(item.get("image"), dict) else {}),
@@ -339,6 +356,22 @@ def _normalize_reference_items(value):
             continue
         refs.append(_normalize_reference_item(item, f"Subject {index + 1}", f"subject_{index + 1}"))
     return refs
+
+
+def _normalize_speaker_assignments(value):
+    if not isinstance(value, list):
+        return []
+    assignments = []
+    for index, item in enumerate(value[:40]):
+        if not isinstance(item, dict):
+            continue
+        assignments.append({
+            "id": _clean_scene_text(item.get("id") or item.get("cue_id") or f"speaker_cue_{index + 1}", 160),
+            "speaker_id": _clean_scene_text(item.get("speaker_id") or item.get("speakerId") or item.get("subject_id") or "", 160),
+            "speaker_name": _clean_scene_text(item.get("speaker_name") or item.get("speakerName") or item.get("speaker") or item.get("character") or "", 240),
+            "text": _clean_scene_text(item.get("text") or item.get("dialogue") or item.get("line") or item.get("lyric") or "", 2000),
+        })
+    return assignments
 
 
 def _normalize_reference_catalog(value):
@@ -499,6 +532,9 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
     prompt_summary = _clean_scene_text(scene.get("prompt_summary") or scene.get("summary") or image_prompt[:260], 1000)
     subjects = _normalize_tags(scene.get("subjects") or scene.get("singers") or scene.get("mapped_subjects"))
     subject_refs = _normalize_reference_items(scene.get("subject_refs"))
+    speaker_assignments = _normalize_speaker_assignments(
+        scene.get("speaker_assignments") or scene.get("minimax_speaker_assignments") or scene.get("dialogue_cues")
+    )
     setting = _clean_scene_text(scene.get("setting") or scene.get("location") or "", 500)
     location_ref = _normalize_reference_item(scene.get("location_ref"), setting or "Location", "location") if isinstance(scene.get("location_ref"), dict) else None
     shot_type = _clean_scene_text(scene.get("shot_type") or scene.get("shot") or "", 200)
@@ -518,6 +554,8 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
     minimax_h3_mode = str(scene.get("minimax_h3_mode") or scene.get("minimaxH3Mode") or "").strip().lower().replace("-", "_").replace(" ", "_")
     if minimax_h3_mode not in {"text_to_video", "image_to_video", "reference_to_video", "video_to_video"}:
         minimax_h3_mode = "text_to_video"
+    raw_minimax_audio_mode = str(scene.get("minimax_h3_audio_mode") or scene.get("minimaxH3AudioMode") or "input_audio").strip().lower().replace("-", "_").replace(" ", "_")
+    minimax_h3_audio_mode = "built_in_audio" if raw_minimax_audio_mode in {"built_in_audio", "native_audio", "generated_audio"} else "input_audio"
     try:
         timeline_start = float(scene.get("timeline_start", scene.get("start", 0)) or 0)
         timeline_end = float(scene.get("timeline_end", scene.get("end", 0)) or 0)
@@ -547,6 +585,7 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
         "motion_summary": motion_summary,
         "subjects": subjects,
         "subject_refs": subject_refs,
+        "speaker_assignments": speaker_assignments,
         "setting": setting,
         "location_ref": location_ref,
         "shot_type": shot_type,
@@ -563,6 +602,11 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
         "video_prompt_type": video_prompt_type,
         "project_video_engine": project_video_engine,
         "minimax_h3_mode": minimax_h3_mode,
+        "minimax_h3_audio_mode": minimax_h3_audio_mode,
+        "video_style": _clean_scene_text(scene.get("video_style") or scene.get("videoStyle") or "", 160),
+        "video_style_custom": _clean_scene_text(scene.get("video_style_custom") or scene.get("videoStyleCustom") or "", 3000),
+        "temporal_world_effect_override": _clean_scene_text(scene.get("temporal_world_effect_override") or scene.get("temporalWorldEffectOverride") or "global", 120),
+        "temporal_world_effect_custom": _clean_scene_text(scene.get("temporal_world_effect_custom") or scene.get("temporalWorldEffectCustom") or "", 3000),
         "timeline_start": timeline_start,
         "timeline_end": timeline_end,
         "exact_duration": exact_duration,
@@ -574,9 +618,123 @@ def _normalize_storyboard_scene(scene, fallback_number=1):
         "image_data": image_data,
         "image_name": image_name,
         "notes": _clean_scene_text(scene.get("notes") or "", 4000),
+        "audio_direction": _clean_scene_text(scene.get("audio_direction") or scene.get("audioDirection") or "", 4000),
+        "continuity": _clean_scene_text(scene.get("continuity") or scene.get("continuity_direction") or scene.get("continuityDirection") or "", 4000),
         "id_lora_character_id": _clean_scene_text(scene.get("id_lora_character_id") or scene.get("character_id") or scene.get("subject_id") or "", 180),
         "id_lora_location_id": _clean_scene_text(scene.get("id_lora_location_id") or scene.get("location_id") or "", 180),
     }
+
+
+def _normalize_script_import(value):
+    source = value if isinstance(value, dict) else {}
+    raw_cues = source.get("cues") if isinstance(source.get("cues"), list) else []
+    cues = []
+    for index, item in enumerate(raw_cues[:1000], start=1):
+        if not isinstance(item, dict):
+            continue
+        speaker_alias = _clean_scene_text(item.get("speaker_alias") or item.get("speaker") or item.get("speaker_name") or "", 240)
+        text = _clean_scene_text(item.get("text") or item.get("dialogue") or item.get("line") or "", 4000)
+        if not speaker_alias or not text:
+            continue
+        cues.append({
+            "index": int(item.get("index") or index),
+            "line_number": int(item.get("line_number") or 0),
+            "scene_index": int(item.get("scene_index") or 0),
+            "scene_label": _clean_scene_text(item.get("scene_label") or "", 240),
+            "speaker": speaker_alias,
+            "speaker_alias": speaker_alias,
+            "speaker_id": _clean_scene_text(item.get("speaker_id") or item.get("reference_subject_id") or "", 180),
+            "speaker_name": _clean_scene_text(item.get("speaker_name") or item.get("reference_subject_name") or speaker_alias, 240),
+            "reference_subject_id": _clean_scene_text(item.get("reference_subject_id") or item.get("speaker_id") or "", 180),
+            "reference_subject_name": _clean_scene_text(item.get("reference_subject_name") or item.get("speaker_name") or "", 240),
+            "speaker_match_method": _clean_scene_text(item.get("speaker_match_method") or "manual", 40),
+            "text": text,
+            "word_count": int(item.get("word_count") or len(text.split())),
+        })
+    raw_matches = source.get("speaker_matches") if isinstance(source.get("speaker_matches"), list) else []
+    speaker_matches = []
+    for item in raw_matches[:180]:
+        if not isinstance(item, dict):
+            continue
+        alias = _clean_scene_text(item.get("speaker_alias") or item.get("speaker") or "", 240)
+        if not alias:
+            continue
+        speaker_matches.append({
+            "speaker_alias": alias,
+            "reference_subject_id": _clean_scene_text(item.get("reference_subject_id") or item.get("speaker_id") or "", 180),
+            "reference_subject_name": _clean_scene_text(item.get("reference_subject_name") or item.get("speaker_name") or "", 240),
+            "match_method": _clean_scene_text(item.get("match_method") or "manual", 40),
+        })
+    try:
+        maximum_scene_seconds = float(source.get("maximum_scene_seconds") or source.get("max_scene_seconds") or 8)
+    except Exception:
+        maximum_scene_seconds = 8.0
+    maximum_scene_seconds = max(3.0, min(15.0, maximum_scene_seconds))
+    plan_source = source.get("scene_plan") if isinstance(source.get("scene_plan"), dict) else {}
+    raw_scenes = plan_source.get("scenes") if isinstance(plan_source.get("scenes"), list) else []
+    planned_scenes = []
+    for scene_index, scene in enumerate(raw_scenes[:240], start=1):
+        if not isinstance(scene, dict):
+            continue
+        raw_assignments = scene.get("speaker_assignments") if isinstance(scene.get("speaker_assignments"), list) else []
+        assignments = []
+        for cue_index, cue in enumerate(raw_assignments[:80], start=1):
+            if not isinstance(cue, dict):
+                continue
+            dialogue = _clean_scene_text(cue.get("text") or cue.get("dialogue") or "", 4000)
+            if not dialogue:
+                continue
+            assignments.append({
+                "speaker_id": _clean_scene_text(cue.get("speaker_id") or cue.get("reference_subject_id") or "", 180),
+                "speaker_name": _clean_scene_text(cue.get("speaker_name") or cue.get("speaker_alias") or "Speaker", 240),
+                "speaker_alias": _clean_scene_text(cue.get("speaker_alias") or cue.get("speaker_name") or "Speaker", 240),
+                "text": dialogue,
+                "source_cue_index": int(cue.get("source_cue_index") or 0),
+                "part_index": int(cue.get("part_index") or 1),
+                "part_count": int(cue.get("part_count") or 1),
+                "planned_start_seconds": float(cue.get("planned_start_seconds") or 0),
+                "planned_end_seconds": float(cue.get("planned_end_seconds") or 0),
+                "estimated_spoken_seconds": float(cue.get("estimated_spoken_seconds") or 0),
+            })
+        if not assignments:
+            continue
+        planned_scenes.append({
+            "index": int(scene.get("index") or scene_index),
+            "label": _clean_scene_text(scene.get("label") or f"Script Segment {scene_index}", 240),
+            "source_scene_index": int(scene.get("source_scene_index") or 0),
+            "source_scene_label": _clean_scene_text(scene.get("source_scene_label") or "", 240),
+            "continuation_of_previous": bool(scene.get("continuation_of_previous")),
+            "duration_seconds": float(scene.get("duration_seconds") or 0),
+            "timeline_start_seconds": float(scene.get("timeline_start_seconds") or 0),
+            "timeline_end_seconds": float(scene.get("timeline_end_seconds") or 0),
+            "participant_ids": [_clean_scene_text(item, 180) for item in (scene.get("participant_ids") or []) if _clean_scene_text(item, 180)],
+            "participant_names": [_clean_scene_text(item, 240) for item in (scene.get("participant_names") or []) if _clean_scene_text(item, 240)],
+            "speaker_assignments": assignments,
+        })
+    enabled = bool(source.get("enabled", True)) and bool(cues)
+    return {
+        "enabled": enabled,
+        "authoritative": bool(source.get("authoritative", True)),
+        "format": _clean_scene_text(source.get("format") or "text", 40),
+        "raw_text": _clean_scene_text(source.get("raw_text") or source.get("rawText") or "", 100000),
+        "imported_at": _clean_scene_text(source.get("imported_at") or source.get("importedAt") or "", 80),
+        "maximum_scene_seconds": maximum_scene_seconds,
+        "cues": cues,
+        "speaker_matches": speaker_matches,
+        "unmatched_speakers": [_clean_scene_text(item, 240) for item in (source.get("unmatched_speakers") or []) if _clean_scene_text(item, 240)],
+        "scene_plan": {
+            "maximum_scene_seconds": maximum_scene_seconds,
+            "scene_count": len(planned_scenes),
+            "estimated_total_seconds": float(plan_source.get("estimated_total_seconds") or 0),
+            "split_cue_count": int(plan_source.get("split_cue_count") or 0),
+            "scenes": planned_scenes,
+        },
+    }
+
+
+def _normalize_short_film_planning_mode(value):
+    clean = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return "fully_custom" if clean in {"fully_custom", "custom"} else "guided_film"
 
 
 def _default_storyboard(payload):
@@ -592,9 +750,19 @@ def _default_storyboard(payload):
         "project_video_engine": "minimax_h3" if str(payload.get("project_video_engine") or payload.get("projectVideoEngine") or "").strip().lower() == "minimax_h3" else "ltx",
         "mode": "image_to_video_prep" if any(scene.get("image_path") or scene.get("image_data") for scene in normalized) else "storyboard_prompts",
         "performance_mode": _normalize_performance_mode(payload.get("performance_mode") or payload.get("performanceMode") or payload.get("video_type") or payload.get("videoType")),
+        "short_film_planning_mode": _normalize_short_film_planning_mode(payload.get("short_film_planning_mode") or payload.get("shortFilmPlanningMode")),
         "camera_flow": _clean_scene_text(payload.get("camera_flow") or "balanced", 80),
         "image_shot_flow": _clean_scene_text(payload.get("image_shot_flow") or "intimate", 80),
         "image_aesthetic": _clean_scene_text(payload.get("image_aesthetic") or "", 120),
+        "video_style": _clean_scene_text(payload.get("video_style") or payload.get("videoStyle") or "", 160),
+        "video_style_custom": _clean_scene_text(payload.get("video_style_custom") or payload.get("videoStyleCustom") or "", 3000),
+        "temporal_world_effect": _clean_scene_text(payload.get("temporal_world_effect") or payload.get("temporalWorldEffect") or "", 160),
+        "temporal_world_effect_custom": _clean_scene_text(payload.get("temporal_world_effect_custom") or payload.get("temporalWorldEffectCustom") or "", 3000),
+        "temporal_allow_background_extras": (payload.get("temporal_allow_background_extras") if "temporal_allow_background_extras" in payload else payload.get("temporalAllowBackgroundExtras", True)) is not False,
+        "temporal_background_intensity": _speed_value(payload.get("temporal_background_intensity") if "temporal_background_intensity" in payload else payload.get("temporalBackgroundIntensity", 8)),
+        "temporal_environment_time_passage": (payload.get("temporal_environment_time_passage") if "temporal_environment_time_passage" in payload else payload.get("temporalEnvironmentTimePassage", True)) is not False,
+        "temporal_protected_characters": _clean_scene_text(payload.get("temporal_protected_characters") or payload.get("temporalProtectedCharacters") or "all_referenced", 80),
+        "temporal_protected_custom": _clean_scene_text(payload.get("temporal_protected_custom") or payload.get("temporalProtectedCustom") or "", 1000),
         "global_consistency_phrase": _clean_scene_text(payload.get("global_consistency_phrase") or "", 1200),
         "camera_motion_speed": _speed_value(payload.get("camera_motion_speed") or payload.get("cameraMotionSpeed")),
         "character_motion_speed": _speed_value(payload.get("character_motion_speed") or payload.get("characterMotionSpeed")),
@@ -602,6 +770,7 @@ def _default_storyboard(payload):
         "facial_performance_default": _clean_scene_text(payload.get("facial_performance_default") or payload.get("facial_performance") or "", 120),
         "facial_performance_custom_default": _clean_scene_text(payload.get("facial_performance_custom_default") or payload.get("facial_performance_custom") or "", 1200),
         "story_layer": _normalize_story_layer(payload.get("story_layer") or payload.get("storyLayer") or {}),
+        "script_import": _normalize_script_import(payload.get("script_import") or payload.get("scriptImport") or {}),
         "reference_builder": _normalize_reference_catalog(payload.get("reference_builder") or payload.get("referenceBuilder") or {}),
         "scenes": normalized,
     }
@@ -618,6 +787,8 @@ def _load_storyboard(payload):
             scenes = []
         data["scenes"] = [_normalize_storyboard_scene(scene, index + 1) for index, scene in enumerate(scenes)]
         data["story_layer"] = _normalize_story_layer(data.get("story_layer") or data.get("storyLayer") or {})
+        data["script_import"] = _normalize_script_import(data.get("script_import") or data.get("scriptImport") or {})
+        data["short_film_planning_mode"] = _normalize_short_film_planning_mode(data.get("short_film_planning_mode") or data.get("shortFilmPlanningMode"))
         data["reference_builder"] = _normalize_reference_catalog(data.get("reference_builder") or data.get("referenceBuilder") or {})
         data["path"] = path
         return data
@@ -642,9 +813,19 @@ def _save_storyboard(payload):
         "project_video_engine": "minimax_h3" if str(storyboard.get("project_video_engine") or storyboard.get("projectVideoEngine") or "").strip().lower() == "minimax_h3" else "ltx",
         "mode": storyboard.get("mode") or "storyboard_prompts",
         "performance_mode": _normalize_performance_mode(storyboard.get("performance_mode") or storyboard.get("performanceMode") or storyboard.get("video_type") or storyboard.get("videoType")),
+        "short_film_planning_mode": _normalize_short_film_planning_mode(storyboard.get("short_film_planning_mode") or storyboard.get("shortFilmPlanningMode")),
         "camera_flow": _clean_scene_text(storyboard.get("camera_flow") or "balanced", 80),
         "image_shot_flow": _clean_scene_text(storyboard.get("image_shot_flow") or "intimate", 80),
         "image_aesthetic": _clean_scene_text(storyboard.get("image_aesthetic") or "", 120),
+        "video_style": _clean_scene_text(storyboard.get("video_style") or storyboard.get("videoStyle") or "", 160),
+        "video_style_custom": _clean_scene_text(storyboard.get("video_style_custom") or storyboard.get("videoStyleCustom") or "", 3000),
+        "temporal_world_effect": _clean_scene_text(storyboard.get("temporal_world_effect") or storyboard.get("temporalWorldEffect") or "", 160),
+        "temporal_world_effect_custom": _clean_scene_text(storyboard.get("temporal_world_effect_custom") or storyboard.get("temporalWorldEffectCustom") or "", 3000),
+        "temporal_allow_background_extras": (storyboard.get("temporal_allow_background_extras") if "temporal_allow_background_extras" in storyboard else storyboard.get("temporalAllowBackgroundExtras", True)) is not False,
+        "temporal_background_intensity": _speed_value(storyboard.get("temporal_background_intensity") if "temporal_background_intensity" in storyboard else storyboard.get("temporalBackgroundIntensity", 8)),
+        "temporal_environment_time_passage": (storyboard.get("temporal_environment_time_passage") if "temporal_environment_time_passage" in storyboard else storyboard.get("temporalEnvironmentTimePassage", True)) is not False,
+        "temporal_protected_characters": _clean_scene_text(storyboard.get("temporal_protected_characters") or storyboard.get("temporalProtectedCharacters") or "all_referenced", 80),
+        "temporal_protected_custom": _clean_scene_text(storyboard.get("temporal_protected_custom") or storyboard.get("temporalProtectedCustom") or "", 1000),
         "global_consistency_phrase": _clean_scene_text(storyboard.get("global_consistency_phrase") or "", 1200),
         "camera_motion_speed": _speed_value(storyboard.get("camera_motion_speed") or storyboard.get("cameraMotionSpeed")),
         "character_motion_speed": _speed_value(storyboard.get("character_motion_speed") or storyboard.get("characterMotionSpeed")),
@@ -652,6 +833,7 @@ def _save_storyboard(payload):
         "facial_performance_default": _clean_scene_text(storyboard.get("facial_performance_default") or storyboard.get("facial_performance") or "", 120),
         "facial_performance_custom_default": _clean_scene_text(storyboard.get("facial_performance_custom_default") or storyboard.get("facial_performance_custom") or "", 1200),
         "story_layer": _normalize_story_layer(storyboard.get("story_layer") or storyboard.get("storyLayer") or {}),
+        "script_import": _normalize_script_import(storyboard.get("script_import") or storyboard.get("scriptImport") or {}),
         "reference_builder": _normalize_reference_catalog(storyboard.get("reference_builder") or storyboard.get("referenceBuilder") or {}),
         "scenes": [_normalize_storyboard_scene(scene, index + 1) for index, scene in enumerate(scenes)],
     }
@@ -712,6 +894,8 @@ def _export_storyboard_prompts(payload):
                 **_prompt_json_entry(scene, index, "video_prompt"),
                 "video_prompt_type": _clean_scene_text(scene.get("video_prompt_type") or "", 80),
                 "minimax_h3_mode": _clean_scene_text(scene.get("minimax_h3_mode") or "", 80),
+                "video_style": _clean_scene_text(scene.get("video_style") or "", 160),
+                "video_style_custom": _clean_scene_text(scene.get("video_style_custom") or "", 3000),
                 "performance_mode": _normalize_performance_mode(scene.get("performance_mode") or saved.get("performance_mode")),
             }
             for index, scene in enumerate(scenes, start=1)
@@ -855,13 +1039,44 @@ def _storyboard_speed_value(value, fallback=4):
     return max(0, min(10, number))
 
 
+def _camera_motion_for_storyboard_speed(value, speed_value):
+    motion = _clean_scene_text(value or "", 500)
+    speed = _storyboard_speed_value(speed_value, 4)
+    if not motion or speed < 7:
+        return motion
+    replacements = [
+        (r"\bslow cinematic drift\b", "energetic cinematic tracking drift"),
+        (r"\bslow orbit\b", "energetic orbit"),
+        (r"\bslow (left|right) orbit\b", r"energetic \1 orbit"),
+        (r"\bslow zoom out\b", "brisk pull-back reveal"),
+        (r"\bslow (left|right|side|lateral) drift\b", r"brisk \1 tracking drift"),
+        (r"\bslow (pan|tilt|track|tracking|pull[ -]?back|drift)\b", r"brisk \1"),
+        (r"\bgentle lateral drift\b", "energetic lateral tracking"),
+        (r"\bgentle pan reveal\b", "brisk pan reveal"),
+        (r"\bgentle (pan|tilt|orbit|drift|camera movement)\b", r"brisk \1"),
+        (r"\bsubtle handheld movement\b", "active handheld tracking"),
+        (r"\bsubtle handheld camera\b", "active handheld camera"),
+        (r"\bsubtle handheld follow\b", "energetic handheld follow"),
+        (r"\bsubtle rack focus\b", "quick rack focus"),
+        (r"\bsubtle energetic orbit\b", "energetic orbit"),
+        (r"\bsubtle settling pause\b", "active reframing beat"),
+        (r"\bsubtle orbit movement\b", "energetic orbit movement"),
+        (r"\b(?:quiet handheld hold|locked-off reaction hold|locked-off shot)\b", "active handheld reaction tracking"),
+        (r"\brestrained pan\b", "brisk pan"),
+    ]
+    for pattern, replacement in replacements:
+        motion = re.sub(pattern, replacement, motion, flags=re.IGNORECASE)
+    return _clean_scene_text(re.sub(r"\s{2,}", " ", motion).strip(), 500)
+
+
 def _enforce_storyboard_high_motion_language(prompt, scene):
     text = _clean_scene_text(prompt or "", 12000)
     if not text or not isinstance(scene, dict):
         return text
     camera_speed = _storyboard_speed_value(scene.get("camera_motion_speed") or scene.get("cameraMotionSpeed"), 4)
     character_speed = _storyboard_speed_value(scene.get("character_motion_speed") or scene.get("characterMotionSpeed"), 4)
-    if camera_speed >= 9:
+    if camera_speed >= 7:
+        text = _camera_motion_for_storyboard_speed(text, camera_speed)
         replacements = [
             (r"\bthen\s+holds?\s+on\b", "then continues moving across"),
             (r"\bthen\s+holds?\b", "then continues moving"),
@@ -872,10 +1087,10 @@ def _enforce_storyboard_high_motion_language(prompt, scene):
         ]
         for pattern, replacement in replacements:
             text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
-        camera_terms = re.findall(r"\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|push|dolly|handheld|reveal)\b", text, flags=re.IGNORECASE)
-        if len(camera_terms) < 2:
-            text = f"{text.rstrip().rstrip('.')}, with the camera chaining multiple readable moves instead of stopping on a hold."
-    if character_speed >= 9:
+        camera_terms = re.findall(r"\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|pull-back|push|dolly|handheld|reveal)\b", text, flags=re.IGNORECASE)
+        if not camera_terms:
+            text = f"{text.rstrip().rstrip('.')}, with energetic camera tracking that keeps moving instead of settling into a static hold."
+    if character_speed >= 4:
         replacements = [
             (r"\bmoves?\s+with\s+a\s+quiet,\s*poised\s+authority\b", "moves with forceful, physically active authority"),
             (r"\bmoves?\s+with\s+quiet,\s*poised\s+authority\b", "moves with forceful, physically active authority"),
@@ -888,8 +1103,8 @@ def _enforce_storyboard_high_motion_language(prompt, scene):
         ]
         for pattern, replacement in replacements:
             text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
-        if not re.search(r"\b(?:strides?|runs?|sprints?|dances?|turns?|crosses?|lunges?|reaches?|pushes?|pulls?|climbs?|fights?|brushing|sweeping|gestures?)\b", text, flags=re.IGNORECASE):
-            text = f"{text.rstrip().rstrip('.')}, while the subject performs clear full-body movement through the set."
+        if not re.search(r"\b(?:walks?|steps?|strides?|runs?|sprints?|dances?|crosses?|lunges?|reaches?|pushes?|pulls?|climbs?|fights?|brushes?|sweeps?|gestures?|interacts?|grabs?|lifts?|paces?)\b", text, flags=re.IGNORECASE):
+            text = f"{text.rstrip().rstrip('.')}, while the subject performs a clear physical action with the body, hands, or surrounding set instead of relying on facial movement alone."
     return _clean_scene_text(re.sub(r"\s{2,}", " ", text).strip(), 12000)
 
 
@@ -1195,7 +1410,11 @@ def _build_storyboard_video_prompt(payload):
                 f"Lyric section:\n{_clean_scene_text(vocal_status.get('lyric_section') or story_layer.get('lyric_section') or '', 200)}",
                 f"Scene story beat:\n{_clean_scene_text(story_layer.get('scene_story_beat') or '', 1200)}",
                 f"Motion/video summary:\n{motion_summary}",
+                f"Required MiniMax video style:\n{_clean_scene_text(selected_scene.get('video_style') or '', 200)}",
+                f"MANDATORY exact MiniMax video style verbiage — copy word-for-word into the final prompt:\n{_clean_scene_text(selected_scene.get('video_style_verbiage') or '', 3000)}",
+                f"MANDATORY exact temporal / world effect verbiage — copy word-for-word into the final prompt:\n{_clean_scene_text(selected_scene.get('temporal_world_effect_verbiage') or '', 5000)}",
                 f"Camera motion:\n{camera_motion}",
+                f"Required camera-flow framing:\n{_clean_scene_text(selected_scene.get('camera_flow_guidance') or '', 1600)}",
                 f"Camera motion speed guidance:\n{_clean_scene_text(camera_speed_guidance, 1000)}",
                 f"Character motion guidance:\n{_clean_scene_text(selected_scene.get('character_motion_guidance') or '', 1000)}",
                 f"Performance direction:\n{_clean_scene_text(selected_scene.get('performance_direction') or selected_scene.get('performance_style') or '', 1000)}",
@@ -1268,9 +1487,105 @@ def _build_storyboard_video_prompt(payload):
     }
 
 
+def _authoritative_script_from_payload(payload):
+    source = payload.get("script_import") or payload.get("scriptImport")
+    if not source and isinstance(payload.get("storyboard"), dict):
+        source = payload["storyboard"].get("script_import") or payload["storyboard"].get("scriptImport")
+    normalized = _normalize_script_import(source or {})
+    return normalized if normalized.get("enabled") and normalized.get("cues") else None
+
+
+def _authoritative_script_text(script_import):
+    raw_text = _clean_scene_text((script_import or {}).get("raw_text") or "", 100000)
+    if raw_text:
+        return raw_text
+    return "\n".join(
+        f'{cue.get("speaker_alias") or cue.get("speaker_name") or "Speaker"}: {cue.get("text") or ""}'
+        for cue in (script_import or {}).get("cues") or []
+        if cue.get("text")
+    )
+
+
+def _build_short_film_script_story_text(payload, script_import, purpose="premise"):
+    story_layer = _normalize_story_layer(payload.get("story_layer") or payload.get("storyLayer") or {})
+    subjects, locations = _storyboard_dialogue_reference_catalog(payload)
+    script_text = _authoritative_script_text(script_import)
+    planned_scenes = (script_import.get("scene_plan") or {}).get("scenes") or []
+    compact_plan = []
+    for scene in planned_scenes[:240]:
+        compact_plan.append({
+            "segment": scene.get("index"),
+            "duration_seconds": scene.get("duration_seconds"),
+            "continuation_of_previous": bool(scene.get("continuation_of_previous")),
+            "dialogue": [
+                {
+                    "speaker_id": cue.get("speaker_id", ""),
+                    "speaker": cue.get("speaker_name") or cue.get("speaker_alias") or "Speaker",
+                    "exact_text": cue.get("text", ""),
+                }
+                for cue in scene.get("speaker_assignments") or []
+            ],
+        })
+    if purpose == "brief":
+        task = (
+            "Create a compact short-film production brief that Guided Film Automation can use to design visual scenes around the authoritative script. "
+            "Use these headings exactly: Story premise:, Character dynamics:, Visual progression:, Continuity rules:, Scene-direction guidance:. "
+            "Keep the complete response under 450 words."
+        )
+        max_tokens = 1000
+        label = "Storyboard Authoritative Script Film Brief"
+    else:
+        task = (
+            "Create one cohesive short-film premise and visual narrative arc from the authoritative script. Explain the dramatic situation, character goals, emotional progression, "
+            "and how the film can develop visually across the supplied timed segments. Output plain prose under 500 words with no screenplay rewrite and no dialogue list."
+        )
+        max_tokens = 1100
+        label = "Storyboard Authoritative Script Film Premise"
+    instruction = (
+        "You are a short-film development director working from a locked screenplay.\n\n"
+        f"{task}\n\n"
+        "NON-NEGOTIABLE SCRIPT CONTRACT:\n"
+        "- The supplied dialogue is authoritative and immutable. Never rewrite, paraphrase, shorten, extend, reorder, merge, or invent spoken words.\n"
+        "- Do not add narration, voice-over, replacement dialogue, or extra speakers.\n"
+        "- Develop only the visual story around the locked dialogue: actions, reactions, motivations, blocking, locations, props, shots, camera language, atmosphere, and continuity.\n"
+        "- Use Reference Builder character names and descriptions as identity authority.\n"
+        "- Use only supplied Reference Builder locations when locations are available.\n\n"
+        f"Optional user story idea:\n{story_layer.get('overall_story_idea') or '[none]'}\n\n"
+        f"Reference Builder characters:\n{json.dumps(subjects, ensure_ascii=False, indent=2) if subjects else '[none]'}\n\n"
+        f"Reference Builder locations:\n{json.dumps(locations, ensure_ascii=False, indent=2) if locations else '[none]'}\n\n"
+        f"Authoritative exact script:\n{script_text}\n\n"
+        f"Authoritative timed segment plan:\n{json.dumps(compact_plan, ensure_ascii=False, indent=2)}"
+    )
+    from .VRGDG_MusicVideoBuilderNodes import _run_builder_text_llm
+
+    text, run_info = _run_builder_text_llm(
+        payload,
+        instruction,
+        temperature=float(payload.get("temperature") or 0.35),
+        top_p=float(payload.get("top_p") or 0.90),
+        max_new_tokens=int(payload.get("max_new_tokens") or max_tokens),
+        label=label,
+        preserve_paragraphs=True,
+    )
+    text = _clean_scene_text(text, 10000)
+    if not text:
+        raise ValueError("The LLM returned an empty short-film story result.")
+    return text, run_info
+
+
 def _build_story_layer_brief(payload):
     lyrics = _clean_scene_text(payload.get("lyrics") or payload.get("lyrics_text") or "", 16000)
     story_layer = _normalize_story_layer(payload.get("story_layer") or payload.get("storyLayer") or {})
+    authoritative_script = _authoritative_script_from_payload(payload)
+    if authoritative_script:
+        text, run_info = _build_short_film_script_story_text(payload, authoritative_script, "brief")
+        return {
+            "story_brief": text,
+            "runner": run_info.get("runner", "builtin"),
+            "used_model": run_info.get("used_model", ""),
+            "unloaded": run_info.get("unloaded", True),
+            "authoritative_script_used": True,
+        }
     scenes = payload.get("scenes")
     if not isinstance(scenes, list):
         scenes = []
@@ -1409,6 +1724,42 @@ def _normalize_story_arc_output(text, required_labels, maximum_words=100):
         end = matches[index + 1].start() if index + 1 < len(matches) else len(raw)
         blocks.append((label, raw[match.end():end].strip()))
     if required_labels:
+        required_keys = {label.casefold() for label in required_labels}
+        nonstructural_scene_markers = {
+            "instrumental", "instrumental section", "instrumental break",
+            "break", "interlude", "solo", "music only", "no vocals",
+            "no vocal", "silence", "b roll", "b-roll",
+        }
+        # The timeline uses values such as [instrumental] as scene-content
+        # markers. Gemma can mistakenly promote one into a ninth story heading
+        # even when it also returned every required lyric heading in order. Fold
+        # that prose into the nearest real section instead of rejecting an
+        # otherwise valid arc. Unknown invented headings still fail below.
+        folded_blocks = []
+        pending_prefix = []
+        for label, body in blocks:
+            key = label.casefold()
+            if key not in required_keys and key in nonstructural_scene_markers:
+                if folded_blocks:
+                    previous_label, previous_body = folded_blocks[-1]
+                    folded_blocks[-1] = (
+                        previous_label,
+                        "\n".join(part for part in (previous_body, body) if part).strip(),
+                    )
+                elif body:
+                    pending_prefix.append(body)
+                continue
+            if pending_prefix:
+                body = "\n".join([*pending_prefix, body] if body else pending_prefix).strip()
+                pending_prefix = []
+            folded_blocks.append((label, body))
+        if pending_prefix and folded_blocks:
+            last_label, last_body = folded_blocks[-1]
+            folded_blocks[-1] = (
+                last_label,
+                "\n".join(part for part in (last_body, *pending_prefix) if part).strip(),
+            )
+        blocks = folded_blocks
         returned = [label.casefold() for label, _body in blocks]
         required = [label.casefold() for label in required_labels]
         if len(blocks) > len(required_labels) and returned[:len(required)] == required:
@@ -1450,6 +1801,18 @@ def _normalize_story_arc_output(text, required_labels, maximum_words=100):
 
 
 def _build_story_layer_arc(payload):
+    authoritative_script = _authoritative_script_from_payload(payload)
+    if authoritative_script:
+        text, run_info = _build_short_film_script_story_text(payload, authoritative_script, "premise")
+        return {
+            "story_arc": text,
+            "lyrics_source": "Authoritative Script Mapper import",
+            "story_arc_seed": _clean_scene_text(payload.get("story_arc_seed") or payload.get("storyArcSeed") or payload.get("seed") or "", 80),
+            "runner": run_info.get("runner", "builtin"),
+            "used_model": run_info.get("used_model", ""),
+            "unloaded": run_info.get("unloaded", True),
+            "authoritative_script_used": True,
+        }
     storyboard = payload.get("storyboard") if isinstance(payload.get("storyboard"), dict) else {}
     timeline_lyrics = _clean_scene_text(payload.get("lyrics") or payload.get("lyrics_text") or "", 40000)
     line_mapping_lyrics = _clean_scene_text(payload.get("line_mapping_lyrics") or payload.get("lineMappingLyrics") or "", 40000)
@@ -1605,6 +1968,7 @@ def _build_story_layer_arc(payload):
         "* Do not invent warehouses, loading docks, corridors, steel stairs, metal doors, concrete halls, or other industrial spaces unless those are explicitly present in the provided Location descriptions.\n"
         "* To create variety, change subject actions, camera energy, props, lighting, mood, blocking, and use of the mapped locations instead of inventing unrelated places.\n"
         "* Never force a standard pop-song template over explicit lyric section headers.\n"
+        "* Values such as [instrumental], [music only], or [no vocals] inside the Scene lyric map are timing/content markers, not additional song-section headings. Cover their visuals inside the nearest listed required section and never output those markers as separate headings.\n"
         "* If only lyrics are provided, build the arc from the lyrics.\n"
         "* If no lyrics are provided, build the arc from the theme or story idea.\n"
         "* Do not ask follow-up questions unless absolutely necessary.\n"
@@ -2043,17 +2407,268 @@ def _normalize_generated_dialogue_scenes(raw_scenes, subjects, locations):
     return scenes
 
 
+_MINIMAX_DIALOGUE_NON_INWARD_CAMERA_SEQUENCE = (
+    "quiet handheld hold",
+    "subtle lateral drift",
+    "slow orbit left",
+    "gentle pull-back",
+    "restrained pan right",
+    "rack focus between the speakers",
+    "slow orbit right",
+    "locked-off reaction hold",
+)
+
+
+def _minimax_camera_motion_family(value):
+    text = _clean_scene_text(value or "", 500).lower()
+    if re.search(r"\b(push(?:es)?[ -]?in|doll(?:y|ies)[ -]?in|zoom(?:s)?[ -]?in|track(?:s|ing)?[ -]?(?:in|forward)|drift(?:s|ing)?[ -]?(?:closer|forward))\b", text):
+        return "inward"
+    if re.search(r"\b(pull(?:s)?[ -]?(?:back|out)|doll(?:y|ies)[ -]?out|zoom(?:s)?[ -]?out|track(?:s|ing)?[ -]?backward)\b", text):
+        return "outward"
+    if re.search(r"\b(orbit|arc|circle|rotate|rotation)\b", text):
+        return "orbit"
+    if re.search(r"\b(pan|lateral|side|truck)\b", text):
+        return "lateral"
+    if re.search(r"\b(rack focus|focus pull)\b", text):
+        return "focus"
+    if re.search(r"\b(hold|locked|static)\b", text):
+        return "hold"
+    return "other" if text else ""
+
+
+def _rebalance_generated_minimax_camera_motion(scenes, camera_flow="balanced", camera_motion_speed=4):
+    """Prevent an LLM-planned dialogue sequence from collapsing into repeated push-ins.
+
+    This only runs while new guided MiniMax scene cards are being created. Later manual
+    edits remain authoritative. Inward moves are allowed as an accent, but no more than
+    once in a rolling six-scene window.
+    """
+    if not isinstance(scenes, list) or str(camera_flow or "").strip().lower() == "off":
+        return scenes
+    try:
+        speed = max(0, min(10, int(round(float(camera_motion_speed)))))
+    except Exception:
+        speed = 4
+    recent_families = []
+    for index, scene in enumerate(scenes):
+        if not isinstance(scene, dict):
+            continue
+        motion = _camera_motion_for_storyboard_speed(scene.get("camera_motion") or "", speed)
+        if motion:
+            scene["camera_motion"] = motion
+        family = _minimax_camera_motion_family(motion)
+        if speed <= 0:
+            replacement = "locked-off camera"
+        else:
+            replacement = _MINIMAX_DIALOGUE_NON_INWARD_CAMERA_SEQUENCE[index % len(_MINIMAX_DIALOGUE_NON_INWARD_CAMERA_SEQUENCE)]
+        if not motion or (family == "inward" and "inward" in recent_families[-5:]):
+            scene["camera_motion"] = replacement
+            family = _minimax_camera_motion_family(replacement)
+        recent_families.append(family)
+    return scenes
+
+
+def _normalize_generated_minimax_dialogue_scenes(
+    raw_scenes,
+    subjects,
+    locations,
+    minimax_h3_mode="text_to_video",
+    camera_flow="balanced",
+    camera_motion_speed=4,
+):
+    if not isinstance(raw_scenes, list):
+        raise ValueError("MiniMax dialogue plan did not include a scenes array.")
+    subject_by_id = {str(item.get("id") or ""): item for item in subjects if str(item.get("id") or "")}
+    location_by_id = {str(item.get("id") or ""): item for item in locations if str(item.get("id") or "")}
+    mode = str(minimax_h3_mode or "text_to_video").strip().lower().replace("-", "_").replace(" ", "_")
+    if mode not in {"text_to_video", "image_to_video", "reference_to_video", "video_to_video"}:
+        mode = "text_to_video"
+    scenes = []
+    for index, item in enumerate(raw_scenes[:80], start=1):
+        if not isinstance(item, dict):
+            continue
+        raw_cues = item.get("dialogue_cues") if isinstance(item.get("dialogue_cues"), list) else []
+        if not raw_cues:
+            raw_cues = [{
+                "character_id": item.get("character_id") or item.get("subject_id") or item.get("speaker_id") or "",
+                "speaker": item.get("character_name") or item.get("speaker") or "",
+                "dialogue": item.get("dialogue") or item.get("line") or item.get("lyrics") or "",
+            }]
+        speaker_assignments = []
+        subject_refs = []
+        seen_subject_ids = set()
+        for cue_index, cue in enumerate(raw_cues[:40], start=1):
+            if not isinstance(cue, dict):
+                continue
+            subject_id = _clean_scene_text(cue.get("character_id") or cue.get("subject_id") or cue.get("speaker_id") or "", 180)
+            if subject_id and subject_by_id and subject_id not in subject_by_id:
+                subject_id = ""
+            subject = subject_by_id.get(subject_id) if subject_id else None
+            speaker_name = _clean_scene_text(cue.get("speaker") or cue.get("character_name") or (subject or {}).get("name") or "", 160)
+            dialogue = _clean_scene_text(cue.get("dialogue") or cue.get("line") or cue.get("text") or "", 1200)
+            if not dialogue:
+                continue
+            speaker_assignments.append({
+                "id": f"minimax_dialogue_{index}_{cue_index}",
+                "speaker_id": subject_id,
+                "speaker_name": speaker_name or "Speaker",
+                "text": dialogue,
+            })
+            if subject and subject_id not in seen_subject_ids:
+                subject_refs.append({
+                    "id": subject.get("id", ""),
+                    "name": subject.get("name", ""),
+                    "description": subject.get("description", ""),
+                    "reference_type": subject.get("reference_type", "character"),
+                    "image": {**(subject.get("image") or {})},
+                })
+                seen_subject_ids.add(subject_id)
+        for participant_id in item.get("participant_ids") or []:
+            participant_id = _clean_scene_text(participant_id, 180)
+            participant = subject_by_id.get(participant_id) if participant_id else None
+            if not participant or participant_id in seen_subject_ids:
+                continue
+            subject_refs.append({
+                "id": participant.get("id", ""),
+                "name": participant.get("name", ""),
+                "description": participant.get("description", ""),
+                "reference_type": participant.get("reference_type", "character"),
+                "image": {**(participant.get("image") or {})},
+            })
+            seen_subject_ids.add(participant_id)
+        location_id = _clean_scene_text(item.get("location_id") or "", 180)
+        if location_id and location_by_id and location_id not in location_by_id:
+            location_id = ""
+        location = location_by_id.get(location_id) if location_id else None
+        location_ref = ({
+            "id": location.get("id", ""),
+            "name": location.get("name", ""),
+            "description": location.get("description", ""),
+            "image": {**(location.get("image") or {})},
+        } if location else None)
+        dialogue_lines = [f'{cue["speaker_name"]}: "{cue["text"]}"' for cue in speaker_assignments]
+        label = _clean_scene_text(item.get("label") or item.get("title") or f"Scene {index}", 160)
+        scene = _normalize_storyboard_scene({
+            "id": _clean_scene_text(item.get("id") or f"minimax_story_scene_{index}", 160),
+            "scene_number": index,
+            "label": label or f"Scene {index}",
+            "lyrics": "\n".join(dialogue_lines),
+            "lyric_singers": [cue["speaker_name"] for cue in speaker_assignments],
+            "speaker_assignments": speaker_assignments,
+            "story_beat": _clean_scene_text(item.get("story_beat") or item.get("beat") or "", 1800),
+            "prompt_summary": _clean_scene_text(item.get("visual_direction") or item.get("summary") or "", 1800),
+            "motion_summary": _clean_scene_text(item.get("motion_summary") or item.get("video_notes") or "", 1400),
+            "subjects": [subject.get("name", "") for subject in subject_refs],
+            "subject_refs": subject_refs,
+            "setting": _clean_scene_text(item.get("setting") or item.get("location_name") or (location_ref or {}).get("name", ""), 1000),
+            "location_ref": location_ref,
+            "video_prompt_type": "i2v",
+            "project_video_engine": "minimax_h3",
+            "minimax_h3_mode": mode,
+            "minimax_h3_audio_mode": "built_in_audio",
+            "performance_mode": "speaking",
+            "timeline_start": item.get("timeline_start", 0),
+            "timeline_end": item.get("timeline_end", 0),
+            "exact_duration": item.get("exact_duration") or item.get("duration") or 0,
+            "shot_type": _clean_scene_text(item.get("shot_type") or "", 160),
+            "camera_motion": _clean_scene_text(item.get("camera_motion") or "", 500),
+            "character_motion": _clean_scene_text(item.get("character_motion") or item.get("action") or "", 500),
+            "facial_performance": _clean_scene_text(item.get("facial_performance") or item.get("emotion") or "", 240),
+            "facial_performance_custom": _clean_scene_text(item.get("facial_performance_custom") or item.get("delivery") or "", 800),
+            "image_prompt": _id_lora_structured_image_prompt(item, subject_refs[0] if subject_refs else None, location_ref),
+            "audio_direction": _clean_scene_text(item.get("audio_direction") or "", 4000),
+            "continuity": _clean_scene_text(item.get("continuity") or "", 4000),
+            "notes": _clean_scene_text(item.get("notes") or "", 4000),
+        }, index)
+        scenes.append(scene)
+    if not scenes:
+        raise ValueError("The LLM returned no usable MiniMax dialogue scenes.")
+    return _rebalance_generated_minimax_camera_motion(scenes, camera_flow, camera_motion_speed)
+
+
+def _apply_authoritative_script_plan(raw_scenes, script_import):
+    generated = raw_scenes if isinstance(raw_scenes, list) else []
+    planned_scenes = ((script_import or {}).get("scene_plan") or {}).get("scenes") or []
+    locked_scenes = []
+    previous_location_id = ""
+    for index, planned in enumerate(planned_scenes):
+        generated_scene = dict(generated[index]) if index < len(generated) and isinstance(generated[index], dict) else {}
+        exact_cues = []
+        for cue in planned.get("speaker_assignments") or []:
+            exact_cues.append({
+                "character_id": cue.get("speaker_id") or "",
+                "speaker_id": cue.get("speaker_id") or "",
+                "speaker": cue.get("speaker_name") or cue.get("speaker_alias") or "Speaker",
+                "dialogue": cue.get("text") or "",
+            })
+        generated_scene["label"] = generated_scene.get("label") or planned.get("label") or f"Script Segment {index + 1}"
+        generated_scene["dialogue_cues"] = exact_cues
+        generated_scene["participant_ids"] = list(planned.get("participant_ids") or [])
+        generated_scene["participant_names"] = list(planned.get("participant_names") or [])
+        current_location_id = _clean_scene_text(generated_scene.get("location_id") or "", 180)
+        if planned.get("continuation_of_previous") and previous_location_id:
+            generated_scene["location_id"] = previous_location_id
+        elif not planned.get("continuation_of_previous"):
+            previous_location_id = current_location_id
+        elif current_location_id:
+            previous_location_id = current_location_id
+        generated_scene["exact_duration"] = float(planned.get("duration_seconds") or 0)
+        generated_scene["duration"] = float(planned.get("duration_seconds") or 0)
+        generated_scene["timeline_start"] = float(planned.get("timeline_start_seconds") or 0)
+        generated_scene["timeline_end"] = float(planned.get("timeline_end_seconds") or 0)
+        generated_scene["notes"] = _clean_scene_text(
+            "\n".join(filter(None, [
+                generated_scene.get("notes") or "",
+                f"Authoritative Script Mapper segment {index + 1}. Exact dialogue and order are locked.",
+                "Continuation of the previous script segment." if planned.get("continuation_of_previous") else "",
+            ])),
+            4000,
+        )
+        locked_scenes.append(generated_scene)
+    return locked_scenes
+
+
 def _build_id_lora_dialogue_scenes(payload):
+    planner_profile = str(payload.get("_dialogue_planner_profile") or "id_lora").strip().lower()
+    is_minimax = planner_profile == "minimax_short_film"
+    authoritative_script = _authoritative_script_from_payload(payload) if is_minimax else None
     story_layer = _normalize_story_layer(payload.get("story_layer") or payload.get("storyLayer") or {})
+    storyboard_settings = payload.get("storyboard") if isinstance(payload.get("storyboard"), dict) else {}
+    camera_flow = _clean_scene_text(
+        payload.get("camera_flow") or payload.get("cameraFlow") or storyboard_settings.get("camera_flow") or "balanced",
+        120,
+    )
+    try:
+        camera_motion_speed = max(0, min(10, int(round(float(
+            payload.get("camera_motion_speed")
+            or payload.get("cameraMotionSpeed")
+            or storyboard_settings.get("camera_motion_speed")
+            or 4
+        )))))
+    except Exception:
+        camera_motion_speed = 4
+    try:
+        character_motion_speed = max(0, min(10, int(round(float(
+            payload.get("character_motion_speed")
+            or payload.get("characterMotionSpeed")
+            or storyboard_settings.get("character_motion_speed")
+            or 4
+        )))))
+    except Exception:
+        character_motion_speed = 4
     story_source = _clean_scene_text(
-        payload.get("story_source") or payload.get("storySource") or story_layer.get("user_story_arc") or story_layer.get("song_story_brief") or "",
-        12000,
+        _authoritative_script_text(authoritative_script) if authoritative_script else payload.get("story_source") or payload.get("storySource") or story_layer.get("user_story_arc") or story_layer.get("song_story_brief") or "",
+        100000 if authoritative_script else 12000,
     )
     try:
         scene_count = int(float(payload.get("scene_count") or payload.get("sceneCount") or 6))
     except Exception:
         scene_count = 6
-    scene_count = max(1, min(24, scene_count))
+    if authoritative_script:
+        scene_count = len((authoritative_script.get("scene_plan") or {}).get("scenes") or []) or scene_count
+        scene_count = max(1, min(80, scene_count))
+    else:
+        scene_count = max(1, min(24, scene_count))
     subjects, locations = _storyboard_dialogue_reference_catalog(payload)
     existing_scenes = payload.get("scenes") if isinstance(payload.get("scenes"), list) else []
     compact_existing = []
@@ -2067,23 +2682,59 @@ def _build_id_lora_dialogue_scenes(payload):
             "dialogue": normalized.get("lyrics", ""),
             "story_beat": normalized.get("story_beat", ""),
         })
-    instruction = (
-        "You are a short-film dialogue scene planner for an ID-LoRA image-to-video workflow.\n\n"
-        "Create a preview storyboard plan. The user will review it before anything is applied to the Video Builder timeline.\n\n"
-        "Important behavior:\n"
-        "- If USER STORY / SCRIPT has text, use it as the source. It may be a premise, outline, or pasted script.\n"
-        "- If USER STORY / SCRIPT is empty, invent an original short-film premise from the available characters and locations.\n"
+    planner_identity = (
+        "You are the dedicated MiniMax H3 short-film scene planner. Create model-ready scene cards for a dialogue-driven MiniMax project."
+        if is_minimax else
+        "You are a short-film dialogue scene planner for an ID-LoRA image-to-video workflow."
+    )
+    dialogue_rule = (
+        "- A scene may contain one or more ordered dialogue_cues. Use exact character ids from AVAILABLE CHARACTERS. Keep every cue short enough to fit naturally in one generated clip.\n"
+        "- When two or more characters speak in one scene, preserve their exact turn order in dialogue_cues and give each character only their own words.\n"
+        if is_minimax else
         "- Create exact spoken dialogue lines. Keep each line short enough for a single generated clip.\n"
         "- Prefer one speaking character per scene. Use only character ids from AVAILABLE CHARACTERS when possible.\n"
+    )
+    authoritative_rule = (
+        "AUTHORITATIVE SCRIPT CONTRACT:\n"
+        "- The SCRIPT MAPPER SEGMENT PLAN below is immutable. Return exactly one scene per supplied segment, in the same order.\n"
+        "- Copy every dialogue cue word-for-word with its exact character_id and speaker. Never rewrite, paraphrase, correct, shorten, extend, merge, reorder, or invent dialogue.\n"
+        "- Do not add narration, voice-over, new speakers, or extra spoken words.\n"
+        "- Your creative job is only the surrounding visual direction: story beat, actions, reactions, blocking, location choice, shot, camera, facial delivery, ambience, and continuity.\n"
+        "- Continuation segments must preserve the prior segment's character identity, wardrobe, location, props, spatial positions, and screen direction unless the locked script plan starts a new source scene.\n\n"
+        if authoritative_script else ""
+    )
+    output_dialogue_shape = (
+        '      "dialogue_cues": [{"character_id": "exact character id", "speaker": "character name", "dialogue": "exact spoken words"}],\n'
+        if is_minimax else
+        '      "character_id": "exact id from available characters or empty",\n'
+        '      "dialogue": "exact spoken line",\n'
+    )
+    instruction = (
+        f"{planner_identity}\n\n"
+        "Create a preview storyboard plan. The user will review it before anything is applied to the Video Builder timeline.\n\n"
+        "Important behavior:\n"
+        f"{authoritative_rule}"
+        "- If USER STORY / SCRIPT has text, use it as the source. It may be a premise, outline, or pasted script.\n"
+        "- If USER STORY / SCRIPT is empty, invent an original short-film premise from the available characters and locations.\n"
+        f"{dialogue_rule}"
         "- Use only location ids from AVAILABLE LOCATIONS when possible.\n"
         "- Each scene needs a story beat, visual direction for image prep, a full text-to-image prompt, and optional camera/facial direction.\n"
+        f"- Follow the project camera plan: camera flow is {camera_flow!r} and camera motion speed is {camera_motion_speed}/10. "
+        "Use controlled cinematic camera variation across the sequence. Do not default every scene to static or locked-off framing when camera speed is above 0. "
+        "At camera speed 7-8, every camera_motion value must use energetic, visibly active wording and must not say slow, gentle, subtle, restrained, locked-off, static, or hold. At speed 9-10, prefer two coordinated readable camera actions. "
+        "An inward move (push-in, dolly-in, zoom-in, track forward, or drift closer) is a rare accent: use at most one inward move in any six neighboring scenes. "
+        "Never assign inward moves to alternating scenes. Prefer lateral drift, restrained pan, orbit, pull-back, rack focus, handheld hold, and intentional locked coverage. "
+        "The requested shot_type is the literal first-frame scale: never begin wider or farther away and move inward to reach it. "
+        "Reserve a static camera for an intentional dramatic beat and keep neighboring camera-motion families visibly different.\n"
+        f"- Character motion speed is {character_motion_speed}/10. At speed 4 or higher, every scene needs at least one clear physical body action, gesture, step, or interaction with the set; facial expression, blinking, breathing, and mouth movement alone do not count. Keep dialogue lip sync practical.\n"
+        "- camera_motion must contain the actual concise camera direction. motion_summary is optional and must only contain additional custom motion direction that is not already stated in camera_motion; otherwise leave motion_summary empty.\n"
         "- The image_prompt must follow the existing NanoBanana/Krea-style still-image prompt structure, not a short keyword list.\n"
         "- For image_prompt, write one polished paragraph, about 65-115 words, practical for text-to-image generation.\n"
         "- For image_prompt, include concrete subject identity, wardrobe, hair, makeup or facial detail when known, pose/body language, shot/framing, lens feel, lighting setup, environment, materials, atmosphere, color palette, texture, and cinematic finish.\n"
         "- For image_prompt, create a still frame only. Do not describe animation, camera movement, future action, lip sync, audio, captions, text overlays, or printed dialogue.\n"
         "- For image_prompt, prefer intimate cinematic compositions when no shot is specified: close-up, medium close-up, profile, upper body, shallow depth of field, foreground framing, bokeh, rim light, atmospheric lighting.\n"
         "- For image_prompt, if character or location reference images are available, start naturally with 'Using the provided character reference...' or 'Using the provided character reference and location reference...' and preserve the important identity/setting details without copying the exact pose, crop, or camera angle.\n"
-        "- Do not mention ID-LoRA, LoRA, nodes, workflow files, voice cloning, prompts, or metadata in dialogue.\n"
+        f"- Do not mention {'MiniMax H3, models' if is_minimax else 'ID-LoRA, LoRA'}, nodes, workflow files, voice cloning, prompts, or metadata in dialogue.\n"
         "- Do not write markdown, explanations, or code fences.\n\n"
         "Return only valid JSON with this exact shape:\n"
         "{\n"
@@ -2092,22 +2743,26 @@ def _build_id_lora_dialogue_scenes(payload):
         '  "scenes": [\n'
         "    {\n"
         '      "label": "Scene 1 title",\n'
-        '      "character_id": "exact id from available characters or empty",\n'
+        f"{output_dialogue_shape}"
         '      "location_id": "exact id from available locations or empty",\n'
-        '      "dialogue": "exact spoken line",\n'
         '      "story_beat": "one concise story beat",\n'
         '      "visual_direction": "short first-frame visual direction for image prep",\n'
         '      "image_prompt": "full NanoBanana/Krea-style still image prompt paragraph for creating the scene image",\n'
         '      "shot_type": "optional shot/framing",\n'
         '      "camera_motion": "optional camera movement",\n'
+        '      "character_motion": "visible character blocking or action",\n'
         '      "facial_performance": "optional facial/emotional direction",\n'
-        '      "delivery": "optional voice/performance delivery note"\n'
+        '      "delivery": "optional voice/performance delivery note",\n'
+        '      "audio_direction": "ambience, sound effects, silence, breathing, and other non-dialogue audio direction",\n'
+        '      "continuity": "identity, wardrobe, props, location, screen direction, and spatial continuity requirements"\n'
         "    }\n"
         "  ]\n"
         "}\n\n"
         f"Requested scene count: {scene_count}\n\n"
         f"USER STORY / SCRIPT:\n{story_source or '[blank - invent an original short-film premise]'}\n\n"
+        f"SCRIPT MAPPER SEGMENT PLAN (authoritative when present):\n{json.dumps((authoritative_script or {}).get('scene_plan') or {}, ensure_ascii=False, indent=2) if authoritative_script else '[none]'}\n\n"
         f"Story layer:\n{json.dumps(story_layer, ensure_ascii=False, indent=2)}\n\n"
+        f"Project motion settings:\n{json.dumps({'camera_flow': camera_flow, 'camera_motion_speed': camera_motion_speed, 'character_motion_speed': character_motion_speed}, ensure_ascii=False, indent=2)}\n\n"
         f"Available characters:\n{json.dumps(subjects, ensure_ascii=False, indent=2) if subjects else '[none provided]'}\n\n"
         f"Available locations:\n{json.dumps(locations, ensure_ascii=False, indent=2) if locations else '[none provided]'}\n\n"
         f"Existing starter scenes:\n{json.dumps(compact_existing, ensure_ascii=False, indent=2) if compact_existing else '[none]'}"
@@ -2120,14 +2775,14 @@ def _build_id_lora_dialogue_scenes(payload):
         temperature=float(payload.get("temperature") or 0.55),
         top_p=float(payload.get("top_p") or 0.92),
         max_new_tokens=int(payload.get("max_new_tokens") or max(1400, scene_count * 280)),
-        label="ID-LoRA Dialogue Scenes Gemma",
+        label="MiniMax Short Film Dialogue Scenes LLM" if is_minimax else "ID-LoRA Dialogue Scenes Gemma",
         preserve_paragraphs=True,
     )
     try:
         data = _extract_json_object_from_text(text)
     except Exception as parse_error:
         repair_instruction = (
-            "Repair this malformed JSON for an ID-LoRA dialogue scene plan.\n"
+            f"Repair this malformed JSON for a {'MiniMax short-film' if is_minimax else 'ID-LoRA'} dialogue scene plan.\n"
             "Return only valid JSON. Do not add prose, markdown, code fences, comments, or trailing commas.\n"
             "Every property name must be enclosed in double quotes. Every string value must be enclosed in double quotes.\n"
             "Keep the same title, premise, and scenes when possible.\n\n"
@@ -2139,7 +2794,7 @@ def _build_id_lora_dialogue_scenes(payload):
             temperature=0.1,
             top_p=0.8,
             max_new_tokens=int(payload.get("max_new_tokens") or max(2200, scene_count * 520)),
-            label="ID-LoRA Dialogue Scenes JSON Repair",
+            label="MiniMax Short Film Dialogue JSON Repair" if is_minimax else "ID-LoRA Dialogue Scenes JSON Repair",
             preserve_paragraphs=True,
         )
         try:
@@ -2147,7 +2802,19 @@ def _build_id_lora_dialogue_scenes(payload):
             run_info = {**run_info, "json_repaired": True, "repair_runner": repair_info.get("runner", "")}
         except Exception:
             raise ValueError(f"Gemma returned malformed dialogue-plan JSON and repair failed. Original parse error: {parse_error}")
-    scenes = _normalize_generated_dialogue_scenes(data.get("scenes"), subjects, locations)
+    generated_scene_rows = _apply_authoritative_script_plan(data.get("scenes"), authoritative_script) if authoritative_script else data.get("scenes")
+    scenes = (
+        _normalize_generated_minimax_dialogue_scenes(
+            generated_scene_rows,
+            subjects,
+            locations,
+            payload.get("minimax_h3_mode"),
+            camera_flow,
+            camera_motion_speed,
+        )
+        if is_minimax else
+        _normalize_generated_dialogue_scenes(data.get("scenes"), subjects, locations)
+    )
     return {
         "title": _clean_scene_text(data.get("title") or "", 200),
         "premise": _clean_scene_text(data.get("premise") or story_source or "", 4000),
@@ -2156,7 +2823,16 @@ def _build_id_lora_dialogue_scenes(payload):
         "runner": run_info.get("runner", "builtin"),
         "used_model": run_info.get("used_model", ""),
         "unloaded": run_info.get("unloaded", True),
+        "authoritative_script_used": bool(authoritative_script),
     }
+
+
+def _build_minimax_dialogue_scenes(payload):
+    request_payload = dict(payload or {})
+    request_payload["_dialogue_planner_profile"] = "minimax_short_film"
+    request_payload["performance_mode"] = "speaking"
+    request_payload["short_film_planning_mode"] = "guided_film"
+    return _build_id_lora_dialogue_scenes(request_payload)
 
 
 def _ensure_storyboard_routes():
@@ -2253,6 +2929,15 @@ def _ensure_storyboard_routes():
         try:
             payload = await request.json()
             result = await asyncio.to_thread(_build_id_lora_dialogue_scenes, payload)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=500)
+        return web.json_response({"ok": True, **result})
+
+    @server_instance.routes.post("/vrgdg/storyboard/minimax_dialogue_scenes")
+    async def vrgdg_storyboard_minimax_dialogue_scenes(request):
+        try:
+            payload = await request.json()
+            result = await asyncio.to_thread(_build_minimax_dialogue_scenes, payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=500)
         return web.json_response({"ok": True, **result})

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -208,6 +208,15 @@ def _minimax_h3_api_template_path():
     )
 
 
+def _minimax_h3_built_in_audio_api_template_path():
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "Workflows",
+        "UsedForUIDoNotTouch",
+        "minimax_built_in_audio_builder_api.json",
+    )
+
+
 def _clear_memory_api_template_path():
     return os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
@@ -2467,7 +2476,10 @@ def _patch_minimax_h3_advanced_settings(prompt, payload):
 
 
 def _build_minimax_h3_api_prompt(payload):
-    workflow_path, prompt = _load_api_template(_minimax_h3_api_template_path())
+    raw_audio_mode = str(payload.get("audio_mode") or payload.get("audioMode") or "input_audio").strip().lower().replace("-", "_").replace(" ", "_")
+    audio_mode = "built_in_audio" if raw_audio_mode in {"built_in_audio", "native_audio", "generated_audio"} else "input_audio"
+    workflow_template = _minimax_h3_built_in_audio_api_template_path() if audio_mode == "built_in_audio" else _minimax_h3_api_template_path()
+    workflow_path, prompt = _load_api_template(workflow_template)
     prompt = copy.deepcopy(prompt)
 
     video_prompt = str(_first_payload_value(
@@ -2476,14 +2488,16 @@ def _build_minimax_h3_api_prompt(payload):
     if not video_prompt:
         raise ValueError("MiniMax H3 video prompt is empty.")
 
-    audio_text = str(_first_payload_value(
-        payload, "audio_path", "source_audio_path", default=""
-    ) or "").strip().strip('"')
-    if not audio_text:
-        raise ValueError("MiniMax H3 source audio path is empty.")
-    audio_path = os.path.abspath(audio_text)
-    if not os.path.isfile(audio_path):
-        raise FileNotFoundError(f"MiniMax H3 source audio was not found: {audio_path}")
+    audio_path = ""
+    if audio_mode == "input_audio":
+        audio_text = str(_first_payload_value(
+            payload, "audio_path", "source_audio_path", default=""
+        ) or "").strip().strip('"')
+        if not audio_text:
+            raise ValueError("MiniMax H3 source audio path is empty.")
+        audio_path = os.path.abspath(audio_text)
+        if not os.path.isfile(audio_path):
+            raise FileNotFoundError(f"MiniMax H3 source audio was not found: {audio_path}")
 
     project_text = str(payload.get("project_folder", "") or "").strip().strip('"')
     if not project_text:
@@ -2513,7 +2527,7 @@ def _build_minimax_h3_api_prompt(payload):
     source_duration = _first_payload_value(
         payload, "source_duration_seconds", "audio_duration_seconds", default=None
     )
-    if source_duration is None:
+    if source_duration is None and audio_mode == "input_audio":
         source_duration = _probe_media_duration_seconds(audio_path)
     source_start = _first_payload_value(
         payload, "source_start_seconds", "audio_start_seconds", default=None
@@ -2532,12 +2546,14 @@ def _build_minimax_h3_api_prompt(payload):
         source_start_seconds=source_start,
         source_duration_seconds=source_duration,
     )
-    prepared_audio = _trim_minimax_h3_audio_context(
-        audio_path,
-        project_folder,
-        scene_number,
-        timing,
-    )
+    prepared_audio = None
+    if audio_mode == "input_audio":
+        prepared_audio = _trim_minimax_h3_audio_context(
+            audio_path,
+            project_folder,
+            scene_number,
+            timing,
+        )
 
     image_paths = _minimax_h3_image_paths(payload)
     video_references = _minimax_h3_video_references(payload)
@@ -2584,9 +2600,10 @@ def _build_minimax_h3_api_prompt(payload):
     _set_api_input(prompt, "128", "clip_name", clip_name)
     _set_api_input(prompt, "119", "vae_name", video_vae_name)
     _set_api_input(prompt, "120", "vae_name", audio_vae_name)
-    _set_api_input(prompt, "171", "audio_file", prepared_audio["audio_path"])
-    _set_api_input(prompt, "171", "seek_seconds", 0)
-    _set_api_input(prompt, "171", "duration", 0)
+    if audio_mode == "input_audio":
+        _set_api_input(prompt, "171", "audio_file", prepared_audio["audio_path"])
+        _set_api_input(prompt, "171", "seek_seconds", 0)
+        _set_api_input(prompt, "171", "duration", 0)
     _set_api_input(prompt, "180", "image_paths", json.dumps(image_paths, ensure_ascii=False))
     _set_api_input(prompt, "180", "video_references", json.dumps(video_references, ensure_ascii=False))
     _set_api_input(prompt, "142", "frame_rate", 24)
@@ -2602,6 +2619,7 @@ def _build_minimax_h3_api_prompt(payload):
         "output_folder": output_folder,
         "prompt": prompt,
         "used_seed": seed,
+        "audio_mode": audio_mode,
         "timing": timing.to_dict(),
         "prepared_audio": prepared_audio,
         "post_render_trim": {

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -1,14 +1,14 @@
-# LTX 2.3 Video Builder Guide
+# Video Builder Guide — LTX 2.3 and MiniMax H3
 
 This guide is for someone opening the Video Builder for the first time. It explains what each main area does, the usual workflow, and where to look when something is missing.
 
-If this guide or the LTX 2.3 Video Builder helps you, you can support VR Game Dev Girl here: [buymeacoffee.com/vrgamedevgirl](https://buymeacoffee.com/vrgamedevgirl).
+If this guide or the Video Builder helps you, you can support VR Game Dev Girl here: [buymeacoffee.com/vrgamedevgirl](https://buymeacoffee.com/vrgamedevgirl).
 
 ![Full Video Builder Window](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/Full%20LTX%202.3%20Video%20Builder%20window.png)
 
 ## Table of Contents
 
-- [What the LTX 2.3 Video Builder Does](#what-the-ltx-23-video-builder-does)
+- [What the Video Builder Does](#what-the-video-builder-does)
 - [Current Feature Overview](#current-feature-overview)
 - [Recent Builder Updates](#recent-builder-updates)
 - [Installing From Main](#installing-from-main)
@@ -27,6 +27,7 @@ If this guide or the LTX 2.3 Video Builder helps you, you can support VR Game De
 - [Image Tab](#image-tab)
 - [Browser AI Image Mode](#browser-ai-image-mode)
 - [Video Tab](#video-tab)
+- [MiniMax H3 Video Engine](#minimax-h3-video-engine)
 - [ID-LoRA Image-to-Video](#id-lora-image-to-video)
 - [First Last Frame Video](#first-last-frame-video)
 - [Audio Tab](#audio-tab)
@@ -50,16 +51,14 @@ If this guide or the LTX 2.3 Video Builder helps you, you can support VR Game De
 - [Settings And Audio Notifications](#settings-and-audio-notifications)
 - [Required Custom Nodes](#required-custom-nodes)
 - [Models and Downloads](#models-and-downloads)
-- [Standalone Video Enhancer and Video Compare](#standalone-video-enhancer-and-video-compare)
-- [Additional Nodes and Utilities](#additional-nodes-and-utilities)
 - [Saving Projects](#saving-projects)
 - [Reference-to-Video (MSR LoRA) Quick-Start Walkthrough](#reference-to-video-msr-lora-video-quick-start-walkthrough)
 - [Recommended Beginner Workflow](#recommended-beginner-workflow)
 - [Common Problems](#common-problems)
 
-## What the LTX 2.3 Video Builder Does
+## What the Video Builder Does
 
-The LTX 2.3 Video Builder is a scene-by-scene video creation UI inside ComfyUI. It helps you build a project from audio, SRT timing, lyric timing, scene notes, prompts, images, video clips, and final stitching.
+The Video Builder is a scene-by-scene video creation UI inside ComfyUI. A project can use the established LTX 2.3 engine or the separate MiniMax H3 engine. It helps you build from audio, SRT timing, lyric or dialogue timing, scene notes, prompts, images, video clips, and final stitching.
 
 The basic idea is:
 
@@ -73,15 +72,20 @@ The basic idea is:
 8. Render scene videos.
 9. Stitch the final video.
 
-The current Builder includes the guided Wizard, Storyboard Builder, reference-video modes, per-scene overrides, flexible LLM runners, post-process tools, First/Last Frame workflows, Browser AI storyboarding, integrated face repair, portable project transfer, safer timeline tools, update checking, and standalone media/training utilities.
+The current Builder includes the guided Wizard, Storyboard Builder, reference-video modes, per-scene overrides, flexible LLM runners, post-process tools, First/Last Frame workflows, Browser AI storyboarding, integrated face repair, portable project transfer, safer timeline tools, update checking, and dedicated MiniMax H3 music-video and short-film paths.
 
 ## Current Feature Overview
 
-The current LTX 2.3 Video Builder feature set includes:
+The current Video Builder feature set includes:
 
 | Feature | What it adds |
 | --- | --- |
 | Status banner and updater | Checks the installed commit against production `main`, reports whether it is current, conditionally installs changed Python requirements, and offers a safe fast-forward update |
+| Project video engines | Keeps LTX 2.3 as the default for existing and new projects while adding a separate MiniMax H3 renderer selected in Builder Settings |
+| MiniMax H3 scene modes | Adds Text-to-Video, Image-to-Video, Reference-to-Video, and Video-to-Video with global settings or locked per-scene overrides |
+| MiniMax exact timing and audio | Renders on H3's required 24 FPS/frame grid, supplies the exact project or scene audio when selected, then trims every result back to the authoritative timeline range |
+| MiniMax references and continuity | Sends up to nine ordered images and three ordered videos, supports exact-start and spatial continuity, and preserves the purpose/order of every reference |
+| MiniMax short-film authoring | Adds built-in generated audio, Reference Builder voice presets, per-scene speaker cues, Guided Film Automation, and an exact-dialogue Script Mapper |
 | Chained First/Last Frame | Builds one opening image plus a destination image for each scene; each destination can become the next scene's start |
 | Independent First/Last Frame pairs | Gives every scene its own start and end image using four resumable passes: starts, motion plans, ends, and final two-image video prompts |
 | `Build Full FLF Video` | Runs missing endpoint planning, the FLF image chain, per-scene prompts/renders, final-frame extraction, and stitching as one pipeline |
@@ -103,7 +107,7 @@ The current LTX 2.3 Video Builder feature set includes:
 | Stronger story planning | Preserves character descriptions, handles repeated song sections, rejects real lyric-heading changes, removes only invented trailing Story Arc sections, supports repeating location blocks, and improves responsive Storyboard layout |
 | Speaking and silent projects | Adds project-wide speaking/no-lip-sync behavior, ID-LoRA dialogue planning and auto durations, per-scene silence, and silent timeline audio |
 | Scene Adjust finishing | Adds color, lightness, sharpness, clarity, vignette, and fade controls with still-frame preview, per-scene render, apply-all, and reusable presets |
-| New standalone utilities | Adds the Standalone Video Enhancer, Video Compare Slider, Face Fix and Video Enhance node sets, advanced LTX CFG/guide scheduling and looping, feathered crop paste-back, a LoRA Dataset Creator, and expanded Krea 2 training/install tools |
+| Flexible project storage and memory management | Lets new projects use a custom parent folder and lets DynamicVRAM users disable automatic Builder cleanup while keeping manual `Clear Memory` available |
 
 ## Recent Builder Updates
 
@@ -111,16 +115,20 @@ These are the newest user-facing changes covered throughout this guide:
 
 | Update | What changed |
 | --- | --- |
+| MiniMax H3 Builder integration | Projects can select MiniMax H3 and use its four scene modes, dedicated prompts and renderer, ordered image/video references, exact timeline trim, input-audio or built-in-audio paths, and H3-aware `Render All`/stitching. |
+| MiniMax H3 B-roll safety | Scenes marked B-roll/no-lip-sync now suppress lyric, singer, speaker, and native-voice inputs during prompt generation, remove singing directions from H3 timestamp blocks, and reapply a visual-only safety contract when rendering an existing prompt. |
+| MiniMax short films | Storyboard Builder can plan Guided Film scene cards, import and validate `speaker: dialogue` scripts, map every speaker to a Reference Builder character, preserve exact dialogue, and create the real timeline only after review. |
+| Project storage and memory control | Settings can choose a default folder for newly created projects and can enable or disable automatic RAM/VRAM cleanup. Existing projects and temporary ComfyUI outputs are not moved. |
+| International lyric alignment and longer waits | Lyric matching now preserves Unicode words such as Cyrillic instead of stripping them, and an individual scene render may wait up to two hours before the Builder reports a timeout. |
 | Reference lyrics and Story Arc reliability | `Transcribe Existing Scenes` now requires reference lyrics, preserves their exact line order, corrects held or missed boundary words, and no longer inserts pipe delimiters. Beat mode automatically transcribes its finished beat scenes. Story Arc keeps a complete valid heading structure when Gemma only appends invented trailing sections. |
 | Faster scene selection and Ingredients panels | `Select Multi` now supports direct timeline clicks and typed scene lists with ranges and shortcuts. The Ingredients Reference Builder correctly mounts its Sheets, Mapping, and Locations panels. |
 | Timeline and Storyboard prompt controls | `+ Segment` can end at the scrubber, Space toggles playback, `S` adds a segment, Left/Right navigate scenes, Storyboard Video Prep exposes Motion Notes inline, and all-scenes Gemma runs can fill only missing prompts or redo every visible scene. |
 | Render visibility and resume safety | `Render All` has a persistent live log and saved reports. Missing-only Storyboard batches preserve completed prompts and save successful partial progress if a later scene fails. |
-| Standalone finishing utilities | The Standalone Video Enhancer adds Original/2K/3K/4K output, sharpening, grain, resumable batches, and before/after comparison. The Video Compare Slider provides synchronized draggable video comparison. |
 | Lyric, prompt, and scene safety | Adjacent scenes can be merged without shifting the remaining timeline, exact pasted lyric units remain intact, manual prompts remain manual, Storyboard starting-shot instructions are enforced, global audio remains the final soundtrack, and undo/thumbnail handling uses less memory. |
 
 ## Installing From Main
 
-The LTX 2.3 Video Builder is the production release on the repository's default `main` branch.
+The Video Builder is released from the repository's default `main` branch.
 
 ### New Install With ComfyUI Manager
 
@@ -276,7 +284,9 @@ Important project options:
 | `Import Project ZIP` | You want to extract, rebase, load, and continue a portable project |
 | `Delete Project` | You want to permanently remove a complete project folder from the project picker; this cannot be undone |
 
-Projects are saved under the ComfyUI output folder. A builder project contains the session JSON, SRT, generated images, scene videos, prompt files, reference images, and copied audio assets.
+By default, projects are saved under the ComfyUI output folder. To keep projects elsewhere, open `Menu` -> `Settings` -> `Project Storage`, choose an absolute parent folder, and click `Save Projects Root`. The preference applies to `New Project`, `Save Project As`, and `Branch Project`; it does not move existing projects or ComfyUI temporary render output. A full project path entered while creating one project overrides the preference for that project.
+
+The project picker lists projects from the configured parent folder as well as the normal output area. For safety, the Builder does not delete projects outside the ComfyUI output folder; remove those manually only after checking the exact path. A builder project contains the session JSON, SRT, generated images, scene videos, prompt files, reference images, and copied audio assets.
 
 ![Menu Dropdown](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/Menu%20Dropdown.png)
 
@@ -905,7 +915,7 @@ To make a scene override:
 
 ## Video Tab
 
-The `Video` tab creates the selected scene video. At the top, choose between:
+The `Video` tab creates the selected scene video. The controls depend on the project engine selected in Settings. In an LTX project, choose between:
 
 | Mode | What it does |
 | --- | --- |
@@ -917,7 +927,7 @@ The `Video` tab creates the selected scene video. At the top, choose between:
 | `First Last Frame` | Guides LTX from a scene start image to a scene end image, either as a continuous chain or independent start/end pairs |
 | `Import Custom Video` | Reserved for a future direct-import panel; use scene video restore/history tools for now |
 
-The Video tab has three subtabs:
+The LTX Video tab has three subtabs:
 
 | Subtab | What it controls |
 | --- | --- |
@@ -1049,6 +1059,118 @@ To create an Ingredients-to-Video scene:
 6. Add scene motion notes and click `Gemma Ingredients Video`.
 7. Check that the correct sheet is shown for the scene, then click `Create Scene Video`.
 8. If a batch uses the wrong sheet, fix the scene mapping before running `LLM Video All` or `Render All` again.
+
+## MiniMax H3 Video Engine
+
+MiniMax H3 is a separate project video engine inside Video Builder. Open `Menu` -> `Settings` -> `Project Video Engine` and choose `MiniMax H3`. This changes the Video tab, prompt preparation, scene renderer, batch renderer, timing adapter, and final stitch for the whole project. It does not convert or rewrite an LTX project automatically; existing projects and projects without an engine value continue to use LTX.
+
+Start a new project or use `Save Project As`/`Branch Project` before changing engines when you want to preserve an established LTX version.
+
+### MiniMax Scene Modes
+
+The MiniMax Video tab provides four modes:
+
+| Mode | Inputs and typical use |
+| --- | --- |
+| `Text to Video` | Prompt plus the selected audio path; no image or video reference is required |
+| `Image to Video` | Uses the selected scene image as the visual starting input |
+| `Reference to Video` | Uses ordered Reference Builder images and can optionally make the selected scene image the exact first frame |
+| `Video to Video` | Uses up to three ordered source videos, their trim ranges and purposes, plus optional ordered edit images |
+
+Mode, models, resolution, audio mode, timing handles, sampler, EasyCache, SageAttention, and FP16 accumulation are project-wide by default. Enable the scene's custom MiniMax settings lock when one scene needs a different mode or render setup. The lock copies the current effective settings into that scene; while it is off, later global changes continue to flow into the scene.
+
+### Models and Render Settings
+
+MiniMax H3 currently uses the standard diffusion model loader. GGUF diffusion models are filtered out and are not supported by this Builder path. The default model names are:
+
+```text
+models/diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors
+models/text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors
+models/vae/minimax_h3_video_vae_fp16.safetensors
+models/vae/minimax_h3_audio_vae_fp32.safetensors
+```
+
+The main video settings choose aspect ratio, megapixels, seed, warm-up frames, and cool-down frames. The collapsed advanced area contains sampler, scheduler, steps, denoise, EasyCache controls, SageAttention, and FP16 accumulation. Begin with the workflow defaults and test a single scene before changing advanced controls.
+
+MiniMax timing rules are different from LTX:
+
+- H3 renders at a fixed `24 FPS`.
+- Frame counts are rounded up to H3's required `17n+5` grid.
+- The Builder renders enough context to cover the scene, then trims the result back to the exact timeline start/end duration.
+- Warm-up and cool-down frames provide context; they do not lengthen the finished scene.
+- One H3 scene is limited to about 15 seconds. Split longer dialogue or music ranges into smaller scenes.
+
+### MiniMax Audio Modes
+
+| Audio mode | Behavior |
+| --- | --- |
+| `Input Audio (exact supplied audio)` | Uses custom scene audio when present, otherwise the matching project-audio range. The source waveform is kept unchanged for timing and lip sync. |
+| `Built-in MiniMax Audio` | Lets MiniMax create scene audio from the prompt. This enables native character voice presets and Short Film speaker assignments. |
+
+Use Input Audio for a finished song, narration, or dialogue recording that must remain exact. The Builder trims/pads the source into H3's audio latent for generation and uses the original audio in the finished timeline; it does not ask H3 to rewrite the words.
+
+Use Built-in MiniMax Audio for a short film where H3 should create the voices and sound. In `Reference Builder`, each mapped character can receive a MiniMax built-in voice preset or a custom preset name and description. In a Short Film scene, use `Speaker Assignment` to order exact dialogue cues. Speaker Assignment is intentionally disabled for Input Audio because changing the typed words would no longer match the supplied recording.
+
+For built-in-audio scenes, use the quiet timeline trim mode to set clean boundaries without automatic preview playback. Review the embedded sound of every scene before the final stitch.
+
+### Ordered Image References
+
+Reference-to-Video can use up to nine image inputs. Open the scene's MiniMax reference chooser from the Video tab and order the Reference Builder images exactly as H3 should receive them. Until you save a custom choice, the scene automatically follows its mapped character and location references.
+
+Important rules:
+
+- `Use scene image as exact start frame` reserves Image 1 for the selected scene image.
+- Previous-scene continuity can reserve one additional image slot, leaving fewer library-reference slots.
+- `Previous final frame — spatial reference` supplies the previous render as another visual reference.
+- `Previous final frame — exact start frame` makes the previous render's last frame the new scene's exact start.
+- A scene image exact start and previous-frame exact start cannot both own the same exact-start position.
+
+The numbered order is significant. Save the scene after rearranging references, then inspect the summary count before rendering.
+
+### Video-to-Video References
+
+Video-to-Video accepts up to three ordered source videos. Each row stores:
+
+| Field | What it controls |
+| --- | --- |
+| Video path | Source clip sent to H3 |
+| Start and duration | Portion of the source clip to use |
+| Purpose | `Continuation / Extension`, `Movement Guide`, `Camera Guide`, `Edit / Rhythm Guide`, `Transformation Source`, or `Visual Style Guide` |
+| Use audio | Whether that reference video's audio is available to the workflow |
+
+`Use Current Scene Video as Reference 1` quickly assigns the selected scene's current video. Reference Builder edit images may be sent alongside the videos in their saved order. Check source trim ranges and purposes carefully; the adapter preserves them rather than flattening every video into the same kind of reference.
+
+### MiniMax Prompting
+
+MiniMax prompts are stored separately from LTX video prompts, so generating or editing an H3 prompt does not overwrite an LTX prompt for the same scene. Click `Create MiniMax H3 Prompt` to use the runner selected in `LLM Runner`. Each H3 mode has its own editable instruction set.
+
+The prompt writer receives the exact scene duration, timeline/audio contract, lyric or dialogue line, mapped performers, ordered image/video references, and the current H3 mode. Review that the prompt:
+
+- describes action that fits within the exact scene time
+- names references in their displayed order
+- uses `<Audio 1>` when the supplied audio drives the performance
+- preserves the exact lyric/dialogue instead of paraphrasing it
+- includes saved voice descriptions only for Built-in Audio speakers
+
+Click `Create MiniMax H3 Scene Video` to render one scene. The Builder uses the dedicated H3 workflow and adds the exact-trimmed result to that scene's video history.
+
+### MiniMax Short Film and Script Mapper
+
+For generated dialogue, set the top-bar `Video Type` to `Speaking (short film)`, select `Built-in MiniMax Audio`, create and save characters/voices in Reference Builder, then open Storyboard Builder. The Short Film Story Layer offers:
+
+| Authoring path | What it does |
+| --- | --- |
+| `Guided Film Automation` | Uses the selected LLM to develop editable scene cards from a premise, outline, saved characters/locations, or an authoritative imported script |
+| `Fully Custom` | Leaves scene-card authoring and speaker cues under manual control |
+| `Import Script / Script Mapper` | Parses `.txt` or `.json`, validates every `speaker: dialogue` cue, maps speakers to saved characters, estimates timing, and splits long cues into H3-safe scenes |
+
+Script Mapper activation does not change the Video Builder timeline. In Guided Film, first activate and review the exact script, then develop the storyboard scenes. The LLM may add visual actions, reactions, shots, camera direction, location, ambience, and continuity, but it may not rewrite, reorder, merge, or omit the authoritative dialogue. After reviewing the cards and speaker assignments, click `Create Timeline Segments` to replace/create the real Builder scenes.
+
+### Rendering and Stitching MiniMax Projects
+
+`Render All` detects the project engine and routes MiniMax scenes through the H3 workflow. It respects each scene's effective global or locked mode, validates required prompts/references/audio, renders only the requested missing/new versions, trims every clip to its exact timeline duration, and stitches the H3 results.
+
+The current MiniMax path does not apply LTX-only canvas, mode, embedded-audio, or Post Process workflow settings. Use H3's own resolution and audio controls. Test one representative scene before a batch, especially after changing models, EasyCache, reference order, audio mode, or continuity.
 
 ## ID-LoRA Image-to-Video
 
@@ -1414,6 +1536,8 @@ For most music-video projects, start with one scene per lyric line. It is easier
 
 Use `Exact reference lyric lines` when the pasted lyric lines are already the units you want. Vocal lines are not split, merged, stretched, or constrained by the scene-duration fields. Instrumental gaps can still be included as complete gaps and split manually later with the timeline scissors.
 
+Lyric matching is Unicode-aware. Cyrillic and other non-Latin words are retained during stable-ts alignment instead of being reduced to empty lines. If an older project created incorrect two-second scenes from `0:00`, update/restart the Builder and run the reference-lyric transcription again with `Replace All`.
+
 Beat mode is a two-stage operation handled by one button: it creates the beat scene blocks, saves those blocks as the current timeline, and then fills them through `Transcribe Existing Scenes`. You do not need to run transcription a second time afterward. The Wizard uses the same shared scene-creation and lyric-mapping engines as Line Mapping, so the same reference-preservation rules apply there.
 
 ### Include Instrumental Gaps
@@ -1689,9 +1813,9 @@ This is why reviewing lyrics before running Gemma can improve lip-sync, reduce w
 
 ## Reference Builder
 
-The `Reference Builder` button opens the `Reference Image Builder`. This is for projects where scenes need consistent characters, locations, or visual references across many generated images.
+The `Reference Builder` button opens the `Reference Image Builder`. This is for projects where scenes need consistent characters, locations, or visual references across many generated images or videos.
 
-Reference Builder can feed references into `Flux/Klein` or `Nano B`, depending on the current image mode. It also supports the video-side reference flows for `Reference to Video` and `Ingredients to Video`.
+Reference Builder can feed references into `Flux/Klein` or `Nano B`, depending on the current image mode. It also supports the LTX video-side reference flows and the ordered image/video/voice data used by MiniMax H3.
 
 Use it when:
 
@@ -1702,6 +1826,9 @@ Use it when:
 | Connect scenes to specific location images | `Scene Mapping` |
 | Drive LTX/MSR Reference-to-Video | `MSR References` and subject mapping |
 | Drive LTX Ingredients-to-Video | `Ingredients Sheets` and scene mapping |
+| Drive MiniMax Reference-to-Video | Ordered character/location/extra image references, with an optional exact scene start image |
+| Drive MiniMax Video-to-Video | Up to three ordered video sources plus ordered visual-edit images |
+| Give MiniMax short-film characters consistent voices | A built-in voice preset or custom preset name/description on each character |
 | Include manually loaded image references too | `Also include manually loaded reference images` |
 
 Main areas:
@@ -1733,6 +1860,7 @@ When Reference Builder opens, choose the setup that matches the current generati
 | `LTX Reference to Video` | MSR/reference-image mapping for the LTX Reference-to-Video workflow |
 | `Ingredients to Video` | Complete Ingredients sheets and per-scene sheet mapping |
 | `ID-LoRA Ref Builder` | Character identity images, voices, locations, dialogue, and automatic or manual scene durations |
+| `MiniMax H3 References` | Ordered character, location, extra-image, video-edit, and voice data appropriate to the active H3 mode |
 
 Basic Reference Builder workflow:
 
@@ -1745,6 +1873,8 @@ Basic Reference Builder workflow:
 7. Generate images normally from the `Image` tab.
 
 For `Reference to Video`, focus on subject/MSR references and singer/subject mapping. For `Ingredients to Video`, open the Ingredients Reference Builder, upload sheet images, describe them if needed, and map sheets to scenes before running video prompts.
+
+For a MiniMax H3 project, Reference Builder hides LTX-only choices and follows the active H3 mode. Reference-to-Video uses ordered mapped images; Video-to-Video adds ordered edit images and the Video tab's source-video rows. The active scene's MiniMax chooser can override the automatic mapped-image order without changing other scenes. In Short Film + Built-in Audio, character cards also show `MiniMax built-in voice`; the saved preset name and description are copied exactly into prompts where that character speaks.
 
 ### Character References
 
@@ -1883,6 +2013,8 @@ Use it when you want stronger control over:
 
 Storyboard Builder works especially well with saved lyric mapping and Reference Builder data. For Reference-to-Video projects, it can enforce clearer facial/lip-sync behavior and add reference-aware trigger phrasing before writing video prompts back into the Video Builder scenes.
 
+For MiniMax H3 projects, Storyboard Builder shows the four H3 modes, writes the separate H3 prompt field, includes exact scene timing and ordered image/video/audio references, and preserves H3-specific settings when cards are saved back to Video Builder. It does not run the normal LTX prompt rewrites on H3 scenes.
+
 The collapsible `Story Layer` keeps the overall idea, lyric strength, user story arc, song story brief, lyric sections, and scene-beat creation controls together.
 
 ![Storyboard Builder Story Layer](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/storyboardbuilder/storylayer.png)
@@ -1902,6 +2034,8 @@ The current Storyboard Builder includes several planning and safety improvements
 - `Clear All Story Beats` clears only the per-scene story-beat field, preserving lyrics, prompts, references, images, locations, and shot settings
 - scene cards and controls reflow more cleanly on smaller or resized Storyboard windows
 - ID-LoRA projects can generate, review, and apply a speaking short-film dialogue plan from saved characters, locations, and an optional premise/script
+- MiniMax Short Film + Built-in Audio projects can use Guided Film Automation or Fully Custom authoring, assign ordered speaker cues, and create timeline segments only after the storyboard is reviewed
+- MiniMax Script Mapper can import `.txt`/`.json` dialogue, require every speaker to match a saved Reference Builder character, preserve exact cue order/text, and split the plan into H3-safe scene durations
 
 Recommended Storyboard Builder workflow:
 
@@ -1996,8 +2130,6 @@ Basic workflow:
 The tool detects and tracks one primary face, prepares safe 512×512 anchors, enhances those anchors with the current Z-Enhance setup, uses LTX 2.3 for temporal consistency, then feathers and color-matches the repaired face frames back into the original scene video. The repaired video is added to that scene's video history and selected automatically.
 
 Smaller anchor intervals are slower but improve consistency. The first and final frames are always included. `Repair distance` prevents already-large/close faces from being unnecessarily replaced, and the custom threshold lets you choose the face-width percentage where the repair fades out.
-
-The repository also includes standalone Face Fix nodes under `VRGameDevGirl/Face Fix` for users who want to assemble the same prepare, anchor, LTX, and composite stages in a normal ComfyUI workflow.
 
 ## Builder Agent
 
@@ -2209,7 +2341,7 @@ The `Menu` contains batch tools that can work across many scenes.
 | Button | What it does |
 | --- | --- |
 | `LLM T2I All` | Creates image prompts for multiple scenes |
-| `LLM Video All` | Creates I2V, T2V, Reference-to-Video, or Ingredients-to-Video prompts for multiple scenes |
+| `LLM Video All` | Creates the active LTX-mode prompts or separate MiniMax H3 prompts for multiple scenes |
 | `Image All` | Creates missing image prompts if needed, then creates missing images |
 | `Enhance All` | Enhances every scene that already has an image using its saved prompt and active Enhance settings |
 | `Render All` | Renders missing scene videos and can stitch when possible |
@@ -2248,6 +2380,8 @@ In `First Last Frame` mode, `Image All` also offers the dedicated chained and in
 
 During `Render All`, the persistent render log shows the current scene, phase, elapsed time, per-scene timing, estimated time remaining, and final-stitch timing. When the run finishes or stops, the Builder saves JSON and text reports with the project so you can review completed scenes, failures, and timing after the progress window closes.
 
+In a MiniMax H3 project, `LLM Video All` creates the separate H3 prompts for the effective mode of each scene. `Render All` uses the dedicated H3 workflow, honors global settings or a scene's locked override, applies exact timeline trim, and stitches the selected H3 clips. It does not route those scenes through LTX post-processing or LTX canvas/audio options.
+
 ![Build Full Video Options](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/Build%20Full%20Video%20Options.png)
 
 When the finished video is stitched, the builder shows a `Final Video Ready` popup. Use `Open Video` to preview it.
@@ -2270,6 +2404,8 @@ Safe batch workflow:
 The left panel has three tabs: `Scenes`, `Tools`, and `Post Process`.
 
 Use `Post Process` after images or videos exist and you want to style, compare, or finish them.
+
+The automatic MiniMax H3 render/stitch path currently skips LTX Post Process workflow settings. The controls in this section describe the established LTX/scene-finishing path; do not assume an H3 `Render All` will apply them.
 
 Post Process tools:
 
@@ -2429,13 +2565,30 @@ Common settings:
 
 | Setting | What it does |
 | --- | --- |
+| Project Video Engine | Chooses `LTX (current Builder)` or the separate `MiniMax H3` path for the whole project |
+| Default folder for new projects | Optional absolute parent folder used by New Project, Save Project As, and Branch Project |
 | Custom model root | Optional alternate models folder root |
+| Run automatic RAM/VRAM cleanup | Controls embedded cleanup nodes and automatic cache clearing between Builder jobs |
 | Audio notifications | Plays a sound when selected events finish or fail |
 | Notification volume | Controls notification sound volume |
 | Notify on error | Plays an error sound when a run fails |
 | Notify on finished item | Plays a sound after scene/image/video tasks finish |
 | Notify on full run complete | Plays a sound when a batch/full build finishes |
 | Custom success/error sound | Lets you choose your own audio file for notifications |
+
+### Project Video Engine
+
+Choose the engine before creating prompts and videos. `LTX (current Builder)` keeps the existing LTX modes and renderer. `MiniMax H3` shows the separate four-mode H3 panel, exact-timeline adapter, and H3 scene action. The value is saved with the project; older sessions without it load as LTX.
+
+### Project Storage
+
+`Default folder for new projects` is optional. Use `Choose Folder`, or enter a full absolute folder path such as:
+
+```text
+D:\VRGDG Projects
+```
+
+Click `Save Projects Root` to use it for future `New Project`, `Save Project As`, and `Branch Project` operations. `Use ComfyUI Output` clears the preference. The Builder never moves an existing project or redirects ComfyUI's temporary render output when this changes. An explicit full path entered for a new project still wins for that one project. For safety, projects outside ComfyUI output are read/load capable but cannot be deleted from the Builder project picker.
 
 ### Custom Model Root
 
@@ -2461,6 +2614,12 @@ models
 
 The model pickers look inside the configured root and its known subfolders. If a model is not visible after changing this setting, save settings and refresh/restart the UI.
 
+### Memory Management
+
+`Run automatic RAM/VRAM cleanup` controls whether the Builder executes embedded `RAMCleanup`/`VRAMCleanup` nodes and directly clears Comfy/Gemma caches between tasks, retries, errors, and stops. It is off by default and off is recommended when ComfyUI DynamicVRAM is enabled. The manual `Clear Memory` top-bar action remains available in either state.
+
+If memory usage grows during a long build, first check whether DynamicVRAM is active. Avoid enabling two competing cleanup strategies without testing a short scene; explicit cleanup can add reload time between renders.
+
 ### Audio Notifications
 
 Audio notifications are optional. They are useful for long overnight runs.
@@ -2478,10 +2637,13 @@ To save settings:
 
 1. Open `Menu` -> `Settings`.
 2. Change only the options you need.
-3. For a custom model root, enter the folder that contains the normal ComfyUI model subfolders.
-4. For notifications, enable the desired events, set a low test volume, and optionally choose success/error audio files.
-5. Save/close Settings.
-6. Refresh or restart ComfyUI when model paths changed; click once inside the browser before testing notification sounds.
+3. Choose the project engine before starting engine-specific prompt/render work.
+4. For custom project storage, choose an absolute parent folder and click `Save Projects Root`.
+5. For a custom model root, enter the folder that contains the normal ComfyUI model subfolders.
+6. Set automatic memory cleanup according to your DynamicVRAM setup.
+7. For notifications, enable the desired events, set a low test volume, and optionally choose success/error audio files.
+8. Save/close Settings.
+9. Refresh or restart ComfyUI when model paths changed; click once inside the browser before testing notification sounds.
 
 ![Settings window with custom model root and audio notifications](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/Settings%20window%20with%20custom%20model%20root%20and%20audio%20notifications.png)
 
@@ -2493,7 +2655,7 @@ Short snippet:
 
 The Builder UI comes from this repo, but the hidden workflows it launches also use several external custom-node packs. Install these before running full image/video builds.
 
-This list was checked against the hidden workflow templates used by the Builder and Prompt Creator, including the ZImage, Krea 2, Ernie, Flux/Klein, Nano B, Enhance, I2V, T2V, Reference-to-Video, Ingredients, ID-LoRA, FLF, Face Fix, cleanup, transcription, and Prompt Creator workflows.
+This list was checked against the hidden workflow templates used by the Builder and Prompt Creator, including the ZImage, Krea 2, Ernie, Flux/Klein, Nano B, Enhance, LTX I2V/T2V/reference modes, MiniMax H3 input-audio/built-in-audio modes, Ingredients, ID-LoRA, FLF, Face Fix, cleanup, transcription, and Prompt Creator workflows.
 
 Use ComfyUI Manager when possible: open `Manager` -> `Install Custom Nodes`, search the name, install it, then restart ComfyUI. If a workflow still opens with red missing nodes, use ComfyUI Manager's missing-node installer on that workflow.
 
@@ -2519,6 +2681,7 @@ Mode-specific notes:
 | Builder feature | Extra dependency notes |
 | --- | --- |
 | `Image to Video` / `Text to Video` | Requires the LTXVideo, VideoHelperSuite, GGUF, and KJNodes packs above |
+| `MiniMax H3` | Requires a current ComfyUI build with `MiniMaxH3ReferenceToVideo`, KJNodes for the standard diffusion loader, VideoHelperSuite for reference video/audio loading and combining, and this repo's H3 timing/audio/reference nodes. Built-in audio also uses the installed LTX audio VAE decode node. GGUF is not supported on this path. |
 | `First Last Frame` | Requires the same LTX stack plus the bundled `LTX2.3_FLF_API.json` hidden workflow and both start/end images |
 | `ID-LoRA I2V` | Requires LTXVideo plus the required ID-LoRA/model shown in the Video tab |
 | `Reference to Video` | Requires LTXVideo plus the MSR LoRA/model files shown in `Download Models` |
@@ -2598,57 +2761,20 @@ ComfyUI/
     latent_upscale_models/ltx-2.3-spatial-upscaler-x2-1.1.safetensors
 ```
 
+MiniMax H3:
+
+```text
+ComfyUI/
+  models/
+    diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors
+    text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors
+    vae/minimax_h3_video_vae_fp16.safetensors
+    vae/minimax_h3_audio_vae_fp32.safetensors
+```
+
+MiniMax H3 model names and folder locations are listed here because they are required by the Builder even when the current `Download Models` window does not provide an H3 download group. The MiniMax diffusion picker intentionally lists non-GGUF files only. If the H3 model or `MiniMaxH3ReferenceToVideo` node is missing after placing the files, update ComfyUI, restart it completely, and hard refresh the browser.
+
 ![Download Models Window](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/2026-06-01%2016_02_27-.png)
-
-## Standalone Video Enhancer and Video Compare
-
-Add `VRGDG Standalone Video Enhancer` to open a clean enhancement workspace for an existing finished video without opening Video Builder.
-
-| Enhancer control | What it does |
-| --- | --- |
-| Output size | Keeps the original size or creates 2K, 3K, or 4K output with high-quality Lanczos scaling while preserving portrait/landscape aspect ratio |
-| Fast Unsharp Sharpen | Adds fast sharpening with strength up to 10; test a short range before using high values |
-| Fast Film Grain | Controls grain intensity, saturation mix, and deterministic seed |
-| Current-frame comparison | Shows the active frame before and after processing with a draggable wipe |
-| Final-video comparison | Synchronizes the source and enhanced videos behind the same draggable divider and supports an expanded, screen-filling view |
-| Memory-aware rendering | Processes long videos in resumable frame batches with checkpoints, cancellation, and an automatic smaller-batch retry after GPU out-of-memory errors |
-| Preserve audio | Copies the original soundtrack into the finished enhanced video when enabled |
-
-Recommended enhancer workflow:
-
-1. Add the node and click `Open Standalone Video Enhancer`.
-2. Load the source video and choose Original, 2K, 3K, or 4K.
-3. Start with low sharpening and grain values and compare a representative frame.
-4. Render a short test before processing a long video.
-5. Use the final-video wipe comparison to check faces, edges, motion, and grain.
-6. Resume from the saved checkpoint after an interruption instead of restarting a completed batch.
-
-Add `VRGDG Video Compare Slider` when you only need to compare two existing videos. It provides synchronized playback, shared scrubbing, looping, optional audio, editable labels, a draggable before/after divider, and an expanded comparison view.
-
-## Additional Nodes and Utilities
-
-The repository also includes standalone nodes and UIs that can be used outside the Video Builder. These do not appear as Builder panels; add them to a normal ComfyUI workflow.
-
-| Node or utility | What it adds | Quick start |
-| --- | --- | --- |
-| `VRGDG Standalone Video Enhancer` | Standalone Original/2K/3K/4K enhancement with sharpening, grain, resumable rendering, audio preservation, and frame/video wipe comparison | Add the node, open the enhancer, load a source video, test conservative settings on a short range, then render and compare the final result |
-| `VRGDG Video Compare Slider` | Synchronized before/after video playback with scrubbing, looping, labels, optional audio, and a draggable divider | Add the node, load both videos, synchronize them, then drag the divider or expand the viewer for inspection |
-| `VRGDG Storyboard Creator with Browser AI — Open This` | The project-aware start/end storyboard workspace described above | Add the node, click `Open Storyboard Creator`, load a saved Builder project, and follow the Start Image Storyboard workflow above |
-| `VRGDG LoRA Dataset Creator UI` | Builds image/caption datasets for art styles, consistent characters, or experimental LTX 2.3 IC edit pairs | Add/open the UI, choose the dataset type/output folder, configure the concept and generator, test one item, then run the batch; review images and captions before training |
-| `Face Fix - ...` node set | Detects/tracks a face, prepares Z-Image anchors and an LTX crop video, validates both branches, and composites repaired frames back into the source | Start from the supplied Face Fix workflow, load the source video, set the face/range/detection options, run prepare and anchors, process the crop through LTX, validate, then composite it back |
-| `Video Enhance - ...` node set | Creates full-frame enhancement anchors, feeds them through Meta Batch and LTX, then restores the exact original resolution/frame count | Start from the supplied Enhance workflow, load the video, create anchors, run the LTX/Meta Batch path, restore the original dimensions/frame count, and adjust source blend if the result is too strong |
-| `VRGDG Modern Face Crop (DNN)` | OpenCV DNN/YuNet face crop with confidence filtering and long-range tiled scanning | Connect an image, choose detector/confidence/minimum-face settings, run it, and pass both the crop and returned crop metadata to a compatible paste-back node |
-| `VRGDG Image Paste Back (Feathered)` | Pastes a processed crop back through compatible crop metadata with edge padding and feathering | Connect the original image, processed crop, and matching crop metadata; tune padding/feathering, then compare the composite with the original |
-| `VRGDG LTXV Looping Sampler Advanced` | Adds per-temporal-tile image, latent, and overlap-conditioning schedules | Replace the official looping sampler in an advanced LTX workflow, reconnect the same model/conditioning/latent inputs, set temporal-tile and overlap schedules, and test a short clip before a long render |
-| `VRGDG LTX First / Last Temporal Guide` and `Endpoint Guide` | Builds temporal first/last-frame guidance and explicit endpoint guidance | Connect the start/end images or latents and the target frame count, set the guide frame positions/strengths, then feed the returned guides into the matching LTX conditioning/sampler path |
-| `VRGDG LTX IC Ingredients Grid` | Composes up to 24 images into LTX IC-LoRA reference-sheet layouts | Connect the required ingredient images, choose grid/strip/story/aspect-aware layout, run the node, and use the resulting sheet as the IC/Ingredients reference image |
-| `VRGDG Optional Multi LoRA Two Pass Strengths` | Applies optional model-only LoRAs with independent first/second-pass strengths | Connect the base model, select each optional LoRA, set pass 1 and pass 2 strengths, and connect the two model outputs to their matching workflow passes |
-| LTX CFG/Sigma nodes | Adds scheduled CFG, APG/STG/variance-rescale guidance, and sigma-aware guide release | Insert the chosen guidance node in the matching LTX guidance path, start with workflow defaults, then change one schedule/scale at a time while testing a short fixed-seed clip |
-| `VRGDG Krea 2 Musubi Installer` | Installs a native Krea 2-ready Musubi-Tuner and model assets | Add/open the installer, choose an install folder, run dependency installation, optionally download models, and restart ComfyUI after it completes |
-| `VRGDG Krea 2 LoRA Studio` | Provides preset-based Krea 2 chunk training, sampling, and comparison grids | Open the Studio, select the dataset/output/model, choose a preset, run a small sample/chunk first, then start training and compare checkpoint samples |
-| `VRGDG Krea 2 AI Toolkit Installer` | Installs an isolated AI Toolkit environment for experimental paired Krea 2 Edit LoRA training | Choose an isolated install folder, run installation, restart ComfyUI, then point the paired-training workflow at that environment and a validated source/target dataset |
-
-These utilities are optional for the basic Video Builder path. Install their model/tool dependencies only if you plan to use those specific nodes.
 
 ## Saving Projects
 
@@ -2657,6 +2783,8 @@ Use `Quick Save` often. Keep `Auto save` on unless you have a reason to turn it 
 Use `Save Project As` before major experiments. This creates a separate copy so you can test new prompts, models, or remake settings without damaging the original project.
 
 Use `Branch Project...` when you want the experiment recorded as a project branch, or `Export Shareable Project ZIP` when the project must be moved or shared. Project ZIP import rebases saved media paths to the extracted destination before loading the session.
+
+By default, new/copy/branch folders are created under ComfyUI output. `Menu` -> `Settings` -> `Project Storage` can set a different absolute parent folder for future projects. This preference never relocates the currently loaded project. External project folders cannot be deleted through the Builder UI.
 
 Project folders may contain:
 
@@ -2751,6 +2879,30 @@ Use this when each scene needs a planned visual destination or continuous handof
 6. Use `Render All` after the endpoints are approved, or `Build Full FLF Video` to finish missing FLF dependencies and stitch automatically.
 7. Prefer resume choices until you intentionally want to replace completed work.
 
+### MiniMax H3 Music Video Workflow
+
+Use this when a finished song or spoken track must drive H3 with exact timeline timing.
+
+1. Create or branch a project, then choose `Menu` -> `Settings` -> `Project Video Engine` -> `MiniMax H3`.
+2. Load project audio and create/review timeline scenes. Keep each scene at or below about 15 seconds.
+3. Choose `Input Audio (exact supplied audio)` in the MiniMax Video Settings.
+4. Add and map Reference Builder characters/locations when using Reference-to-Video, or add source videos when using Video-to-Video.
+5. Choose the H3 mode and settings globally. Lock only the scenes that need different settings.
+6. Create/review the separate MiniMax prompt for a representative scene, then click `Create MiniMax H3 Scene Video`.
+7. Confirm lip sync, reference order, exact start/end duration, and original audio before using `LLM Video All` and `Render All`.
+
+### MiniMax H3 Short Film Workflow
+
+Use this when MiniMax should generate the dialogue voices and scene sound.
+
+1. Select MiniMax H3, set `Video Type` to `Speaking (short film)`, and choose `Built-in MiniMax Audio`.
+2. In Reference Builder, create the film characters, choose each character's built-in/custom voice, add locations, and save.
+3. Open Storyboard Builder and choose `Guided Film Automation` or `Fully Custom`.
+4. For an existing script, open `Import Script / Script Mapper`, validate every cue, map every speaker, and activate the exact script.
+5. Develop the storyboard, review visual actions and ordered speaker assignments, then click `Create Timeline Segments`.
+6. Create and test one H3 prompt/video, then run the missing-only prompt and render batches.
+7. Review every scene's generated audio and trim before final stitching.
+
 ### Recommended Video Builder Workflow
 
 Use this for new projects.
@@ -2767,6 +2919,16 @@ Use this for new projects.
 | No scene is editable | Select a scene from the left list or timeline |
 | The Image/Video/Audio tabs are disabled | No scene is selected |
 | Model dropdowns are empty | Install models, then restart ComfyUI |
+| MiniMax H3 is not shown in the Video tab | Open `Menu` -> `Settings`, set the whole project's Video Engine to `MiniMax H3`, save, and reselect the scene |
+| MiniMax diffusion model is missing from the picker | H3 uses non-GGUF diffusion models only. Place the `.safetensors` model in `models/diffusion_models`, restart ComfyUI, and hard refresh |
+| MiniMax reports a scene is too long | Split the scene so each H3 range is about 15 seconds or shorter; H3 is fixed at 24 FPS and a maximum 362-frame render |
+| MiniMax references are missing or in the wrong order | Save Reference Builder, reopen the scene's H3 reference chooser, and check the numbered image/video order plus any slot reserved for exact-start continuity |
+| MiniMax exact start is unavailable | A scene image exact start and previous-final-frame exact start cannot both be active; choose one exact-start source |
+| MiniMax Input Audio cannot edit speaker cues | This is intentional because typed changes would not match the supplied waveform. Choose Built-in MiniMax Audio for generated dialogue |
+| MiniMax Script Mapper will not activate | Use `speaker: dialogue` or supported JSON, fix every parse error, and map every speaker to a saved Reference Builder character |
+| MiniMax Render All uses the wrong mode | Check whether the scene has custom MiniMax settings locked. Unlock it to follow the current global mode, or update the locked scene settings |
+| A character still sings in a MiniMax B-roll scene | Confirm `B-roll / no lip-sync` is saved in Line Mapping, then regenerate the prompt or render again. The renderer now reapplies the visual-only contract even to an older saved prompt; Input Audio vocals remain audible only as off-screen soundtrack. |
+| MiniMax final clip timing is wrong | Confirm the timeline scene itself has valid start/end times and stays inside the source audio; H3 renders extra aligned frames but the Builder should trim back to the exact scene duration |
 | Gemma prompt buttons fail | Make sure the correct Gemma model and mmproj are selected |
 | NanoBanana fails | Add the API key in the Nano B `Models` tab |
 | Render All skips scenes | Scenes with selected videos may already be complete |
@@ -2784,6 +2946,7 @@ Use this for new projects.
 | Image-to-video prompt looks wrong | Turn `Use image reference for I2V prompt?` on/off depending on whether the image should guide Gemma |
 | Characters sing during instrumental sections | Mark the scene `Instrumental` or `B-roll / no lip-sync`, then save lyric mapping |
 | Existing-scene transcription misses or shifts lyrics | Confirm the complete reference lyrics are pasted, use `Replace All`, restart ComfyUI after updating, and listen through boundary scenes in lyric review |
+| Cyrillic lyrics create empty two-second scenes from 0:00 | Update/restart the Builder, then rerun reference-lyric transcription with `Replace All`; lyric normalization now preserves Unicode letters |
 | Beat mode created scenes but lyrics are blank | Beat mode now transcribes its finished scenes automatically; confirm reference lyrics were supplied and review the transcription error/progress window |
 | Wrong singer performs a duet line | Open `Review Lines + Map Performers`, check both singers, then save |
 | A dialogue prompt talks about singing | Set the top-bar `Video Type` to `Speaking (short film)`, map the correct speaker, and regenerate the prompt |
@@ -2793,12 +2956,14 @@ Use this for new projects.
 | Ingredients tabs are blank | Update to the newest Builder, restart ComfyUI, and hard refresh the browser so the repaired Sheets, Mapping, and Locations panels load |
 | Story Arc reports a changed lyric structure | Update and rerun. Trailing invented headings are removed automatically; a remaining error means Gemma actually missed, renamed, reordered, or inserted a heading inside the required structure |
 | Render All progress disappeared | Reopen the persistent render log and inspect the saved JSON/text report in the project for completed phases, failures, and stitch timing |
+| A scene render reports the wait limit | The Builder now waits up to two hours. Check whether the ComfyUI queue is still running; if it finished, use scene-video recovery/history, and inspect the terminal plus temporary output before retrying |
 | Prompt Creator data does not populate notes | Use `Send To Video Creator` or `Import Data From Prompt Creator`, then reload/import prompt files if needed |
 | LM Studio is selected but not used | Vision Gemma still uses built-in GGUF; only text-only passes use LM Studio |
 | Browser AI cannot control the browser | Run Install/Check Browser Setup, sign in with `Open Selected Login`, or use the manual export/import path |
 | Face Fix finds no face | Choose a clearer description frame, lower minimum face pixels, adjust confidence/rotation assist, or pick a repair-distance preset that includes the face size |
 | Updater stops | Local edits or a non-fast-forward branch can block the safe updater; save/back up your work and use the manual Git commands to inspect the conflict |
 | Project ZIP import fails | Keep ComfyUI running, confirm the archive came from `Export Shareable Project ZIP`, and check the terminal for extraction/path validation errors |
+| A project outside ComfyUI output cannot be deleted in the picker | This safety restriction is intentional. Verify the full external path and remove it manually outside the Builder if desired |
 | Audio notification does not play | Click inside the browser once and check notification settings |
 | Model path is wrong on Linux | Use forward slashes and make sure the model picker shows the exact model name |
 

--- a/Workflows/UsedForUIDoNotTouch/minimax_built_in_audio_builder_api.json
+++ b/Workflows/UsedForUIDoNotTouch/minimax_built_in_audio_builder_api.json
@@ -1,0 +1,333 @@
+{
+  "115": {
+    "inputs": {
+      "aspect_ratio": "16:9 (Widescreen)",
+      "megapixels": 0.9,
+      "multiple": 32
+    },
+    "class_type": "ResolutionSelector",
+    "_meta": {
+      "title": "Resolution Selector (Size)"
+    }
+  },
+  "119": {
+    "inputs": {
+      "vae_name": "minimax_h3_video_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Video VAE"
+    }
+  },
+  "120": {
+    "inputs": {
+      "vae_name": "minimax_h3_audio_vae_fp32.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Audio VAE"
+    }
+  },
+  "121": {
+    "inputs": {
+      "samples": [
+        "125",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ]
+    },
+    "class_type": "LTXVAudioVAEDecode",
+    "_meta": {
+      "title": "BUILDER OUTPUT - Decode MiniMax Generated Audio"
+    }
+  },
+  "122": {
+    "inputs": {
+      "samples": [
+        "125",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "123": {
+    "inputs": {
+      "sampler_name": "res_multistep"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "124": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": 20,
+      "denoise": 1,
+      "model": [
+        "174",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "BasicScheduler"
+    }
+  },
+  "125": {
+    "inputs": {
+      "noise": [
+        "129",
+        0
+      ],
+      "guider": [
+        "126",
+        0
+      ],
+      "sampler": [
+        "123",
+        0
+      ],
+      "sigmas": [
+        "124",
+        0
+      ],
+      "latent_image": [
+        "136",
+        1
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "126": {
+    "inputs": {
+      "model": [
+        "174",
+        0
+      ],
+      "conditioning": [
+        "136",
+        0
+      ]
+    },
+    "class_type": "BasicGuider",
+    "_meta": {
+      "title": "Basic Guider"
+    }
+  },
+  "128": {
+    "inputs": {
+      "clip_name": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "129": {
+    "inputs": {
+      "noise_seed": 177702610855563
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "BUILDER INPUT - Seed"
+    }
+  },
+  "131": {
+    "inputs": {
+      "expression": "max(5, round(a * 24)) + (5 - (max(5, round(a * 24)) % 17)) % 17",
+      "values.a": [
+        "132",
+        0
+      ]
+    },
+    "class_type": "ComfyMathExpression",
+    "_meta": {
+      "title": "H3 Duration To Valid Frame Count"
+    }
+  },
+  "132": {
+    "inputs": {
+      "value": 5
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "BUILDER INPUT - Duration"
+    }
+  },
+  "136": {
+    "inputs": {
+      "prompt": [
+        "138",
+        0
+      ],
+      "width": [
+        "115",
+        0
+      ],
+      "height": [
+        "115",
+        1
+      ],
+      "length": [
+        "131",
+        1
+      ],
+      "ref_image_size": "match",
+      "clip": [
+        "128",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ],
+      "ref_images.ref_image_0": [
+        "180",
+        0
+      ],
+      "ref_images.ref_image_1": [
+        "180",
+        1
+      ],
+      "ref_images.ref_image_2": [
+        "180",
+        2
+      ],
+      "ref_images.ref_image_3": [
+        "180",
+        3
+      ],
+      "ref_images.ref_image_4": [
+        "180",
+        4
+      ],
+      "ref_images.ref_image_5": [
+        "180",
+        5
+      ],
+      "ref_images.ref_image_6": [
+        "180",
+        6
+      ],
+      "ref_images.ref_image_7": [
+        "180",
+        7
+      ],
+      "ref_images.ref_image_8": [
+        "180",
+        8
+      ],
+      "ref_videos.ref_video_0": [
+        "180",
+        9
+      ],
+      "ref_videos.ref_video_1": [
+        "180",
+        10
+      ],
+      "ref_videos.ref_video_2": [
+        "180",
+        11
+      ]
+    },
+    "class_type": "MiniMaxH3ReferenceToVideo",
+    "_meta": {
+      "title": "MiniMax H3 Reference to Video - Native Generated Audio"
+    }
+  },
+  "138": {
+    "inputs": {
+      "value": "Generate the requested video and its synchronized native audio together. Include the exact lyric or dialogue line and complete audio direction in this prompt."
+    },
+    "class_type": "PrimitiveStringMultiline",
+    "_meta": {
+      "title": "BUILDER INPUT - Prompt With Lyric Dialogue And Audio Direction"
+    }
+  },
+  "141": {
+    "inputs": {
+      "model_name": "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
+      "weight_dtype": "default",
+      "compute_dtype": "default",
+      "patch_cublaslinear": false,
+      "sage_attention": "auto",
+      "enable_fp16_accumulation": true
+    },
+    "class_type": "DiffusionModelLoaderKJ",
+    "_meta": {
+      "title": "Diffusion Model Loader KJ"
+    }
+  },
+  "142": {
+    "inputs": {
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "MiniMaxH3_BuiltInAudio_Builder",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true,
+      "images": [
+        "122",
+        0
+      ],
+      "audio": [
+        "121",
+        0
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "BUILDER OUTPUT - Video With MiniMax Generated Audio"
+    }
+  },
+  "174": {
+    "inputs": {
+      "reuse_threshold": 0.3,
+      "start_percent": 0.2,
+      "end_percent": 0.9,
+      "verbose": false,
+      "model": [
+        "141",
+        0
+      ]
+    },
+    "class_type": "EasyCache",
+    "_meta": {
+      "title": "EasyCache"
+    }
+  },
+  "180": {
+    "inputs": {
+      "image_paths": "[]",
+      "video_references": "[]"
+    },
+    "class_type": "VRGDG_MiniMaxH3ReferenceMediaFromPaths",
+    "_meta": {
+      "title": "BUILDER INPUTS - Ordered H3 Reference Images And Videos"
+    }
+  }
+}

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,52 @@
   "product": "LTX 2.3 Video Builder",
   "releases": [
     {
+      "id": "2026-08-05-minimax-h3-short-film-builder",
+      "version": "2026.08.05-minimax-h3",
+      "date": "2026-08-05",
+      "title": "MiniMax H3 built-in audio and short-film authoring",
+      "commit": "e0055190d989a2fb70522b7101086880d61ce8f3",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added Built-in MiniMax Audio as an alternative to exact supplied Input Audio, with a dedicated hidden workflow that generates and preserves native scene audio through rendering and final stitching.",
+            "Added ordered per-scene speaker cues plus American, British, Australian, and custom voice descriptions saved with Reference Builder characters.",
+            "Added Guided Film Automation, Fully Custom short-film scene cards, and a Script Mapper that validates speaker: dialogue text or JSON, maps speakers to saved characters, preserves exact cue order and wording, previews timing, and creates the real timeline only after review.",
+            "Added previous-scene spatial-reference and exact-start-frame continuity modes while preserving MiniMax's nine-image reference limit.",
+            "Added MiniMax video-aesthetic controls and protected-character temporal/world effects for Storyboard planning.",
+            "Added an optional custom projects root for newly created projects without moving existing projects or ComfyUI temporary render output."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "MiniMax prompts now keep Input Audio and Built-in Audio contracts separate, preserve exact speaker order, avoid repeating full dialogue or lyrics in every timestamp, and relax visible mouths after the audible vocal ends.",
+            "MiniMax render progress can display the exact prompt, lyric or dialogue, mode, and ordered reference images being sent for the current scene.",
+            "The per-scene render wait limit was increased from 40 minutes to two hours.",
+            "Multi-view character sheets are now treated as one subject instead of creating duplicate people from alternate views."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "MiniMax H3 scenes marked B-roll or no-lip-sync now suppress singer, lyric, speaker, and native-voice inputs, remove conflicting vocal actions from timestamp blocks, and receive a final visual-only safety contract again at render time.",
+            "Cyrillic and other Unicode letters are preserved during reference-lyric timestamp matching instead of being stripped by ASCII-only normalization.",
+            "Added a session-save safeguard that prevents an ordinary stale save from accidentally clearing many populated lyric lines at once."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "Existing and newly created projects continue to use LTX 2.3 unless MiniMax H3 is explicitly selected in Builder Settings.",
+            "MiniMax Input Audio remains the exact supplied soundtrack path; Built-in MiniMax Audio must be selected when generated voices, dialogue, ambience, or sound effects are required."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-03-minimax-h3-builder-testing",
       "version": "2026.08.03-minimax-h3-test",
       "date": "2026-08-03",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -158,8 +158,61 @@ const MINIMAX_H3_VIDEO_REFERENCE_PURPOSES = [
   { value: "transformation", label: "Transformation Source" },
   { value: "visual_style", label: "Visual Style Guide" },
 ];
+const MINIMAX_H3_AUDIO_MODE_OPTIONS = [
+  { value: "input_audio", label: "Input Audio (exact supplied audio)" },
+  { value: "built_in_audio", label: "Built-in MiniMax Audio" },
+];
+const MINIMAX_H3_VOICE_PRESETS = [
+  { value: "none", label: "No voice preset", gender: "", name: "", description: "" },
+  {
+    value: "female_velvet_ember",
+    label: "Woman — Velvet Ember (American)",
+    gender: "female",
+    name: "VELVET EMBER",
+    description: "an adult feminine low contralto with a warm smoky texture, a soft neutral American accent, measured confident cadence, crisp consonants, gentle breathiness, and clean intimate close-microphone delivery.",
+  },
+  {
+    value: "female_silver_thistle",
+    label: "Woman — Silver Thistle (British)",
+    gender: "female",
+    name: "SILVER THISTLE",
+    description: "an adult feminine clear mid-range voice with an unmistakable polished British Received Pronunciation accent, non-rhotic pronunciation, elongated broad-A vowels in words such as can’t, after, and glass, measured aristocratic English cadence, light airy resonance, precise consonants, elegant warmth, and clean intimate close-microphone delivery.",
+  },
+  {
+    value: "female_sunlit_wattle",
+    label: "Woman — Sunlit Wattle (Australian)",
+    gender: "female",
+    name: "SUNLIT WATTLE",
+    description: "an adult feminine bright mezzo voice with an unmistakable contemporary General Australian English accent, non-rhotic pronunciation, broad open vowels, relaxed upward inflection, confident friendly cadence, crisp natural consonants, lively sunlit warmth, and clean intimate close-microphone delivery.",
+  },
+  { value: "female_custom", label: "Woman — Custom Voice", gender: "female", name: "", description: "" },
+  {
+    value: "male_iron_cedar",
+    label: "Man — Iron Cedar (American)",
+    gender: "male",
+    name: "IRON CEDAR",
+    description: "an adult masculine deep baritone voice with a clear neutral American accent, grounded resonant timbre, measured confident cadence, crisp consonants, subtle gravel, calm authority, natural warmth, and clean intimate close-microphone delivery.",
+  },
+  {
+    value: "male_crowned_ash",
+    label: "Man — Crowned Ash (British)",
+    gender: "male",
+    name: "CROWNED ASH",
+    description: "an adult masculine polished baritone voice with an unmistakable British Received Pronunciation accent, non-rhotic pronunciation, elongated broad-A vowels in words such as can’t, after, and glass, measured articulate cadence, precise consonants, restrained dry warmth, quiet authority, and clean intimate close-microphone delivery.",
+  },
+  {
+    value: "male_red_gum",
+    label: "Man — Red Gum (Australian)",
+    gender: "male",
+    name: "RED GUM",
+    description: "an adult masculine warm tenor-baritone voice with an unmistakable contemporary General Australian English accent, non-rhotic pronunciation, broad open vowels, relaxed upward inflection, easygoing confident cadence, clear natural consonants, bright resonant warmth, and clean intimate close-microphone delivery.",
+  },
+  { value: "male_custom", label: "Man — Custom Voice", gender: "male", name: "", description: "" },
+];
 const DEFAULT_MINIMAX_H3_SETTINGS = {
   video_mode: "text_to_video",
+  audio_mode: "input_audio",
+  continuity_mode: "off",
   diffusion_model_name: "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
   clip_name: "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
   video_vae_name: "minimax_h3_video_vae_fp16.safetensors",
@@ -182,6 +235,12 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   enable_fp16_accumulation: true,
 };
 
+const MINIMAX_H3_CONTINUITY_OPTIONS = [
+  { value: "off", label: "Off" },
+  { value: "spatial_reference", label: "Previous final frame — spatial reference" },
+  { value: "exact_start_frame", label: "Previous final frame — exact start frame" },
+];
+
 const MINIMAX_H3_SAGE_ATTENTION_OPTIONS = [
   { value: "disabled", label: "Disabled" },
   { value: "auto", label: "Auto" },
@@ -198,6 +257,44 @@ function normalizeMiniMaxH3Mode(value) {
   return MINIMAX_H3_MODE_OPTIONS.some((item) => item.value === clean) ? clean : "text_to_video";
 }
 
+function normalizeMiniMaxH3AudioMode(value) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return ["built_in_audio", "native_audio", "generated_audio"].includes(clean) ? "built_in_audio" : "input_audio";
+}
+
+function normalizeMiniMaxH3ContinuityMode(value) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (["spatial", "spatial_reference", "continuity_reference"].includes(clean)) return "spatial_reference";
+  if (["exact", "exact_start", "exact_start_frame", "continuous_start"].includes(clean)) return "exact_start_frame";
+  return "off";
+}
+
+function normalizeMiniMaxH3Voice(value = {}) {
+  const source = value && typeof value === "object" ? value : {};
+  const rawPreset = String(source.preset_id || source.presetId || source.preset || "none").trim().toLowerCase();
+  const preset = MINIMAX_H3_VOICE_PRESETS.find((item) => item.value === rawPreset) || MINIMAX_H3_VOICE_PRESETS[0];
+  const custom = preset.value.endsWith("_custom");
+  return {
+    preset_id: preset.value,
+    gender: preset.gender,
+    preset_name: custom ? String(source.preset_name || source.presetName || source.name || "").trim() : preset.name,
+    description: custom ? String(source.description || source.voice_description || source.voiceDescription || "").trim() : preset.description,
+  };
+}
+
+function normalizeMiniMaxSpeakerAssignments(value = []) {
+  const source = Array.isArray(value) ? value : [];
+  return source
+    .filter((item) => item && typeof item === "object")
+    .map((item, index) => ({
+      id: String(item.id || item.cue_id || item.cueId || `speaker_cue_${Date.now()}_${index}_${Math.floor(Math.random() * 10000)}`),
+      speaker_id: String(item.speaker_id || item.speakerId || item.subject_id || item.subjectId || ""),
+      speaker_name: String(item.speaker_name || item.speakerName || item.speaker || item.character || "").trim(),
+      text: String(item.text || item.dialogue || item.line || item.lyric || "").trim(),
+    }))
+    .slice(0, 40);
+}
+
 function miniMaxH3ModeLabel(value) {
   const mode = normalizeMiniMaxH3Mode(value);
   return MINIMAX_H3_MODE_OPTIONS.find((item) => item.value === mode)?.label || "Text to Video";
@@ -205,6 +302,17 @@ function miniMaxH3ModeLabel(value) {
 
 function miniMaxH3InstructionKey(value) {
   return MINIMAX_H3_INSTRUCTION_KEYS[normalizeMiniMaxH3Mode(value)] || MINIMAX_H3_INSTRUCTION_KEYS.text_to_video;
+}
+
+function normalizeMiniMaxShortFilmPlanningMode(value = "") {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return clean === "fully_custom" || clean === "custom" ? "fully_custom" : "guided_film";
+}
+
+function miniMaxH3ShortFilmInstructionKey(value, planningMode = "guided_film") {
+  const mode = normalizeMiniMaxH3Mode(value);
+  const profile = normalizeMiniMaxShortFilmPlanningMode(planningMode) === "fully_custom" ? "custom" : "guided";
+  return `minimax_h3_short_film_${profile}_${mode}`;
 }
 
 function normalizeMiniMaxH3VideoPurpose(value) {
@@ -218,6 +326,8 @@ function cloneMiniMaxH3Settings(value = {}) {
     ...DEFAULT_MINIMAX_H3_SETTINGS,
     ...source,
     video_mode: normalizeMiniMaxH3Mode(source.video_mode || source.mode || DEFAULT_MINIMAX_H3_SETTINGS.video_mode),
+    audio_mode: normalizeMiniMaxH3AudioMode(source.audio_mode || source.audioMode || DEFAULT_MINIMAX_H3_SETTINGS.audio_mode),
+    continuity_mode: normalizeMiniMaxH3ContinuityMode(source.continuity_mode || source.continuityMode || DEFAULT_MINIMAX_H3_SETTINGS.continuity_mode),
     diffusion_model_name: String(source.diffusion_model_name || DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name),
     clip_name: String(source.clip_name || DEFAULT_MINIMAX_H3_SETTINGS.clip_name),
     video_vae_name: String(source.video_vae_name || DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name),
@@ -846,8 +956,13 @@ function createProgressWindow(title, options = {}) {
   headerActions.append(minimize, close);
   header.append(heading, headerActions);
   const body = document.createElement("div");
-  body.style.cssText = "padding:12px;font-size:12px;line-height:1.45;white-space:pre-wrap;max-height:min(62vh,620px);overflow:auto;";
-  body.textContent = "Starting...";
+  body.style.cssText = "padding:12px;font-size:12px;line-height:1.45;max-height:min(72vh,760px);overflow:auto;";
+  const status = document.createElement("div");
+  status.style.cssText = "white-space:pre-wrap;";
+  status.textContent = "Starting...";
+  const sceneDetails = document.createElement("div");
+  sceneDetails.style.cssText = "display:none;margin-top:12px;padding-top:12px;border-top:1px solid #164e63;";
+  body.append(status, sceneDetails);
   const barOuter = document.createElement("div");
   barOuter.style.cssText = "height:8px;background:#164e63;border-radius:999px;margin:0 12px 12px;overflow:hidden;";
   const barInner = document.createElement("div");
@@ -876,15 +991,90 @@ function createProgressWindow(title, options = {}) {
   close.onclick = removeAll;
   return {
     set(message, percent = null) {
-      body.textContent = message;
+      status.textContent = message;
       if (percent !== null) barInner.style.width = `${Math.max(5, Math.min(100, percent))}%`;
       const firstLine = String(message || title).split(/\r?\n/)[0] || title;
       restore.textContent = `${title}: ${firstLine}`;
     },
     setHtml(html, percent = null) {
-      body.innerHTML = html;
+      status.innerHTML = html;
       if (percent !== null) barInner.style.width = `${Math.max(5, Math.min(100, percent))}%`;
       restore.textContent = title;
+    },
+    setSceneDetails(details = {}) {
+      const images = Array.isArray(details.images) ? details.images : [];
+      const prompt = String(details.prompt || "").trim();
+      const lyric = String(details.lyric || "").trim();
+      const sceneLabel = String(details.sceneLabel || "Current scene").trim();
+      const modeLabel = String(details.modeLabel || "").trim();
+      sceneDetails.replaceChildren();
+      sceneDetails.style.display = "block";
+      box.style.width = "min(1100px, calc(100vw - 48px))";
+
+      const summary = document.createElement("div");
+      summary.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px;";
+      const sceneName = document.createElement("div");
+      sceneName.textContent = sceneLabel;
+      sceneName.style.cssText = "font-size:13px;font-weight:900;color:#e0f2fe;";
+      const mode = document.createElement("div");
+      mode.textContent = modeLabel;
+      mode.style.cssText = "font-size:11px;color:#67e8f9;text-align:right;";
+      summary.append(sceneName, mode);
+      sceneDetails.append(summary);
+
+      const sectionTitle = (text) => {
+        const label = document.createElement("div");
+        label.textContent = text;
+        label.style.cssText = "margin:10px 0 6px;font-size:10px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;color:#94a3b8;";
+        return label;
+      };
+
+      sceneDetails.append(sectionTitle(`Reference images (${images.length})`));
+      if (images.length) {
+        const strip = document.createElement("div");
+        strip.style.cssText = "display:flex;gap:8px;overflow-x:auto;padding:2px 0 8px;";
+        images.forEach((item, index) => {
+          const card = document.createElement("div");
+          card.style.cssText = "flex:0 0 118px;border:1px solid #334155;border-radius:7px;background:#020617;overflow:hidden;";
+          const image = document.createElement("img");
+          const imagePath = String(item?.path || "").trim();
+          const imageData = String(item?.data || "").trim();
+          image.src = imagePath ? makeEditorImageUrl(imagePath) : imageData;
+          image.alt = String(item?.label || `Image ${index + 1}`);
+          image.title = [item?.label, imagePath].filter(Boolean).join("\n");
+          image.style.cssText = "display:block;width:118px;height:86px;object-fit:cover;background:#0f172a;";
+          const caption = document.createElement("div");
+          caption.textContent = `Image ${index + 1}: ${String(item?.label || "Reference")}`;
+          caption.title = image.title;
+          caption.style.cssText = "padding:6px;font-size:10px;color:#cbd5e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
+          card.append(image, caption);
+          strip.append(card);
+        });
+        sceneDetails.append(strip);
+      } else {
+        const empty = document.createElement("div");
+        empty.textContent = "No image references are being sent for this scene.";
+        empty.style.cssText = "padding:8px;border:1px dashed #334155;border-radius:6px;color:#94a3b8;background:#020617;";
+        sceneDetails.append(empty);
+      }
+
+      sceneDetails.append(sectionTitle("Lyric / dialogue sent"));
+      const lyricBox = document.createElement("div");
+      lyricBox.textContent = lyric || "No lyric or dialogue line is assigned to this scene.";
+      lyricBox.style.cssText = "padding:9px 10px;border:1px solid #334155;border-radius:6px;background:#020617;color:#f8fafc;white-space:pre-wrap;";
+      sceneDetails.append(lyricBox);
+
+      const promptDetails = document.createElement("details");
+      promptDetails.open = true;
+      promptDetails.style.cssText = "margin-top:10px;border:1px solid #334155;border-radius:6px;background:#020617;overflow:hidden;";
+      const promptSummary = document.createElement("summary");
+      promptSummary.textContent = "Exact prompt sent to MiniMax H3";
+      promptSummary.style.cssText = "padding:9px 10px;cursor:pointer;font-weight:900;color:#67e8f9;background:#0b1220;";
+      const promptText = document.createElement("pre");
+      promptText.textContent = prompt || "No prompt is available.";
+      promptText.style.cssText = "margin:0;padding:10px;max-height:260px;overflow:auto;white-space:pre-wrap;overflow-wrap:anywhere;color:#e2e8f0;font:11px/1.45 monospace;";
+      promptDetails.append(promptSummary, promptText);
+      sceneDetails.append(promptDetails);
     },
     close(delay = 0) {
       setTimeout(removeAll, delay);
@@ -1358,6 +1548,8 @@ function showWelcomeProjectModal(projects = [], projectsLoader = null) {
         const del = makeButton("Delete");
         del.style.borderColor = "#7f1d1d";
         del.style.color = "#fecaca";
+        del.disabled = project.can_delete === false;
+        if (del.disabled) del.title = "For safety, projects outside the ComfyUI output folder must be deleted manually.";
         open.onclick = () => finish({ action: "load", project_folder: project.project_folder || "" });
         del.onclick = async (event) => {
           event.preventDefault();
@@ -1477,6 +1669,8 @@ function showLoadProjectModal(projects = []) {
         const del = makeButton("Delete");
         del.style.borderColor = "#7f1d1d";
         del.style.color = "#fecaca";
+        del.disabled = project.can_delete === false;
+        if (del.disabled) del.title = "For safety, projects outside the ComfyUI output folder must be deleted manually.";
         open.onclick = () => finish({ action: "load", project_folder: project.project_folder || "" });
         del.onclick = async (event) => {
           event.preventDefault();
@@ -1719,7 +1913,7 @@ function sceneVideoTimeoutMessage({
   finalFolder = "",
 } = {}) {
   const lines = [
-    `${sceneLabel}: ${modeLabel} did not finish before the 40-minute wait limit.`,
+    `${sceneLabel}: ${modeLabel} did not finish before the 2-hour wait limit.`,
     "",
     "What this means:",
     "- ComfyUI may still be rendering, or the workflow may have stopped without returning a video to the builder.",
@@ -1740,7 +1934,7 @@ function sceneVideoTimeoutMessage({
 async function waitForVideos(promptId, onStatus, shouldCancel, findOutputFallback = null, options = {}) {
   const started = Date.now();
   let lastFallbackCheck = 0;
-  while (Date.now() - started < 40 * 60 * 1000) {
+  while (Date.now() - started < 2 * 60 * 60 * 1000) {
     if (shouldCancel?.()) throw new Error("Stopped by user.");
     const response = await api.fetchApi(`/history/${encodeURIComponent(promptId)}`);
     const data = await response.json().catch(() => ({}));
@@ -1955,6 +2149,7 @@ function audioUrl(path) {
     flf_end_frame_stale: false,
     flf_final_prompt_ready: false,
     lyric_singers: [],
+    minimax_speaker_assignments: [],
     facial_performance: "",
     facial_performance_custom: "",
     no_character_present: false,
@@ -3589,6 +3784,9 @@ function openBuilder(node) {
   const i2vTextGemmaModelSelect = makeSelect([""], "");
   const i2vGemmaModelSelect = makeSelect([""], "");
   const i2vMmprojSelect = makeSelect([""], "");
+  const miniMaxTextGemmaModelSelect = makeSelect([""], "");
+  const miniMaxGemmaModelSelect = makeSelect([""], "");
+  const miniMaxMmprojSelect = makeSelect([""], "");
   function copySelectOptions(sourceSelect, targetSelect) {
     targetSelect.textContent = "";
     for (const option of sourceSelect.options) {
@@ -3611,6 +3809,22 @@ function openBuilder(node) {
   }
   for (const select of [t2iTextGemmaModelSelect, gemmaModelSelect, mmprojSelect]) {
     select.addEventListener("change", syncKrea2TwoPassLlmSelectsFromShared);
+  }
+  const syncMiniMaxLlmSelectsFromShared = () => {
+    miniMaxTextGemmaModelSelect.value = i2vTextGemmaModelSelect.value || "";
+    miniMaxGemmaModelSelect.value = i2vGemmaModelSelect.value || "";
+    miniMaxMmprojSelect.value = i2vMmprojSelect.value || "";
+  };
+  const syncMiniMaxLlmSelectsToShared = () => {
+    i2vTextGemmaModelSelect.value = miniMaxTextGemmaModelSelect.value || "";
+    i2vGemmaModelSelect.value = miniMaxGemmaModelSelect.value || "";
+    i2vMmprojSelect.value = miniMaxMmprojSelect.value || "";
+  };
+  for (const select of [miniMaxTextGemmaModelSelect, miniMaxGemmaModelSelect, miniMaxMmprojSelect]) {
+    select.addEventListener("change", syncMiniMaxLlmSelectsToShared);
+  }
+  for (const select of [i2vTextGemmaModelSelect, i2vGemmaModelSelect, i2vMmprojSelect]) {
+    select.addEventListener("change", syncMiniMaxLlmSelectsFromShared);
   }
   const useVisionReference = makeCheckbox("Use vision reference image?", false);
   const useI2VVisionReference = makeCheckbox("Use image reference for I2V prompt?", true);
@@ -4713,6 +4927,10 @@ function openBuilder(node) {
   const miniMaxClipPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.clip_name);
   const miniMaxVideoVaePicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name);
   const miniMaxAudioVaePicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name);
+  const miniMaxAudioMode = makeSelect(MINIMAX_H3_AUDIO_MODE_OPTIONS, DEFAULT_MINIMAX_H3_SETTINGS.audio_mode);
+  const miniMaxContinuityMode = makeSelect(MINIMAX_H3_CONTINUITY_OPTIONS, DEFAULT_MINIMAX_H3_SETTINGS.continuity_mode);
+  const miniMaxContinuityNote = document.createElement("div");
+  miniMaxContinuityNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
   const miniMaxNoGgufNote = document.createElement("div");
   miniMaxNoGgufNote.textContent = "MiniMax H3 currently uses the standard diffusion-model loader. GGUF is not enabled yet.";
   miniMaxNoGgufNote.style.cssText = "font-size:11px;color:#fcd34d;line-height:1.4;";
@@ -4882,8 +5100,14 @@ function openBuilder(node) {
   miniMaxPromptActions.append(miniMaxCreatePromptButton, miniMaxEditInstructionsButton);
   const miniMaxPromptRunnerNote = document.createElement("div");
   miniMaxPromptRunnerNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const miniMaxSpeakerAssignmentPanel = makeSettingsPanel([]);
+  const miniMaxSpeakerAssignmentNote = document.createElement("div");
+  miniMaxSpeakerAssignmentNote.style.cssText = "font-size:11px;color:#cbd5e1;line-height:1.45;border:1px solid #155e75;border-radius:7px;background:#07111f;padding:9px;";
+  const miniMaxSpeakerAssignmentList = document.createElement("div");
+  miniMaxSpeakerAssignmentList.style.cssText = "display:flex;flex-direction:column;gap:8px;";
+  const miniMaxAddSpeakerCueButton = makeButton("Add Dialogue Cue", "primary");
+  miniMaxSpeakerAssignmentPanel.append(miniMaxSpeakerAssignmentNote, miniMaxSpeakerAssignmentList, miniMaxAddSpeakerCueButton);
   const miniMaxAudioNote = document.createElement("div");
-  miniMaxAudioNote.textContent = "The current hidden workflow requires custom scene audio or project audio. Built-in MiniMax audio will be added with a separate workflow later.";
   miniMaxAudioNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
   const useSceneMiniMaxH3Settings = makeCheckbox("Lock MiniMax mode, models, and video settings for this scene", false);
   const useSceneMiniMaxH3SettingsNote = document.createElement("div");
@@ -4901,6 +5125,13 @@ function openBuilder(node) {
         makeField("Text encoder / CLIP", miniMaxClipPicker.wrapper),
         makeField("Video VAE", miniMaxVideoVaePicker.wrapper),
         makeField("Audio VAE", miniMaxAudioVaePicker.wrapper),
+        makeSettingsSection("Non-Vision LLM Models", [
+          makeField("Non-Vision text Gemma model", miniMaxTextGemmaModelSelect),
+        ]),
+        makeSettingsSection("Vision LLM Models", [
+          makeField("Vision Gemma model", miniMaxGemmaModelSelect),
+          makeField("Vision mmproj", miniMaxMmprojSelect),
+        ]),
       ]),
     },
     {
@@ -4910,14 +5141,26 @@ function openBuilder(node) {
         useSceneMiniMaxH3Settings.wrapper,
         useSceneMiniMaxH3SettingsNote,
         miniMaxSettingsScopeNote,
+        makeSettingsSection("Audio", [
+          makeField("Audio mode", miniMaxAudioMode),
+          miniMaxAudioNote,
+        ]),
+        makeSettingsSection("Between-scene continuity", [
+          makeField("Previous rendered final frame", miniMaxContinuityMode),
+          miniMaxContinuityNote,
+        ]),
         ...Object.values(miniMaxModePanels),
         makeSettingsSection("Render Settings", [miniMaxRenderSettingsGrid]),
         miniMaxAdvancedSettings,
-        miniMaxAudioNote,
       ]),
     },
     {
-      label: "Prompt",
+      label: "Speaker Assignment",
+      value: "speakers",
+      content: miniMaxSpeakerAssignmentPanel,
+    },
+    {
+      label: "LLM Prompting",
       value: "prompt",
       content: makeSettingsPanel([
         miniMaxPromptRunnerNote,
@@ -5073,7 +5316,7 @@ function openBuilder(node) {
   closeTimelineGapsButton.title = "Shift later base scenes left to remove empty gaps in the timeline.";
   snapSceneEdgeButton.title = "Move the selected scene start or end to its closest beat marker. A connected neighboring scene follows only at that shared boundary. Shortcuts: Ctrl+S snaps the start; Ctrl+E snaps the end.";
   splitSceneButton.title = "Split the selected base scene at the playhead. The left and right scene timings stay exactly where they are; later clips do not move and are only renumbered. Vocal text stays on the left half, while instrumental text is kept on both halves. Scenes with rendered video must be cleared before splitting.";
-  idLoraTrimModeButton.title = "ID-LoRA only: quiet scrub mode for finding trim points without autoplay.";
+  idLoraTrimModeButton.title = "Quiet scrub mode for finding left/right video trim points without autoplay. Available for ID-LoRA and MiniMax built-in-audio scenes.";
   overlayTrackToggleButton.title = "Turn the advanced overlay timeline on or off.";
   overlayTrackHintButton.title = "How does the overlay timeline work?";
   addTimelineMarkerButton.title = "Add a free timeline note/song marker at the playhead or selected In/Out range.";
@@ -5563,6 +5806,7 @@ function openBuilder(node) {
     const motionDefaults = source.motion_defaults && typeof source.motion_defaults === "object" ? source.motion_defaults : {};
     const cameraSpeed = Math.max(0, Math.min(10, Number(source.camera_motion_speed ?? source.cameraMotionSpeed ?? motionDefaults.camera_motion_speed ?? 4)));
     const characterSpeed = Math.max(0, Math.min(10, Number(source.character_motion_speed ?? source.characterMotionSpeed ?? motionDefaults.character_motion_speed ?? 4)));
+    const temporalIntensity = Math.max(0, Math.min(10, Number(source.temporal_background_intensity ?? source.temporalBackgroundIntensity ?? 8)));
     return {
       global_consistency_phrase: String(source.global_consistency_phrase || source.globalConsistencyPhrase || ""),
       camera_motion_speed: Number.isFinite(cameraSpeed) ? cameraSpeed : 4,
@@ -5570,9 +5814,21 @@ function openBuilder(node) {
       camera_guidance: String(source.camera_guidance || motionDefaults.camera_guidance || ""),
       character_guidance: String(source.character_guidance || motionDefaults.character_guidance || ""),
       performance_style: String(source.performance_style || source.performanceStyle || source.performance_style_default || ""),
+      short_film_planning_mode: normalizeMiniMaxShortFilmPlanningMode(source.short_film_planning_mode || source.shortFilmPlanningMode),
       camera_flow: String(source.camera_flow || source.cameraFlow || ""),
       image_shot_flow: String(source.image_shot_flow || source.imageShotFlow || ""),
       image_aesthetic: String(source.image_aesthetic || source.imageAesthetic || ""),
+      video_style: String(source.video_style || source.videoStyle || ""),
+      video_style_custom: String(source.video_style_custom || source.videoStyleCustom || ""),
+      temporal_world_effect: String(source.temporal_world_effect || source.temporalWorldEffect || ""),
+      temporal_world_effect_custom: String(source.temporal_world_effect_custom || source.temporalWorldEffectCustom || ""),
+      temporal_allow_background_extras: (source.temporal_allow_background_extras ?? source.temporalAllowBackgroundExtras) !== false,
+      temporal_background_intensity: Number.isFinite(temporalIntensity) ? temporalIntensity : 8,
+      temporal_environment_time_passage: (source.temporal_environment_time_passage ?? source.temporalEnvironmentTimePassage) !== false,
+      temporal_protected_characters: ["all_referenced", "lead_only", "custom"].includes(String(source.temporal_protected_characters || source.temporalProtectedCharacters || ""))
+        ? String(source.temporal_protected_characters || source.temporalProtectedCharacters)
+        : "all_referenced",
+      temporal_protected_custom: String(source.temporal_protected_custom || source.temporalProtectedCustom || ""),
     };
   }
 
@@ -5747,6 +6003,18 @@ function openBuilder(node) {
     return miniMaxH3SettingsForSegment(segment).video_mode;
   }
 
+  function miniMaxH3ContinuityModeForSegment(segment = activeSegment()) {
+    const mode = miniMaxH3ModeForSegment(segment);
+    if (!["reference_to_video", "video_to_video"].includes(mode)) return "off";
+    return normalizeMiniMaxH3ContinuityMode(miniMaxH3SettingsForSegment(segment).continuity_mode);
+  }
+
+  function miniMaxH3ContinuityReferenceReserved(segment = activeSegment()) {
+    return Boolean(segment
+      && miniMaxH3ContinuityModeForSegment(segment) !== "off"
+      && previousAutoChainSourceSegment(segment));
+  }
+
   function setMiniMaxH3ModeForSegment(segment, value) {
     const mode = normalizeMiniMaxH3Mode(value);
     if (segment?.use_scene_minimax_h3_settings) {
@@ -5789,12 +6057,13 @@ function openBuilder(node) {
       && effectiveMode === "reference_to_video"
       && (segmentImageSource(segment)?.path || segmentImageSource(segment)?.data)
     );
+    const hasContinuityReservation = miniMaxH3ContinuityReferenceReserved(segment);
     for (const button of miniMaxReferenceButtons) {
       button.textContent = button === miniMaxVideoReferencesButton
-        ? `Choose MiniMax Edit References (${orderedCount}/9)`
+        ? `Choose MiniMax Edit References (${orderedCount}${hasContinuityReservation ? " + continuity" : ""}/9)`
         : hasStartFrame
-          ? `Choose MiniMax References (${orderedCount}/9 — start + ${Math.max(0, orderedCount - 1)})`
-          : `Choose MiniMax References (${libraryCount}/9)`;
+          ? `Choose MiniMax References (${orderedCount}${hasContinuityReservation ? " + continuity" : ""}/9 — start + ${Math.max(0, orderedCount - 1)})`
+          : `Choose MiniMax References (${libraryCount}${hasContinuityReservation ? " + continuity" : ""}/9)`;
       button.disabled = !segment;
     }
   }
@@ -5804,6 +6073,8 @@ function openBuilder(node) {
     const currentSettings = miniMaxH3SettingsForSegment(segment);
     const settings = cloneMiniMaxH3Settings({
       video_mode: currentSettings.video_mode,
+      audio_mode: miniMaxAudioMode.value,
+      continuity_mode: miniMaxContinuityMode.value,
       diffusion_model_name: miniMaxDiffusionModelPicker.input.value,
       clip_name: miniMaxClipPicker.input.value,
       video_vae_name: miniMaxVideoVaePicker.input.value,
@@ -5852,6 +6123,143 @@ function openBuilder(node) {
       .slice(0, 3);
   }
 
+  function miniMaxMappedSpeakersForSegment(segment) {
+    if (!segment || segment.no_character_present) return [];
+    return (storyboardReferenceDataForSegment(segment).subject_refs || [])
+      .filter((subject) => (subject.reference_type || "character") === "character")
+      .map((subject) => ({ id: String(subject.id || ""), name: String(subject.name || "Character").trim() || "Character" }));
+  }
+
+  function syncMiniMaxSpeakerAssignmentLegacyFields(segment) {
+    if (!segment) return;
+    segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(segment.minimax_speaker_assignments);
+    const filled = segment.minimax_speaker_assignments.filter((cue) => cue.text);
+    // An empty Storyboard speaker plan means no dialogue override was supplied.
+    // It must not erase lyrics/transcription already stored on the timeline.
+    if (filled.length) {
+      segment.lyric_text = filled.map((cue) => cue.text).join("\n");
+      segment.lyric_singers = Array.from(new Set(filled.map((cue) => cue.speaker_name).filter(Boolean)));
+    }
+  }
+
+  function ensureMiniMaxSpeakerAssignments(segment, speakers = miniMaxMappedSpeakersForSegment(segment)) {
+    if (!segment) return [];
+    let cues = normalizeMiniMaxSpeakerAssignments(segment.minimax_speaker_assignments || segment.speaker_assignments || []);
+    if (!cues.length) {
+      const existingLine = isInstrumentalLyricText(segment.lyric_text) ? "" : String(segment.lyric_text || "").trim();
+      if (existingLine) {
+        const preferredName = String((Array.isArray(segment.lyric_singers) ? segment.lyric_singers[0] : "") || "").trim();
+        const speaker = speakers.find((item) => item.name.toLowerCase() === preferredName.toLowerCase()) || speakers[0] || { id: "", name: preferredName };
+        cues = normalizeMiniMaxSpeakerAssignments([{ speaker_id: speaker.id, speaker_name: speaker.name, text: existingLine }]);
+      } else if (speakers.length) {
+        cues = normalizeMiniMaxSpeakerAssignments(speakers.map((speaker) => ({ speaker_id: speaker.id, speaker_name: speaker.name, text: "" })));
+      }
+      segment.minimax_speaker_assignments = cues;
+    }
+    return cues;
+  }
+
+  function renderMiniMaxSpeakerAssignmentPanel() {
+    const segment = activeSegment();
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const shortFilm = normalizeVideoType(segment?.performance_mode || state.videoType) === "speaking";
+    const enabled = Boolean(miniMaxProject && segment && shortFilm && settings.audio_mode === "built_in_audio" && !segment.no_character_present);
+    const speakers = enabled ? miniMaxMappedSpeakersForSegment(segment) : [];
+    miniMaxSpeakerAssignmentList.replaceChildren();
+    miniMaxAddSpeakerCueButton.disabled = !enabled || !speakers.length;
+    if (!miniMaxProject || !segment) {
+      miniMaxSpeakerAssignmentNote.textContent = "Choose an active MiniMax scene to assign speakers.";
+      return;
+    }
+    if (!shortFilm) {
+      miniMaxSpeakerAssignmentNote.textContent = "Speaker Assignment is available for Short Film projects. Music Video continues to use the scene lyric/vocal line.";
+      return;
+    }
+    if (settings.audio_mode !== "built_in_audio") {
+      miniMaxSpeakerAssignmentNote.textContent = "Speaker Assignment is disabled for Input Audio because changing the words would no longer match the supplied audio. Select Built-in MiniMax Audio in Video Settings to create dialogue here.";
+      return;
+    }
+    if (segment.no_character_present) {
+      miniMaxSpeakerAssignmentNote.textContent = "This scene is marked No character present, so it cannot contain assigned dialogue.";
+      return;
+    }
+    miniMaxSpeakerAssignmentNote.textContent = "Drag cues into the exact speaking order. A character may appear more than once. Only characters mapped to this scene in Reference Builder are available, and MiniMax must speak each line exactly as entered.";
+    if (!speakers.length) {
+      const empty = document.createElement("div");
+      empty.textContent = "No characters are mapped to this scene yet. Map them in Reference Builder first.";
+      empty.style.cssText = "border:1px dashed #334155;border-radius:7px;padding:12px;color:#94a3b8;text-align:center;font-size:12px;";
+      miniMaxSpeakerAssignmentList.append(empty);
+      return;
+    }
+    const cues = ensureMiniMaxSpeakerAssignments(segment, speakers);
+    let draggedIndex = -1;
+    cues.forEach((cue, index) => {
+      const row = document.createElement("div");
+      row.style.cssText = "display:grid;grid-template-columns:32px 34px minmax(150px,.7fr) minmax(240px,1.5fr) 74px;gap:8px;align-items:center;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:8px;";
+      row.addEventListener("dragover", (event) => {
+        if (draggedIndex < 0 || draggedIndex === index) return;
+        event.preventDefault();
+        row.style.borderColor = "#22d3ee";
+      });
+      row.addEventListener("dragleave", () => { row.style.borderColor = "#334155"; });
+      row.addEventListener("drop", (event) => {
+        event.preventDefault();
+        row.style.borderColor = "#334155";
+        if (draggedIndex < 0 || draggedIndex === index) return;
+        const [moved] = cues.splice(draggedIndex, 1);
+        cues.splice(index, 0, moved);
+        segment.minimax_speaker_assignments = cues;
+        syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+        renderMiniMaxSpeakerAssignmentPanel();
+        autoSaveSessionQuiet("MiniMax speaker cue reordered").catch(() => null);
+      });
+      const handle = document.createElement("button");
+      handle.type = "button";
+      handle.textContent = "::";
+      handle.title = "Drag to change speaking order";
+      handle.draggable = true;
+      handle.style.cssText = "height:38px;border:1px solid #334155;border-radius:6px;background:#07111f;color:#67e8f9;font-weight:900;cursor:grab;";
+      handle.addEventListener("dragstart", () => { draggedIndex = index; row.style.opacity = ".55"; });
+      handle.addEventListener("dragend", () => { draggedIndex = -1; row.style.opacity = ""; });
+      const number = document.createElement("div");
+      number.textContent = String(index + 1);
+      number.style.cssText = "font-size:14px;font-weight:900;color:#cffafe;text-align:center;";
+      const speakerSelect = makeSelect(speakers.map((speaker) => ({ value: speaker.id, label: speaker.name })), cue.speaker_id);
+      if (!speakers.some((speaker) => speaker.id === cue.speaker_id) && cue.speaker_name) {
+        speakerSelect.prepend(new Option(`${cue.speaker_name} (not currently mapped)`, cue.speaker_id));
+        speakerSelect.value = cue.speaker_id;
+      }
+      const line = makeInput(cue.text || "");
+      line.placeholder = "Exact words this character says...";
+      const remove = makeButton("Remove");
+      speakerSelect.addEventListener("change", () => {
+        const speaker = speakers.find((item) => item.id === speakerSelect.value) || { id: speakerSelect.value, name: speakerSelect.selectedOptions[0]?.textContent || "" };
+        cue.speaker_id = speaker.id;
+        cue.speaker_name = speaker.name;
+        segment.minimax_speaker_assignments = cues;
+        syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+        autoSaveSessionQuiet("MiniMax speaker assignment changed").catch(() => null);
+      });
+      line.addEventListener("input", () => {
+        cue.text = line.value;
+        segment.minimax_speaker_assignments = cues;
+        syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+      });
+      line.addEventListener("change", () => autoSaveSessionQuiet("MiniMax dialogue cue changed").catch(() => null));
+      remove.onclick = () => {
+        pushHistory();
+        cues.splice(index, 1);
+        segment.minimax_speaker_assignments = cues;
+        syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+        renderMiniMaxSpeakerAssignmentPanel();
+        autoSaveSessionQuiet("MiniMax dialogue cue removed").catch(() => null);
+      };
+      row.append(handle, number, speakerSelect, line, remove);
+      miniMaxSpeakerAssignmentList.append(row);
+    });
+  }
+
   function syncMiniMaxH3Panel() {
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const segment = activeSegment();
@@ -5861,6 +6269,8 @@ function openBuilder(node) {
     miniMaxClipPicker.input.value = settings.clip_name;
     miniMaxVideoVaePicker.input.value = settings.video_vae_name;
     miniMaxAudioVaePicker.input.value = settings.audio_vae_name;
+    miniMaxAudioMode.value = settings.audio_mode;
+    miniMaxContinuityMode.value = settings.continuity_mode;
     miniMaxAspectRatio.value = settings.aspect_ratio;
     miniMaxMegapixels.value = String(settings.megapixels);
     miniMaxSeed.value = String(settings.seed);
@@ -5897,7 +6307,23 @@ function openBuilder(node) {
     miniMaxCreatePromptButton.textContent = `Create MiniMax ${modeLabel} Prompt`;
     miniMaxEditInstructionsButton.textContent = `Edit ${modeLabel} Instructions`;
     miniMaxPromptRunnerNote.textContent = `Uses the existing ${gemmaRunnerLabel()} selection from LLM Runner. The result is saved only as this scene's MiniMax H3 prompt.`;
+    miniMaxAudioNote.textContent = settings.audio_mode === "built_in_audio"
+      ? "MiniMax generates the scene audio from the prompt. In Short Film mode, character voice presets are configured in Reference Builder and copied exactly into every matching scene prompt."
+      : "Uses custom scene audio or project audio unchanged for exact timing and lip sync. Native voice presets are hidden while Input Audio is selected.";
+    const continuitySupported = ["reference_to_video", "video_to_video"].includes(mode);
+    miniMaxContinuityMode.disabled = !continuitySupported;
+    miniMaxContinuityNote.textContent = !continuitySupported
+      ? "Available in Reference to Video and Video to Video. Those modes can receive the prior clip's extracted final frame as one additional reference image."
+      : settings.continuity_mode === "spatial_reference"
+        ? "Recommended for a new camera angle. Preserves character blocking, orientation, screen direction, props, and environment layout without forcing the same opening composition. The extracted frame and its prompt contract are injected when rendering; Scene 1 is unaffected."
+        : settings.continuity_mode === "exact_start_frame"
+          ? "Begins each later scene on the previous rendered clip's exact final frame. The extracted frame and its prompt contract are injected when rendering. Do not also enable the scene-image exact start-frame option; Scene 1 is unaffected."
+          : "Off: every scene starts independently from its normal MiniMax references.";
     miniMaxUseSceneImageAsStartFrame.input.checked = Boolean(segment?.minimax_h3_use_scene_image_as_start_frame);
+    miniMaxUseSceneImageAsStartFrame.input.disabled = !segment || settings.continuity_mode === "exact_start_frame";
+    miniMaxStartFrameReferenceNote.textContent = settings.continuity_mode === "exact_start_frame"
+      ? "Disabled because the previous rendered final frame is the sole exact opening frame. Character and location references remain supporting references."
+      : "When enabled, Image 1 locks the exact opening composition. Character and location references begin at Image 2 and preserve identity or environment details that are not visible in the start frame.";
     const imagePath = String(segment ? selectedSegmentImagePath(segment) || "" : "").trim();
     miniMaxImageModeSource.textContent = imagePath
       ? `Scene image input:\n${imagePath}`
@@ -5913,6 +6339,8 @@ function openBuilder(node) {
     });
     miniMaxSceneVideoButton.disabled = !miniMaxProject || !segment;
     syncMiniMaxReferenceButtons();
+    renderMiniMaxSpeakerAssignmentPanel();
+    syncTimelineTrimModeButton();
   }
 
   function normalizeRenderLog(raw) {
@@ -7895,6 +8323,7 @@ function openBuilder(node) {
     videoTypeSelect.value = state.videoType;
   }
   const LAST_PROJECT_KEY = "vrgdg_music_builder_last_project_folder";
+  const PROJECT_ROOT_KEY = "vrgdg_music_builder_project_root";
 
   let notificationAudioContext = null;
   let lastNotificationAt = 0;
@@ -8095,6 +8524,32 @@ function openBuilder(node) {
     } catch {
       return "";
     }
+  }
+
+  function getPreferredProjectRoot() {
+    try {
+      return String(localStorage.getItem(PROJECT_ROOT_KEY) || "").trim();
+    } catch {
+      return "";
+    }
+  }
+
+  function setPreferredProjectRoot(projectRoot = "") {
+    const root = String(projectRoot || "").trim();
+    try {
+      if (root) localStorage.setItem(PROJECT_ROOT_KEY, root);
+      else localStorage.removeItem(PROJECT_ROOT_KEY);
+    } catch (error) {
+      console.warn("[VRGDG Music Builder] Could not save the preferred projects root:", error);
+    }
+    return root;
+  }
+
+  function projectListUrl() {
+    const root = getPreferredProjectRoot();
+    return root
+      ? `/vrgdg/music_builder/list_projects?project_root=${encodeURIComponent(root)}`
+      : "/vrgdg/music_builder/list_projects";
   }
 
   function allEditableSegments() {
@@ -8809,7 +9264,9 @@ function openBuilder(node) {
   }
 
   function syncTimelineTrimModeButton() {
-    const canUseTrimMode = currentVideoMode() === "id_lora";
+    const miniMaxBuiltInAudio = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"
+      && miniMaxH3SettingsForSegment(activeSegment()).audio_mode === "built_in_audio";
+    const canUseTrimMode = currentVideoMode() === "id_lora" || miniMaxBuiltInAudio;
     if (!canUseTrimMode && state.timelineTrimEditMode) state.timelineTrimEditMode = false;
     idLoraTrimModeButton.style.display = canUseTrimMode ? "" : "none";
     idLoraTrimModeButton.textContent = state.timelineTrimEditMode ? "Trim Mode On" : "Trim Mode";
@@ -8897,6 +9354,16 @@ function openBuilder(node) {
     segment.flf_end_frame_stale = Boolean(segment.flf_end_frame_stale);
     segment.flf_final_prompt_ready = Boolean(segment.flf_final_prompt_ready);
     if (!Array.isArray(segment.lyric_singers)) segment.lyric_singers = [];
+    segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(
+      segment.minimax_speaker_assignments || segment.speaker_assignments || segment.dialogue_cues || [],
+    );
+    if (segment.minimax_speaker_assignments.length) {
+      const filledSpeakerCues = segment.minimax_speaker_assignments.filter((cue) => cue.text);
+      if (filledSpeakerCues.length) {
+        segment.lyric_text = filledSpeakerCues.map((cue) => cue.text).join("\n");
+        segment.lyric_singers = Array.from(new Set(filledSpeakerCues.map((cue) => cue.speaker_name).filter(Boolean)));
+      }
+    }
     if (segment.facial_performance == null) segment.facial_performance = "";
     if (segment.facial_performance_custom == null) segment.facial_performance_custom = "";
     segment.lyric_no_lip_sync = Boolean(segment.lyric_no_lip_sync);
@@ -8905,6 +9372,10 @@ function openBuilder(node) {
     if (segment.i2v_notes == null) segment.i2v_notes = "";
     segment.i2v_prompt_origin = normalizeVideoPromptOrigin(segment.i2v_prompt_origin);
     segment.minimax_h3_mode = normalizeMiniMaxH3Mode(segment.minimax_h3_mode);
+    if (segment.minimax_h3_video_style == null) segment.minimax_h3_video_style = "";
+    if (segment.minimax_h3_video_style_custom == null) segment.minimax_h3_video_style_custom = "";
+    if (segment.temporal_world_effect_override == null) segment.temporal_world_effect_override = "global";
+    if (segment.temporal_world_effect_custom == null) segment.temporal_world_effect_custom = "";
     segment.use_scene_minimax_h3_settings = Boolean(segment.use_scene_minimax_h3_settings);
     if (segment.minimax_h3_settings != null && typeof segment.minimax_h3_settings !== "object") {
       segment.minimax_h3_settings = null;
@@ -8925,6 +9396,11 @@ function openBuilder(node) {
         : null;
     }
     segment.minimax_h3_use_scene_image_as_start_frame = Boolean(segment.minimax_h3_use_scene_image_as_start_frame);
+    segment.minimax_h3_continuity_frame_path = String(segment.minimax_h3_continuity_frame_path || "");
+    segment.minimax_h3_continuity_source_video_path = String(segment.minimax_h3_continuity_source_video_path || "");
+    segment.minimax_h3_continuity_source_scene_id = String(segment.minimax_h3_continuity_source_scene_id || "");
+    segment.minimax_h3_continuity_mode_used = normalizeMiniMaxH3ContinuityMode(segment.minimax_h3_continuity_mode_used);
+    segment.minimax_h3_continuity_image_number = Math.max(0, Math.trunc(Number(segment.minimax_h3_continuity_image_number || 0)));
     segment.minimax_h3_video_references = (Array.isArray(segment.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
       .slice(0, 3)
       .map((item) => ({
@@ -11100,7 +11576,7 @@ function openBuilder(node) {
       use_location_references: false,
       include_manual_ingredients: true,
       subject_count: 0,
-      subject: { description: "", reference_type: "character", image: { path: "", data: "", name: "" } },
+      subject: { description: "", reference_type: "character", minimax_voice: normalizeMiniMaxH3Voice(), image: { path: "", data: "", name: "" } },
       subjects: [],
       subject_scene_map: {},
       locations: [],
@@ -11587,6 +12063,7 @@ function openBuilder(node) {
           trigger_position: existing.trigger_position || item.trigger_position,
           extra_reference_for: existing.extra_reference_for || item.extra_reference_for || item.extraReferenceFor || item.same_subject_as || item.sameSubjectAs,
           extra_reference_note: existing.extra_reference_note || item.extra_reference_note || item.extraReferenceNote,
+          minimax_voice: existing.minimax_voice || item.minimax_voice || item.miniMaxVoice,
           image: {
             ...(item.image || {}),
             ...(existing.image || {}),
@@ -11627,6 +12104,7 @@ function openBuilder(node) {
     normalized.subject = {
       description: String(subject.description || ""),
       reference_type: normalizeReferenceType(subject.reference_type || subject.referenceType || subject.type || "character"),
+      minimax_voice: normalizeMiniMaxH3Voice(subject.minimax_voice || subject.miniMaxVoice),
       reference_generation_draft: normalizeReferenceGenerationDraft(subject.reference_generation_draft || subject.referenceGenerationDraft),
       image: normalizeRefImage(subject),
     };
@@ -11642,6 +12120,7 @@ function openBuilder(node) {
           trigger_position: String(item.trigger_position || item.triggerPosition || item.trigger_placement || "start") === "end" ? "end" : "start",
           extra_reference_for: String(item.extra_reference_for || item.extraReferenceFor || item.same_subject_as || item.sameSubjectAs || ""),
           extra_reference_note: String(item.extra_reference_note || item.extraReferenceNote || ""),
+          minimax_voice: normalizeMiniMaxH3Voice(item.minimax_voice || item.miniMaxVoice),
           reference_generation_draft: normalizeReferenceGenerationDraft(item.reference_generation_draft || item.referenceGenerationDraft),
           image: normalizeRefImage(item),
         };
@@ -11656,6 +12135,7 @@ function openBuilder(node) {
         trigger_position: String(subject.trigger_position || subject.triggerPosition || subject.trigger_placement || "start") === "end" ? "end" : "start",
         extra_reference_for: "",
         extra_reference_note: "",
+        minimax_voice: normalizeMiniMaxH3Voice(subject.minimax_voice || subject.miniMaxVoice),
         reference_generation_draft: normalizeReferenceGenerationDraft(subject.reference_generation_draft || subject.referenceGenerationDraft),
         image: { ...normalized.subject.image },
       });
@@ -11670,6 +12150,7 @@ function openBuilder(node) {
         trigger_position: "start",
         extra_reference_for: "",
         extra_reference_note: "",
+        minimax_voice: normalizeMiniMaxH3Voice(),
         reference_generation_draft: normalizeReferenceGenerationDraft(),
         image: { path: "", data: "", name: "" },
       });
@@ -11689,6 +12170,7 @@ function openBuilder(node) {
         name: "",
         description: "",
         reference_type: normalized.subject.reference_type || "character",
+        minimax_voice: normalized.subject.minimax_voice || normalizeMiniMaxH3Voice(),
         reference_generation_draft: normalized.subject.reference_generation_draft || normalizeReferenceGenerationDraft(),
         image: { path: "", data: "", name: "" },
       };
@@ -11698,6 +12180,7 @@ function openBuilder(node) {
       normalized.subject = {
         description: firstSubject.description || normalized.subject.description || "",
         reference_type: firstSubject.reference_type || normalized.subject.reference_type || "character",
+        minimax_voice: normalizeMiniMaxH3Voice(firstSubject.minimax_voice || normalized.subject.minimax_voice),
         reference_generation_draft: firstSubject.reference_generation_draft || normalized.subject.reference_generation_draft || normalizeReferenceGenerationDraft(),
         image: (firstSubject.image?.path || firstSubject.image?.data || firstSubject.image?.name)
           ? { ...(firstSubject.image || { path: "", data: "", name: "" }) }
@@ -12788,13 +13271,15 @@ function openBuilder(node) {
   function syncInspector() {
     const segment = activeSegment();
     startInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
+    lyricTextInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
+    lyricTextInput.dataset.vrgdgUserEdited = "0";
     const disabled = !segment;
     for (const control of [labelInput, startInput, endInput, notesInput, ernieNotesInput, krea2TwoPassNotesInput, nbNotes, lyricTextInput, lyricSingersInput, i2vNotesInput, t2iPrompt, ernieT2IPrompt, krea2TwoPassT2IPrompt, nbPrompt, i2vPrompt, zEnhanceGemmaNotes, zEnhancePromptPreview, previewButton, ernieCreateButton, previewNBButton, deleteSegmentButton, createSceneVideoButton, miniMaxSceneVideoButtons[0]]) {
       control.disabled = disabled;
     }
     loadCustomImageButton.disabled = disabled;
     openSceneAudioOptionsButton.disabled = disabled;
-    for (const control of [t2iTextGemmaModelSelect, gemmaModelSelect, mmprojSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, ernieMmprojSelect, zEnhanceGemmaModelSelect, zEnhanceMmprojSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, i2vMmprojSelect, nbApiKey, nbModelSelect, nbGemmaModelSelect, nbMmprojSelect, fluxUseTextOnlyGemmaPrompt.input, fluxUseDirectorNotes.input, nbUseTextOnlyGemmaPrompt.input, nbUseDirectorNotes.input, useVisionReference.input, ernieUseVisionReference.input, krea2TwoPassUseVisionReference.input, useI2VVisionReference.input, useT2VVisionReference.input, useSceneZImageSettings.input, useSceneErnieImageSettings.input, useSceneFluxKleinSettings.input, useSceneNBImageSettings.input, useSceneI2VVideoSettings.input, useSceneMiniMaxH3Settings.input, rtvReferenceBehaviorSelect, createSceneEndFrameButton, clearSceneEndFrameButton, i2vUseGgufModel.input, refImageInput, createT2IButton, editZImageT2IInstructionsButton, ernieCreateT2IButton, editErnieT2IInstructionsButton, krea2TwoPassCreateT2IButton, editKrea2T2IInstructionsButton, createNBPromptButton, editNanoBT2IInstructionsButton, flowGptCreatePromptButton, editFlowGptT2IInstructionsButton, createFluxPromptButton, editFluxKleinT2IInstructionsButton, createI2VButton, editI2VPromptButton, editIdLoraInstructionsButton, zEnhanceGemmaButton, ...editImagePromptButtons]) {
+    for (const control of [t2iTextGemmaModelSelect, gemmaModelSelect, mmprojSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, ernieMmprojSelect, zEnhanceGemmaModelSelect, zEnhanceMmprojSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, i2vMmprojSelect, miniMaxTextGemmaModelSelect, miniMaxGemmaModelSelect, miniMaxMmprojSelect, nbApiKey, nbModelSelect, nbGemmaModelSelect, nbMmprojSelect, fluxUseTextOnlyGemmaPrompt.input, fluxUseDirectorNotes.input, nbUseTextOnlyGemmaPrompt.input, nbUseDirectorNotes.input, useVisionReference.input, ernieUseVisionReference.input, krea2TwoPassUseVisionReference.input, useI2VVisionReference.input, useT2VVisionReference.input, useSceneZImageSettings.input, useSceneErnieImageSettings.input, useSceneFluxKleinSettings.input, useSceneNBImageSettings.input, useSceneI2VVideoSettings.input, useSceneMiniMaxH3Settings.input, rtvReferenceBehaviorSelect, createSceneEndFrameButton, clearSceneEndFrameButton, i2vUseGgufModel.input, refImageInput, createT2IButton, editZImageT2IInstructionsButton, ernieCreateT2IButton, editErnieT2IInstructionsButton, krea2TwoPassCreateT2IButton, editKrea2T2IInstructionsButton, createNBPromptButton, editNanoBT2IInstructionsButton, flowGptCreatePromptButton, editFlowGptT2IInstructionsButton, createFluxPromptButton, editFluxKleinT2IInstructionsButton, createI2VButton, editI2VPromptButton, editIdLoraInstructionsButton, zEnhanceGemmaButton, ...editImagePromptButtons]) {
       control.disabled = disabled;
     }
     const lockedByVideo = hasLockedVideo(segment);
@@ -14031,7 +14516,8 @@ function openBuilder(node) {
     const startFrameReserved = miniMaxH3ModeForSegment(segment) === "reference_to_video"
       && Boolean(segment.minimax_h3_use_scene_image_as_start_frame)
       && Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
-    const maxLibraryReferences = startFrameReserved ? 8 : 9;
+    const continuityReserved = miniMaxH3ContinuityReferenceReserved(segment);
+    const maxLibraryReferences = Math.max(0, 9 - (startFrameReserved ? 1 : 0) - (continuityReserved ? 1 : 0));
     let selectedKeys = miniMaxReferenceKeysForSegment(segment, refs).slice(0, maxLibraryReferences);
     let useAutomaticMappings = !Array.isArray(segment.minimax_h3_reference_keys);
 
@@ -14048,8 +14534,8 @@ function openBuilder(node) {
     header.append(heading, close);
     const note = document.createElement("div");
     note.textContent = startFrameReserved
-      ? "The scene image is reserved as Image 1 and the exact start frame. Choose up to eight additional Reference Builder images; they become Image 2 through Image 9 in the exact order shown."
-      : "Choose up to nine existing Reference Builder images. The numbered order below is the exact order sent into MiniMax H3. Scene character/location mappings are used automatically until you save a custom selection.";
+      ? `The scene image is reserved as Image 1 and the exact start frame. Choose up to ${maxLibraryReferences} additional Reference Builder image${maxLibraryReferences === 1 ? "" : "s"}.${continuityReserved ? " One final slot is reserved for the previous rendered scene's continuity frame." : ""}`
+      : `Choose up to ${maxLibraryReferences} existing Reference Builder image${maxLibraryReferences === 1 ? "" : "s"}. The numbered order is sent into MiniMax H3 exactly as shown.${continuityReserved ? " One final slot is reserved for the previous rendered scene's continuity frame." : ""} Scene character/location mappings are used automatically until you save a custom selection.`;
     note.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;padding:11px 15px;border-bottom:1px solid #1e293b;";
     const body = document.createElement("div");
     body.style.cssText = "display:grid;grid-template-columns:minmax(0,1.25fr) minmax(320px,.75fr);gap:12px;padding:12px;overflow:auto;min-height:260px;";
@@ -14164,10 +14650,10 @@ function openBuilder(node) {
       syncMiniMaxReferenceButtons();
       await autoSaveSessionQuiet("MiniMax H3 scene references");
       const savedCount = miniMaxReferenceKeysForSegment(segment).slice(0, maxLibraryReferences).length;
-      const totalCount = savedCount + (startFrameReserved ? 1 : 0);
+      const totalCount = savedCount + (startFrameReserved ? 1 : 0) + (continuityReserved ? 1 : 0);
       toast(useAutomaticMappings
-        ? `MiniMax H3 will automatically follow this scene's Reference Builder mappings (${totalCount}/9 images${startFrameReserved ? ", including the start frame" : ""}).`
-        : `Saved ${totalCount} ordered MiniMax H3 image${totalCount === 1 ? "" : "s"}${startFrameReserved ? " including Image 1 as the exact start frame" : ""}.`);
+        ? `MiniMax H3 will automatically follow this scene's Reference Builder mappings (${totalCount}/9 images${startFrameReserved ? ", including the start frame" : ""}${continuityReserved ? ", including the reserved continuity frame" : ""}).`
+        : `Saved ${totalCount} ordered MiniMax H3 image${totalCount === 1 ? "" : "s"}${startFrameReserved ? " including Image 1 as the exact start frame" : ""}${continuityReserved ? " including the reserved continuity frame" : ""}.`);
     };
     footer.append(utility, save);
     box.append(header, note, body, footer);
@@ -15899,7 +16385,18 @@ function openBuilder(node) {
     }
     segment.i2v_notes = i2vNotesInput.value || "";
     segment.flf_transition_type = ["auto", "smooth", "morph"].includes(flfTransitionTypeSelect.value) ? flfTransitionTypeSelect.value : "global";
-    segment.lyric_text = lyricTextInput.value || "";
+    // The inspector can temporarily contain an old/blank value while scenes are
+    // replaced by transcription, SRT import, project load, or another batch
+    // operation. Only let this field overwrite the scene after a real user edit.
+    // Timeline lyric boxes update their scene objects directly.
+    const lyricInspectorSegmentId = String(lyricTextInput.dataset.vrgdgInspectorSegmentId || "");
+    if (
+      lyricTextInput.dataset.vrgdgUserEdited === "1"
+      && lyricInspectorSegmentId === String(segment.id || "")
+    ) {
+      segment.lyric_text = lyricTextInput.value || "";
+      segment.lyric_no_lip_sync = isInstrumentalLyricText(segment.lyric_text);
+    }
     segment.lyric_singers = lyricSingersInput.value.split(",").map((item) => item.trim()).filter(Boolean);
     let editedT2IPrompt = t2iPrompt.value || "";
     if (state.imageModelMode === "ernie_image") editedT2IPrompt = ernieT2IPrompt.value || "";
@@ -17305,14 +17802,28 @@ function openBuilder(node) {
     await snapSceneEdgeToNearestBeat(segment, side);
   }
 
-  async function trimIdLoraSceneVideoAtPlayhead(segment, side, trimTimeOverride = null) {
+  function baseSceneVideoTrimKind(segment) {
+    if (!segment || segmentTrack(segment) === "overlay" || !String(selectedSegmentVideoPath(segment) || "").trim()) return "";
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+      return miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio" ? "minimax_h3" : "";
+    }
+    return currentVideoMode() === "id_lora" ? "id_lora" : "";
+  }
+
+  async function trimBaseSceneVideoAtPlayhead(segment, side, trimTimeOverride = null) {
     const videoPath = String(selectedSegmentVideoPath(segment) || "").trim();
-    if (currentVideoMode() !== "id_lora") {
-      toast("Timeline video trim is only available in ID-LoRA I2V mode.", true);
+    const trimKind = baseSceneVideoTrimKind(segment);
+    const miniMaxTrim = trimKind === "minimax_h3";
+    const modeLabel = miniMaxTrim ? "MiniMax H3 built-in-audio" : "ID-LoRA";
+    if (!trimKind) {
+      const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+      toast(miniMaxProject
+        ? "Playhead trimming is currently available for MiniMax built-in-audio scenes. Input-audio scenes stay protected so their separately stitched source audio cannot drift."
+        : "Timeline video trim is only available in ID-LoRA I2V mode.", true);
       return;
     }
     if (!segment || segmentTrack(segment) === "overlay" || !videoPath) {
-      toast("Select a rendered ID-LoRA scene video first.", true);
+      toast(`Select a rendered ${modeLabel} scene video first.`, true);
       return;
     }
     const sceneStart = Number(segment.start || 0);
@@ -17337,7 +17848,7 @@ function openBuilder(node) {
     const progress = createProgressWindow(trimLeft ? "Trimming left side of scene video" : "Trimming right side of scene video");
     try {
       pauseTimelineForEditing();
-      progress.set(`Creating trimmed ID-LoRA scene video...\n${videoPath}`, 20);
+      progress.set(`Creating trimmed ${modeLabel} scene video with synchronized embedded audio...\n${videoPath}`, 20);
       const data = await postJson("/vrgdg/workflow_runner/trim_scene_video", {
         project_folder: projectInput.value || state.projectFolder || "",
         source_path: videoPath,
@@ -17345,6 +17856,7 @@ function openBuilder(node) {
         start: sourceStart,
         duration: nextDuration,
         label,
+        mark_as_audio_video: miniMaxTrim,
       }, 180000);
       pushHistory();
       const oldEnd = sceneEnd;
@@ -17353,14 +17865,33 @@ function openBuilder(node) {
       segment.video_status = "done";
       segment.end = sceneStart + nextDuration;
       shiftTimelineAfterTrim(segment, oldEnd, removedDuration);
+      if (miniMaxTrim) {
+        segment.minimax_h3_trimmed_video = true;
+        segment.minimax_h3_trim_side = trimLeft ? "left" : "right";
+        segment.minimax_h3_trim_removed_seconds = Number(removedDuration.toFixed(3));
+        segment.minimax_h3_trim_source_start_seconds = Number(sourceStart.toFixed(3));
+        segment.minimax_h3_trimmed_duration_seconds = Number(nextDuration.toFixed(3));
+        if (!trimLeft) {
+          const nextSegment = allEditableSegments()
+            .filter((item) => segmentTrack(item) === segmentTrack(segment))
+            .sort((left, right) => Number(left.start || 0) - Number(right.start || 0))
+            .find((item) => Number(item.start || 0) >= Number(segment.end || 0) - 0.001 && item.id !== segment.id);
+          if (nextSegment) {
+            nextSegment.minimax_h3_continuity_frame_path = "";
+            nextSegment.minimax_h3_continuity_source_video_path = "";
+            nextSegment.minimax_h3_continuity_source_scene_id = "";
+            nextSegment.minimax_h3_continuity_image_number = 0;
+          }
+        }
+      }
       state.activeId = segment.id;
       state.sceneAudioGlobalTime = trimLeft ? Number(segment.start || 0) : Number(segment.end || 0);
       syncInspector();
       render();
-      await autoSaveSessionQuiet(trimLeft ? "ID-LoRA scene video trimmed left" : "ID-LoRA scene video trimmed right");
+      await autoSaveSessionQuiet(`${modeLabel} scene video trimmed ${trimLeft ? "left" : "right"}`);
       progress.set(`Trim complete.\n${data.video_path || ""}`, 100);
       progress.close(900);
-      toast(trimLeft ? "Trimmed left side of ID-LoRA scene video." : "Trimmed right side of ID-LoRA scene video.");
+      toast(`Trimmed ${trimLeft ? "left" : "right"} side of ${modeLabel} scene video.${miniMaxTrim && !trimLeft ? " Rerender the following scene if it was already created with previous-frame continuity." : ""}`);
     } catch (error) {
       progress.set(`Trim failed:\n${String(error?.message || error)}`, 100);
       toast(String(error?.message || error), true);
@@ -17585,9 +18116,7 @@ function openBuilder(node) {
       menu.append(button);
     };
     const isOverlay = segmentTrack(segment) === "overlay";
-    const idLoraTrimMode = currentVideoMode() === "id_lora"
-      && !isOverlay
-      && String(selectedSegmentVideoPath(segment) || "").trim();
+    const baseTrimKind = !isOverlay ? baseSceneVideoTrimKind(segment) : "";
     const playheadTime = currentGlobalTime();
     const sceneStart = Number(segment.start || 0);
     const sceneEnd = Number(segment.end || 0);
@@ -17599,9 +18128,9 @@ function openBuilder(node) {
     const trimTime = playheadInsideScene ? playheadTime : clickedTime;
     const trimLabel = playheadInsideScene ? "Playhead" : "Click";
     addItem("Restore Video...", () => restoreVideoForSegment(segment), !String(state.projectFolder || projectInput.value || "").trim());
-    if (idLoraTrimMode) {
-      addItem(`Trim Left at ${trimLabel}`, () => trimIdLoraSceneVideoAtPlayhead(segment, "left", trimTime), !(playheadInsideScene || clickInsideScene));
-      addItem(`Trim Right at ${trimLabel}`, () => trimIdLoraSceneVideoAtPlayhead(segment, "right", trimTime), !(playheadInsideScene || clickInsideScene));
+    if (baseTrimKind) {
+      addItem(`Trim Left at ${trimLabel}`, () => trimBaseSceneVideoAtPlayhead(segment, "left", trimTime), !(playheadInsideScene || clickInsideScene));
+      addItem(`Trim Right at ${trimLabel}`, () => trimBaseSceneVideoAtPlayhead(segment, "right", trimTime), !(playheadInsideScene || clickInsideScene));
     }
     if (isOverlay && String(selectedSegmentVideoPath(segment) || "").trim()) {
       addItem(`Trim Left at ${trimLabel}`, () => trimOverlayVideoAtPlayhead(segment, "left", trimTime), segment.overlay_locked !== false || !(playheadInsideScene || clickInsideScene));
@@ -20689,6 +21218,7 @@ function openBuilder(node) {
   function normalizeLyricSectionLookupText(value = "") {
     return String(value || "")
       .toLowerCase()
+      .replace(/[\u2018\u2019'`]/g, "")
       .replace(/[^\p{L}\p{N}' ]/gu, " ")
       .replace(/\s+/g, " ")
       .trim();
@@ -23017,8 +23547,11 @@ function openBuilder(node) {
     const wizardLocationMode = Boolean(options?.wizardMode || options?.wizard_location_mode);
     const referenceImagesEnabled = options?.textOnlyMode !== true;
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    const showMiniMaxNativeVoiceControls = miniMaxProject
+      && normalizeVideoType(state.videoType) === "speaking"
+      && miniMaxH3SettingsForSegment(activeSegment()).audio_mode === "built_in_audio";
     const miniMaxTargetMode = normalizeMiniMaxH3Mode(options?.miniMaxTargetMode || miniMaxH3ModeForSegment(activeSegment()));
-    const allowExtraSubjectReferences = referenceImagesEnabled && (currentVideoMode() === "rtv" || (miniMaxProject && ["reference_to_video", "video_to_video"].includes(miniMaxTargetMode)));
+    const allowExtraSubjectReferences = referenceImagesEnabled && !miniMaxProject && currentVideoMode() === "rtv";
     const referenceBuilderTargetLabel = !referenceImagesEnabled
       ? "Gemma scene text mapping"
       : miniMaxProject && miniMaxTargetMode === "video_to_video"
@@ -23929,6 +24462,7 @@ function openBuilder(node) {
           reference_type: "character",
           extra_reference_for: "",
           extra_reference_note: "",
+          minimax_voice: normalizeMiniMaxH3Voice(),
           image: { path: "", data: "", name: "" },
         });
       }
@@ -23948,6 +24482,7 @@ function openBuilder(node) {
         reference_type: "character",
         extra_reference_for: "",
         extra_reference_note: "",
+        minimax_voice: normalizeMiniMaxH3Voice(),
         image: { path: "", data: "", name: "" },
       };
       refs.subjects.push(subject);
@@ -23965,6 +24500,7 @@ function openBuilder(node) {
           name: "",
           description: "",
           reference_type: "character",
+          minimax_voice: normalizeMiniMaxH3Voice(),
           image: { path: "", data: "", name: "" },
         };
         return;
@@ -23976,6 +24512,7 @@ function openBuilder(node) {
         name: first.name || "Character 1",
         description: first.description || "",
         reference_type: first.reference_type || "character",
+        minimax_voice: normalizeMiniMaxH3Voice(first.minimax_voice),
         image: { ...(first.image || { path: "", data: "", name: "" }) },
       };
     };
@@ -26587,6 +27124,65 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         metaRow.append(used);
         if (allowExtraSubjectReferences && refs.subjects.length > 1) metaRow.append(sameSubjectWrap);
         row.append(mainRow, metaRow);
+        if (showMiniMaxNativeVoiceControls && subject.reference_type === "character" && !isExtraSubjectReference(subject)) {
+          subject.minimax_voice = normalizeMiniMaxH3Voice(subject.minimax_voice);
+          const voiceWrap = document.createElement("div");
+          voiceWrap.style.cssText = "border:1px solid #155e75;border-radius:7px;background:#061620;padding:10px;display:flex;flex-direction:column;gap:8px;";
+          const voiceHeading = document.createElement("div");
+          voiceHeading.innerHTML = `<div style="font-size:12px;font-weight:900;color:#cffafe;">MiniMax built-in voice</div><div style="font-size:11px;color:#94a3b8;margin-top:2px;">Short Film + Built-in Audio only. The saved preset name and voice description are copied verbatim into every prompt where this character speaks.</div>`;
+          const voicePreset = makeSelect(MINIMAX_H3_VOICE_PRESETS, subject.minimax_voice.preset_id);
+          const voiceName = makeInput(subject.minimax_voice.preset_name || "");
+          voiceName.placeholder = "Exact reusable preset name, e.g. MIDNIGHT ROSE";
+          const voiceDescription = document.createElement("textarea");
+          voiceDescription.placeholder = "Exact reusable voice description: adult voice range, accent, timbre, cadence, consonants, warmth, and microphone delivery.";
+          voiceDescription.style.cssText = "min-height:76px;resize:vertical;border:1px solid #3f3f46;border-radius:6px;background:#09090b;color:#f8fafc;padding:8px;font-size:12px;line-height:1.4;";
+          const voiceFields = document.createElement("div");
+          voiceFields.style.cssText = "display:grid;grid-template-columns:minmax(180px,.7fr) minmax(320px,1.8fr);gap:8px;";
+          const voiceNameField = makeField("Exact preset name", voiceName);
+          const voiceDescriptionField = makeField("Exact voice description", voiceDescription);
+          voiceFields.append(voiceNameField, voiceDescriptionField);
+          const syncVoiceFields = () => {
+            const preset = MINIMAX_H3_VOICE_PRESETS.find((item) => item.value === voicePreset.value) || MINIMAX_H3_VOICE_PRESETS[0];
+            const custom = preset.value.endsWith("_custom");
+            const normalizedVoice = normalizeMiniMaxH3Voice({
+              preset_id: preset.value,
+              preset_name: custom ? voiceName.value : preset.name,
+              description: custom ? voiceDescription.value : preset.description,
+            });
+            subject.minimax_voice = normalizedVoice;
+            voiceName.value = normalizedVoice.preset_name;
+            voiceDescription.value = normalizedVoice.description;
+            voiceName.disabled = !custom;
+            voiceDescription.disabled = !custom;
+            voiceFields.style.display = preset.value === "none" ? "none" : "grid";
+          };
+          voicePreset.addEventListener("change", () => {
+            if (voicePreset.value.endsWith("_custom") && subject.minimax_voice.preset_id !== voicePreset.value) {
+              voiceName.value = "";
+              voiceDescription.value = "";
+            }
+            syncVoiceFields();
+          });
+          voiceName.addEventListener("input", () => {
+            subject.minimax_voice = normalizeMiniMaxH3Voice({
+              ...subject.minimax_voice,
+              preset_id: voicePreset.value,
+              preset_name: voiceName.value,
+              description: voiceDescription.value,
+            });
+          });
+          voiceDescription.addEventListener("input", () => {
+            subject.minimax_voice = normalizeMiniMaxH3Voice({
+              ...subject.minimax_voice,
+              preset_id: voicePreset.value,
+              preset_name: voiceName.value,
+              description: voiceDescription.value,
+            });
+          });
+          syncVoiceFields();
+          voiceWrap.append(voiceHeading, makeField("Voice preset", voicePreset), voiceFields);
+          row.append(voiceWrap);
+        }
         subjectsList.append(row);
       });
     }
@@ -27355,6 +27951,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
           name: primarySubject.name || "Character 1",
           description: primarySubject.description || "",
           reference_type: primarySubject.reference_type || "character",
+          minimax_voice: normalizeMiniMaxH3Voice(primarySubject.minimax_voice),
           reference_generation_draft: primarySubject.reference_generation_draft || refs.subject.reference_generation_draft || {},
           image: { ...(primarySubject.image || { path: "", data: "", name: "" }) },
         };
@@ -27364,6 +27961,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
           name: refs.subjects[0].name || "Character 1",
           description: refs.subjects[0].description || "",
           reference_type: refs.subjects[0].reference_type || "character",
+          minimax_voice: normalizeMiniMaxH3Voice(refs.subjects[0].minimax_voice),
           image: { ...(refs.subjects[0].image || { path: "", data: "", name: "" }) },
         };
       } else {
@@ -27371,6 +27969,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
           name: "",
           description: "",
           reference_type: "character",
+          minimax_voice: normalizeMiniMaxH3Voice(),
           image: { path: "", data: "", name: "" },
         };
       }
@@ -30596,6 +31195,22 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const customModelsRootRow = document.createElement("div");
     customModelsRootRow.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;align-items:end;";
     customModelsRootRow.append(makeField("Custom ComfyUI models root", customModelsRootInput, "Optional. Point this at the folder that contains diffusion_models, text_encoders, vae, loras, LLM, and other Comfy model folders."), saveCustomModelsRootButton);
+    const projectRootInput = makeInput(getPreferredProjectRoot());
+    projectRootInput.placeholder = "Optional projects root, e.g. D:\\VRGDG Projects";
+    const chooseProjectRootButton = makeButton("Choose Folder");
+    const saveProjectRootButton = makeButton("Save Projects Root", "primary");
+    const clearProjectRootButton = makeButton("Use ComfyUI Output");
+    const projectRootActions = document.createElement("div");
+    projectRootActions.style.cssText = "display:grid;grid-template-columns:repeat(3,minmax(120px,auto));gap:8px;";
+    projectRootActions.append(chooseProjectRootButton, saveProjectRootButton, clearProjectRootButton);
+    const projectRootNote = document.createElement("div");
+    projectRootNote.textContent = "Optional and safe: only newly created projects use this parent folder. Existing projects and ComfyUI temporary render outputs are not moved. Leave blank to keep using the ComfyUI output folder. A full folder path entered in New Project still overrides this preference for that one project.";
+    projectRootNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+    const projectStoragePanel = makeSettingsSection("Project Storage", [
+      makeField("Default folder for new projects", projectRootInput),
+      projectRootActions,
+      projectRootNote,
+    ], true);
     pathGrid.append(
       makePickerField("Audio file path", audioInput, pickAudioButton),
       makeField("Project folder", projectInput),
@@ -30894,7 +31509,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     testErrorSound.onclick = () => playBuilderNotification("error", true);
     syncCustomAudioLabels();
     syncContinuityModeVisibility();
-    box.append(header, pathGrid, actions, note, projectVideoEnginePanel, themePanel, memoryManagementPanel, autoChainPanel, notificationPanel);
+    box.append(header, pathGrid, actions, note, projectStoragePanel, projectVideoEnginePanel, themePanel, memoryManagementPanel, autoChainPanel, notificationPanel);
     backdrop.append(box);
     document.body.append(backdrop);
     modalClose.onclick = () => backdrop.remove();
@@ -32042,7 +32657,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.overlaySegments = [];
       state.activeId = state.segments[0]?.id || "";
     }
-    const projectsLoader = getJson("/vrgdg/music_builder/list_projects")
+    const projectsLoader = getJson(projectListUrl())
       .then((data) => Array.isArray(data.projects) ? data.projects : []);
     const choice = await showWelcomeProjectModal([], projectsLoader);
     if (!choice) return false;
@@ -32059,7 +32674,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     try {
       let projects = [];
       try {
-        const data = await getJson("/vrgdg/music_builder/list_projects");
+        const data = await getJson(projectListUrl());
         projects = Array.isArray(data.projects) ? data.projects : [];
       } catch (error) {
         console.warn("[VRGDG Music Builder] Could not list existing projects:", error);
@@ -34306,17 +34921,191 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
   }
 
+  function miniMaxDialogueAssignmentsForSegment(segment) {
+    return normalizeMiniMaxSpeakerAssignments(
+      segment?.minimax_speaker_assignments || segment?.speaker_assignments || segment?.dialogue_cues || [],
+    ).filter((cue) => cue.text);
+  }
+
+  function miniMaxDialogueOrderText(segment) {
+    const cues = miniMaxDialogueAssignmentsForSegment(segment);
+    if (!cues.length) return "";
+    return cues.map((cue, index) => `${index + 1}. ${cue.speaker_name || "The assigned speaker"} says exactly: “${cue.text}”`).join("\n");
+  }
+
+  function miniMaxH3NativeVoiceAssignments(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (settings.audio_mode !== "built_in_audio" || normalizeVideoType(segment?.performance_mode || state.videoType) !== "speaking") return [];
+    const subjectRefs = storyboardReferenceDataForSegment(segment).subject_refs || [];
+    const configured = subjectRefs
+      .map((subject) => ({ ...subject, minimax_voice: normalizeMiniMaxH3Voice(subject.minimax_voice) }))
+      .filter((subject) => subject.minimax_voice.preset_id !== "none"
+        && subject.minimax_voice.preset_name
+        && subject.minimax_voice.description);
+    if (!configured.length) return [];
+    const dialogueSpeakers = miniMaxDialogueAssignmentsForSegment(segment).map((cue) => cue.speaker_name).filter(Boolean);
+    const speakerKeys = (dialogueSpeakers.length
+      ? dialogueSpeakers
+      : Array.isArray(segment?.lyric_singers)
+        ? segment.lyric_singers
+      : String(segment?.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").trim())
+      .filter(Boolean);
+    if (!speakerKeys.length) return configured.length === 1 ? configured : configured;
+    const matched = configured.filter((subject) => {
+      const nameKey = String(subject.name || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+      return nameKey && speakerKeys.some((speaker) => speaker === nameKey || speaker.includes(nameKey) || nameKey.includes(speaker));
+    });
+    return matched.length ? matched : configured;
+  }
+
+  function miniMaxH3NativeVoiceBlock(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (segmentUsesNoLipSyncPerformance(segment)
+      || settings.audio_mode !== "built_in_audio"
+      || normalizeVideoType(segment?.performance_mode || state.videoType) !== "speaking") return "";
+    const assignments = miniMaxH3NativeVoiceAssignments(segment);
+    const lyricText = isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const dialogueOrder = miniMaxDialogueOrderText(segment);
+    if (!assignments.length && !dialogueOrder && !lyricText) return "";
+    const lines = ["MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM:"];
+    if (assignments.length) {
+      lines.push(
+        ...assignments.map((subject) => `${subject.name || "The speaking character"}: voice preset “${subject.minimax_voice.preset_name}” — ${subject.minimax_voice.description}`),
+        "Use each preset name and its complete voice description exactly as written for that character. Do not paraphrase, shorten, blend, or transfer voices between characters.",
+      );
+    }
+    if (dialogueOrder) {
+      lines.push("DIALOGUE RELIABILITY — MANDATORY:");
+      lines.push("Use the single authoritative exact dialogue script written in the Native audio section. Do not print or quote that script again anywhere else in this prompt.");
+      lines.push("Generate those cues in exactly the assigned speaker order. Do not merge speakers, reorder cues, rewrite, restart, repeat, improvise, omit, or add any word.");
+      lines.push("Speak only in the language used by the supplied dialogue. Do not translate, switch languages, generate gibberish, babble, invented syllables, filler, phonetic substitutions, or extra vocalizations.");
+      lines.push("Begin the first cue within the first 0.15 seconds, pace every supplied word naturally across the available clip, and land the final spoken word approximately 0.15-0.30 seconds before the clip ends. Never finish early and fill time with invented speech.");
+      lines.push("If a character appears in more than one cue, preserve that character’s same assigned voice in every turn.");
+      lines.push("If the dialogue finishes before the video ends, fill the remaining time only with natural silence, breathing, facial reaction, physical action, and low environmental ambience—never additional speech.");
+    } else if (lyricText) {
+      lines.push(`Generate only the exact spoken words “${lyricText}”. Do not add, repeat, improvise, or replace any word.`);
+      lines.push("If the spoken line finishes before the video ends, fill the remaining time only with natural silence, breathing, facial reaction, physical action, and low environmental ambience—never additional speech.");
+    }
+    return lines.join("\n");
+  }
+
+  function miniMaxH3VisualOnlySafetyBlock(segment) {
+    if (!segmentUsesNoLipSyncPerformance(segment)) return "";
+    const builtInAudio = miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio";
+    return [
+      "VISUAL-ONLY B-ROLL / NO-LIP-SYNC SAFETY — MANDATORY AND FINAL:",
+      "This scene is explicitly B-roll / visual-only. This safety block overrides any conflicting lyric, singer, speaker, dialogue, voice, timestamp, facial-performance, or mouth instruction elsewhere in the prompt.",
+      "No visible subject sings, speaks, raps, whispers, lip-syncs, mouths words, or performs the saved lyric. Keep every visible mouth naturally relaxed or closed and use only visual acting, physical action, dancing without vocal performance, camera motion, and environmental motion.",
+      builtInAudio
+        ? "Built-in MiniMax Audio: generate only requested environmental ambience and sound effects. Do not generate speech, singing, dialogue, lyrics, narration, voices, or vocal layers."
+        : "Input Audio: preserve Audio 1 completely unchanged as the soundtrack and timing reference, including any audible vocals, but treat those vocals as off-screen soundtrack only. No visible subject may synchronize to them.",
+      "Treat the saved lyric only as hidden mood/story context; never quote it as dialogue or describe anyone performing it.",
+    ].join("\n");
+  }
+
+  function stripMiniMaxH3VisualOnlyTimelineVocalDirections(prompt) {
+    const positiveVocal = /\b(?:sing(?:s|ing)?|sang|sung|rap(?:s|ping)?|lip[ -]?sync(?:s|ing)?|speak(?:s|ing)?|say(?:s|ing)?|said|mouth(?:s|ed|ing)?|whisper(?:s|ing)?|perform(?:s|ing)?\s+(?:the\s+)?(?:saved\s+|exact\s+)?(?:lyric|dialogue|words?))\b/i;
+    const negativeSafety = /\b(?:no|not|never|without|does\s+not|do\s+not|must\s+not|cannot|can['’]t|don['’]t)\b/i;
+    const timestampPattern = /(\[\s*\d+(?:\.\d+)?s?\s*[-–—]\s*\d+(?:\.\d+)?s?\s*\]\s*\n)([\s\S]*?)(?=\n\n(?:\[\s*\d+(?:\.\d+)?s?\s*[-–—]|Audio\s*:|Continuity\s*:)|$)/gi;
+    return String(prompt || "").replace(timestampPattern, (match, header, body) => {
+      const kept = String(body || "")
+        .split(/(?<=[.!?])\s+|\n+/)
+        .map((part) => part.trim())
+        .filter((part) => part && !(positiveVocal.test(part) && !negativeSafety.test(part)));
+      if (!kept.length) kept.push("Continue the requested visual action, camera movement, and environmental motion naturally.");
+      kept.push("All visible subjects remain silent and do not sing, speak, rap, mouth words, or lip-sync; every mouth stays naturally relaxed or closed.");
+      return `${header}${kept.join(" ")}`;
+    });
+  }
+
+  function miniMaxH3SubjectMultiplicityBlock(segment) {
+    const mode = miniMaxH3ModeForSegment(segment);
+    if (mode !== "reference_to_video" && mode !== "video_to_video") return "";
+    const subjectRefs = storyboardReferenceDataForSegment(segment).subject_refs || [];
+    const subjects = [];
+    const seen = new Set();
+    for (const subject of subjectRefs) {
+      const name = String(subject?.name || subject?.label || "").trim();
+      const key = name.toLocaleLowerCase();
+      if (!name || seen.has(key)) continue;
+      seen.add(key);
+      subjects.push(name);
+    }
+    if (!subjects.length) return "";
+    const count = subjects.length;
+    return [
+      "REFERENCE SUBJECT COUNT — MANDATORY:",
+      `This scene contains exactly ${count} distinct named ${count === 1 ? "subject" : "subjects"}: ${subjects.join(", ")}.`,
+      "A character/person reference image may be a multi-view character sheet, turnaround sheet, or contact sheet. Every portrait and full-body view inside one character reference image depicts the same single person; use those views only to learn that one person's identity, face, hair, clothing, and proportions.",
+      "Render exactly one on-screen instance of each named subject. Do not turn alternate views from a reference sheet into additional people. Do not duplicate, clone, twin, multiply, or add background copies of any referenced subject unless the scene explicitly requests duplicates.",
+    ].join("\n");
+  }
+
+  function miniMaxH3ContinuityPromptBlock(segment, continuityInput, imageNumber) {
+    const continuityMode = normalizeMiniMaxH3ContinuityMode(continuityInput?.continuityMode);
+    const number = Math.max(1, Math.trunc(Number(imageNumber || 1)));
+    if (continuityMode === "off" || !continuityInput?.framePath) return "";
+    const sharedIdentityRule = `Image ${number} contains the same named subjects already assigned by the character references; it does not introduce additional people. Never duplicate or clone a person because they appear in both a character sheet and Image ${number}.`;
+    if (continuityMode === "exact_start_frame") {
+      return [
+        "PREVIOUS-SCENE EXACT FRAME CONTINUITY — MANDATORY:",
+        `Image ${number} is the actual final frame of the immediately previous rendered scene and is the sole exact opening frame for this scene. Begin on Image ${number} exactly, preserving its composition, camera angle, subject positions, poses, orientations, screen direction, distances, props, environment layout, lighting, and visual state.`,
+        "Continue naturally from that exact frame without resetting, teleporting, mirroring, swapping sides, changing wardrobe, or rearranging the set. Character and location reference images remain identity and environment support only.",
+        `Image ${number} is only the opening frame, never an ending target. Progress the requested action and camera direction away from that opening state and finish on a newly advanced frame; do not return to the same composition at the end.`,
+        sharedIdentityRule,
+      ].join("\n");
+    }
+    return [
+      "PREVIOUS-SCENE SPATIAL CONTINUITY — MANDATORY:",
+      `Image ${number} is a blocking-and-layout reference extracted from the immediately previous rendered scene. It is not a start frame, opening-frame anchor, end frame, or destination target. Use it only to understand each subject's relative physical position, orientation, distance from the others, screen-direction relationship, nearby props, and the environment's physical layout.`,
+      `The literal first generated frame must be a visibly different composition from Image ${number}, using the new shot type, angle, crop, distance, height, and lens requested by this scene. Do not reproduce Image ${number}'s camera view, framing, or pixel composition at the beginning or at any later point in the clip.`,
+      "Preserve the established blocking when photographing it from the new viewpoint. Do not reset, teleport, mirror, swap sides, reverse screen direction, rearrange the set, or move a subject behind/in front of another unless the requested action visibly causes that movement.",
+      `Progress naturally from the new first frame and finish on a newly advanced composition. Do not recreate, return to, or converge on Image ${number}. Do not invent a distant establishing shot or an automatic push-in; use only the scene's requested camera motion.`,
+      sharedIdentityRule,
+    ].join("\n");
+  }
+
+  function applyMiniMaxH3ContinuityPromptBlock(prompt, segment, continuityInput, imageNumber) {
+    const clean = String(prompt || "").trim()
+      .replace(/\n*PREVIOUS-SCENE (?:SPATIAL|EXACT FRAME) CONTINUITY — MANDATORY:[\s\S]*?(?=\n\n(?:MINIMAX NATIVE VOICE IDENTITY|REFERENCE SUBJECT COUNT|Audio:|Continuity:)|$)/g, "")
+      .trim();
+    const block = miniMaxH3ContinuityPromptBlock(segment, continuityInput, imageNumber);
+    return block ? `${clean}\n\n${block}`.trim() : clean;
+  }
+
+  function applyMiniMaxH3NativeVoiceBlock(prompt, segment) {
+    const clean = String(prompt || "").trim()
+      .replace(/\n*MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM:[\s\S]*?(?=\n\n(?:Audio:|Continuity:)|$)/g, "")
+      .replace(/\n*REFERENCE SUBJECT COUNT — MANDATORY:[\s\S]*?(?=\n\n(?:MINIMAX NATIVE VOICE IDENTITY|Audio:|Continuity:)|$)/g, "")
+      .replace(/\n*VISUAL-ONLY B-ROLL \/ NO-LIP-SYNC SAFETY — MANDATORY AND FINAL:[\s\S]*$/g, "")
+      .trim();
+    const visualOnlyBlock = miniMaxH3VisualOnlySafetyBlock(segment);
+    const safePrompt = visualOnlyBlock ? stripMiniMaxH3VisualOnlyTimelineVocalDirections(clean) : clean;
+    const block = visualOnlyBlock ? "" : miniMaxH3NativeVoiceBlock(segment);
+    const subjectMultiplicityBlock = miniMaxH3SubjectMultiplicityBlock(segment);
+    return [safePrompt, subjectMultiplicityBlock, block, visualOnlyBlock].filter(Boolean).join("\n\n").trim();
+  }
+
   function miniMaxH3PromptContextForSegment(segment, mode) {
     const settings = miniMaxH3SettingsForSegment(segment);
+    const nativeAudio = settings.audio_mode === "built_in_audio";
     const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
     const exactDuration = String(Number(duration.toFixed(3)));
     const aspectRatio = String(settings.aspect_ratio || "16:9").match(/\d+\s*:\s*\d+/)?.[0]?.replace(/\s+/g, "") || "16:9";
-    const lyricText = isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
-    const performanceMode = segmentUsesNoLipSyncPerformance(segment)
+    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const dialogueAssignments = visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment);
+    const dialogueOrder = visualOnly ? "" : miniMaxDialogueOrderText(segment);
+    const lyricText = dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.text).join(" ")
+      : isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const performanceMode = visualOnly
       ? "no_lip_sync"
       : normalizeVideoType(segment?.performance_mode || state.videoType);
-    const singerNames = (Array.isArray(segment?.lyric_singers)
-      ? segment.lyric_singers
+    const singerNames = (dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.speaker_name)
+      : Array.isArray(segment?.lyric_singers)
+        ? segment.lyric_singers
       : String(segment?.lyric_singers || "").split(/[,;\n]+/))
       .map((value) => String(value || "").trim())
       .filter(Boolean);
@@ -34329,34 +35118,59 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       `Exact duration: ${exactDuration} seconds`,
       `Timeline range: ${Number(segment?.start || 0).toFixed(3)}s to ${Number(segment?.end || 0).toFixed(3)}s`,
       `Aspect ratio: ${aspectRatio}`,
+      `Audio mode: ${nativeAudio ? "Built-in MiniMax Audio — generate native scene audio" : "Input Audio — preserve the supplied Audio 1 unchanged"}`,
       "Visual style: follow the supplied scene/theme context; default to photorealistic when no style is specified.",
     ];
+    const cameraMotionSpeed = Number(segment?.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed ?? 4);
+    const characterMotionSpeed = Number(segment?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed ?? 4);
+    const cameraMotionGuidance = String(segment?.camera_motion_speed_guidance || state.builderStoryboardDefaults?.camera_guidance || "").trim();
+    const characterMotionGuidance = String(segment?.character_motion_guidance || state.builderStoryboardDefaults?.character_guidance || "").trim();
+    parts.push(
+      `Camera motion speed: ${Number.isFinite(cameraMotionSpeed) ? cameraMotionSpeed : 4}/10.`,
+      cameraMotionGuidance || "Follow the selected camera speed as a hard motion requirement.",
+      `Character motion speed: ${Number.isFinite(characterMotionSpeed) ? characterMotionSpeed : 4}/10.`,
+      characterMotionGuidance || "Include physical character action appropriate to the selected character-motion speed.",
+    );
+    if (cameraMotionSpeed >= 7) {
+      parts.push("MANDATORY CAMERA RULE: use energetic, visibly active camera movement. Slow, gentle, subtle, restrained, locked-off, static, and hold camera language contradicts this setting and must not appear.");
+    }
+    if (characterMotionSpeed >= 4) {
+      parts.push("MANDATORY CHARACTER ACTION RULE: include at least one clear physical body action, gesture, step, or interaction with the set. Facial expression, blinking, breathing, and mouth movement alone do not satisfy character motion.");
+    }
     if (segment?.no_character_present) {
       parts.push(
         "Vocal performance: NO VISIBLE CHARACTER / NO LIP SYNC.",
-        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing. Do not invent a visible singer or speaker.",
+        nativeAudio
+          ? "Native audio assignment: generate only low environmental ambience and requested sound effects. Do not invent a singer, speaker, dialogue, lyrics, or voice."
+          : "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing. Do not invent a visible singer or speaker.",
       );
     } else if (performanceMode === "no_lip_sync") {
       parts.push(
         "Vocal performance: VISUAL ONLY / NO LIP SYNC.",
-        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing, but do not show singing, speaking, or mouth synchronization.",
+        nativeAudio
+          ? "Native audio assignment: generate only ambience and requested sound effects. Do not generate speech, singing, lyrics, dialogue, or visible mouth synchronization."
+          : "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for timing, but do not show singing, speaking, or mouth synchronization.",
       );
     } else if (lyricText && performanceMode === "speaking") {
       parts.push(
         "Vocal performance: SPEAKING WITH EXACT DIALOGUE LIP SYNC.",
-        `Exact dialogue line: “${lyricText}”`,
-        `Audio 1 assignment: use as the exact voice, timing, and lip-sync reference. ${performerLabel} says the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that spoken line in Audio 1. Do not replace, alter, extend, or add words.`,
+        dialogueOrder ? `Mandatory dialogue order:\n${dialogueOrder}` : `Exact dialogue line: “${lyricText}”`,
+        nativeAudio
+          ? `Native audio assignment: MiniMax generates the voices and audio. Follow the mandatory speaker assignment and dialogue order exactly. Synchronize each assigned speaker’s lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that speaker’s generated line. Do not merge speakers, reorder cues, replace, alter, repeat, extend, improvise, omit, or add words. Use silence, breathing, facial reaction, physical action, and low ambience for all remaining time.`
+          : `Audio 1 assignment: use as the exact voice, timing, and lip-sync reference. ${performerLabel} says the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that spoken line in Audio 1. Do not replace, alter, extend, or add words.`,
       );
     } else if (lyricText) {
       parts.push(
         "Vocal performance: SINGING WITH EXACT LYRIC LIP SYNC.",
         `Exact lyric line to sing: “${lyricText}”`,
-        `Audio 1 assignment: use as the exact vocal, timing, and lip-sync reference. ${performerLabel} is singing the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that sung line in Audio 1. Every active vocal timestamp must visibly describe the singing and exact lip sync. Do not replace, alter, extend, or add vocals.`,
+        `Audio 1 assignment: use as the exact vocal, timing, and lip-sync reference. ${performerLabel} is singing the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely only while that sung line is audible in Audio 1. Never stretch, restart, or repeat the full lyric across every timestamp. When the vocal ends, the mouth closes or relaxes naturally while physical action continues. Do not replace, alter, extend, or add vocals.`,
       );
     } else {
       parts.push(
         "Vocal performance: no exact lyric or dialogue is assigned to this scene.",
-        "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for performance, movement, and camera timing. Do not invent lyrics, dialogue, or replacement audio.",
+        nativeAudio
+          ? "Native audio assignment: generate only ambience and requested sound effects. Do not invent lyrics, dialogue, or voices."
+          : "Audio 1 assignment: use the exact supplied custom/project audio segment unchanged for performance, movement, and camera timing. Do not invent lyrics, dialogue, or replacement audio.",
       );
     }
     const add = (label, value) => {
@@ -34365,13 +35179,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     };
     add("Scene idea / image prompt", sceneVideoConceptPromptText(segment));
     add("Scene notes", segment?.notes || segment?.director_note);
+    add("Exact manual audio / sound direction", segment?.audio_direction);
+    add("Exact manual continuity requirements", segment?.continuity);
     add("Director timeline note", segment?.timeline_note);
     add("Motion and camera request", segment?.i2v_notes);
     add("Scene story beat", segment?.story_beat);
-    add("Exact supplied lyric or dialogue", lyricText);
+    add(performanceMode === "no_lip_sync" ? "Hidden lyric mood/story context — never performed" : "Exact supplied lyric or dialogue", lyricText);
     add("Lyric section", segment?.lyric_section);
     add("Visible character context", segment?.no_character_present ? "No main character is visible in this scene." : segmentMappedSubjectText(segment));
     add("Location context", segmentMappedLocationText(segment));
+    const nativeVoiceBlock = miniMaxH3NativeVoiceBlock(segment);
+    if (nativeVoiceBlock) parts.push(nativeVoiceBlock);
 
     if (mode === "image_to_video") {
       parts.push("Ordered image assignment:\nImage 1: exact start frame and authoritative opening composition, character identity, clothing, location, lighting, and visual-state anchor.");
@@ -34458,8 +35276,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       return;
     }
     const context = miniMaxH3PromptContextForSegment(segment, mode);
-    const promptLyricText = isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
-    const promptSingerNames = (Array.isArray(segment.lyric_singers)
+    const miniMaxVisualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const promptLyricText = miniMaxVisualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
+    const promptSingerNames = miniMaxVisualOnly ? [] : (Array.isArray(segment.lyric_singers)
       ? segment.lyric_singers
       : String(segment.lyric_singers || "").split(/[,;\n]+/))
       .map((value) => String(value || "").trim())
@@ -34482,9 +35301,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         project_folder: projectFolder,
         scene_id: segment.id || "",
         builder_instruction_key: miniMaxH3InstructionKey(mode),
-        model_file: visionImages.length ? i2vGemmaModelSelect.value : i2vTextGemmaModelSelect.value,
-        repair_model_file: i2vTextGemmaModelSelect.value,
-        mmproj_file: visionImages.length ? i2vMmprojSelect.value : "",
+        model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
+        repair_model_file: miniMaxTextGemmaModelSelect.value,
+        mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
         t2i_prompt: context,
         user_notes: "Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.",
         subject_context: segment.no_character_present ? "" : segmentMappedSubjectText(segment),
@@ -34494,6 +35313,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         performance_mode: effectiveVideoPerformanceModeForSegment(segment),
         lyric_text: promptLyricText,
         singers: promptSingerNames,
+        audio_mode: miniMaxH3SettingsForSegment(segment).audio_mode,
+        speaker_assignments: miniMaxVisualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment),
         theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
         story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
         subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
@@ -34502,7 +35323,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         top_p: 0.92,
         max_new_tokens: 4000,
       }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-      const prompt = String(data.prompt || "").trim();
+      const prompt = applyMiniMaxH3NativeVoiceBlock(String(data.prompt || ""), segment);
       if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
       pushHistory();
       segment.minimax_h3_prompt = prompt;
@@ -35338,6 +36159,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         name: subject.name,
         description: subject.description,
         reference_type: subject.reference_type || "character",
+        minimax_voice: normalizeMiniMaxH3Voice(subject.minimax_voice),
         trigger_phrase: subject.trigger_phrase || "",
         trigger_position: subject.trigger_position || "start",
         image: { ...(subject.image || {}) },
@@ -35410,6 +36232,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           prompt_summary: promptSummary,
           motion_summary: videoNotes,
           lyric_singers: Array.isArray(segment.lyric_singers) && !segment.no_character_present ? segment.lyric_singers : [],
+          speaker_assignments: normalizeMiniMaxSpeakerAssignments(segment.minimax_speaker_assignments),
           lyric_no_lip_sync: Boolean(segmentUsesNoLipSyncPerformance(segment)),
           lyric_instrumental: isInstrumentalLyricText(lyric),
           no_character_present: Boolean(segment.no_character_present),
@@ -35418,6 +36241,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           performance_style: String(segment.performance_style || defaults.performance_style || "").trim(),
           project_video_engine: normalizeProjectVideoEngine(state.projectVideoEngine),
           minimax_h3_mode: miniMaxH3ModeForSegment(segment),
+          minimax_h3_audio_mode: miniMaxH3SettingsForSegment(segment).audio_mode,
+          video_style: String(segment.minimax_h3_video_style || defaults.video_style || "").trim(),
+          video_style_custom: String(segment.minimax_h3_video_style_custom || defaults.video_style_custom || "").trim(),
+          temporal_world_effect_override: String(segment.temporal_world_effect_override || "global").trim(),
+          temporal_world_effect_custom: String(segment.temporal_world_effect_custom || "").trim(),
           timeline_start: Number(segment.start || 0),
           timeline_end: Number(segment.end || 0),
           exact_duration: Number(timelineSegmentDuration(segment).toFixed(3)),
@@ -35440,6 +36268,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           image_path: imageReference.path || selectedSegmentImagePath(segment),
           image_data: imageReference.data || "",
           notes: sceneNotes,
+          audio_direction: String(segment.audio_direction || "").trim(),
+          continuity: String(segment.continuity || "").trim(),
         };
       });
   }
@@ -35455,12 +36285,24 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       mode: promptMode === "video" ? "image_to_video_prep" : "storyboard_prompts",
       performanceMode: normalizeVideoType(state.videoType),
       videoType: normalizeVideoType(state.videoType),
+      shortFilmPlanningMode: defaults.short_film_planning_mode,
       videoPromptType: videoMode,
+      miniMaxH3Mode: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" ? normalizeMiniMaxH3Mode(options.miniMaxH3Mode || state.miniMaxH3Settings?.video_mode) : "",
+      miniMaxH3AudioMode: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" ? normalizeMiniMaxH3AudioMode(state.miniMaxH3Settings?.audio_mode) : "",
       imageMode,
       imageModeLabel: imageModeDisplayLabel(imageMode),
       cameraFlow: defaults.camera_flow || "balanced",
       imageShotFlow: defaults.image_shot_flow || "intimate",
       imageAesthetic: defaults.image_aesthetic || "",
+      videoStyle: defaults.video_style || "",
+      videoStyleCustom: defaults.video_style_custom || "",
+      temporalWorldEffect: defaults.temporal_world_effect || "",
+      temporalWorldEffectCustom: defaults.temporal_world_effect_custom || "",
+      temporalAllowBackgroundExtras: defaults.temporal_allow_background_extras !== false,
+      temporalBackgroundIntensity: Number(defaults.temporal_background_intensity ?? 8),
+      temporalEnvironmentTimePassage: defaults.temporal_environment_time_passage !== false,
+      temporalProtectedCharacters: defaults.temporal_protected_characters || "all_referenced",
+      temporalProtectedCustom: defaults.temporal_protected_custom || "",
       globalConsistencyPhrase: defaults.global_consistency_phrase || "",
       performanceStyle: defaults.performance_style || "",
       facialPerformance: state.defaultFacialPerformance || "",
@@ -35486,6 +36328,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     updateActiveFromInputs();
     saveI2VVideoSettingsFromPanel();
+    const storyboardOpeningMiniMaxMode = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"
+      ? miniMaxH3ModeForSegment(activeSegment())
+      : "";
     const applyStoryboardReferenceMappings = (updates = {}) => {
       const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
       const incomingSource = updates.reference_builder || updates.referenceBuilder || {};
@@ -35572,6 +36417,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (locationId && !refs.locations_cleared) refs.scene_map[segment.id] = locationId;
         else delete refs.scene_map[segment.id];
         if (item.trigger_position) refs.location_trigger_position = String(item.trigger_position || "start") === "end" ? "end" : "start";
+        if (Array.isArray(item.speaker_assignments) || Array.isArray(item.minimax_speaker_assignments) || Array.isArray(item.dialogue_cues)) {
+          segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(item.speaker_assignments || item.minimax_speaker_assignments || item.dialogue_cues);
+          syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+        }
       }
       state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
       render();
@@ -35585,6 +36434,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       let storyChanged = false;
       let facialChanged = false;
       let beatChanged = false;
+      let speakerChanged = false;
       const hasIncomingFacialDefault = Object.prototype.hasOwnProperty.call(updates, "facial_performance_default")
         || Object.prototype.hasOwnProperty.call(updates, "facialPerformance")
         || Object.prototype.hasOwnProperty.call(updates, "default_facial_performance");
@@ -35596,7 +36446,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         || Object.prototype.hasOwnProperty.call(updates, "motion_defaults")
         || Object.prototype.hasOwnProperty.call(updates, "global_consistency_phrase")
         || Object.prototype.hasOwnProperty.call(updates, "performance_style_default")
-        || Object.prototype.hasOwnProperty.call(updates, "performanceStyle");
+        || Object.prototype.hasOwnProperty.call(updates, "performanceStyle")
+        || Object.prototype.hasOwnProperty.call(updates, "video_style")
+        || Object.prototype.hasOwnProperty.call(updates, "videoStyle")
+        || Object.prototype.hasOwnProperty.call(updates, "video_style_custom")
+        || Object.prototype.hasOwnProperty.call(updates, "videoStyleCustom")
+        || Object.prototype.hasOwnProperty.call(updates, "temporal_world_effect")
+        || Object.prototype.hasOwnProperty.call(updates, "temporalWorldEffect")
+        || Object.prototype.hasOwnProperty.call(updates, "short_film_planning_mode")
+        || Object.prototype.hasOwnProperty.call(updates, "shortFilmPlanningMode");
       if (hasIncomingFacialDefault) {
         const nextDefault = String(updates.facial_performance_default ?? updates.facialPerformance ?? updates.default_facial_performance ?? "").trim();
         if (state.defaultFacialPerformance !== nextDefault) {
@@ -35618,6 +36476,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           motion_defaults: updates.motion_defaults || updates.builder_storyboard_defaults?.motion_defaults || updates.storyboard_defaults?.motion_defaults || state.builderStoryboardDefaults?.motion_defaults || {},
           global_consistency_phrase: updates.global_consistency_phrase ?? updates.globalConsistencyPhrase ?? state.builderStoryboardDefaults?.global_consistency_phrase,
           performance_style: updates.performance_style_default ?? updates.performance_style ?? updates.performanceStyle ?? state.builderStoryboardDefaults?.performance_style,
+          video_style: updates.video_style ?? updates.videoStyle ?? updates.builder_storyboard_defaults?.video_style ?? updates.storyboard_defaults?.video_style ?? state.builderStoryboardDefaults?.video_style,
+          video_style_custom: updates.video_style_custom ?? updates.videoStyleCustom ?? updates.builder_storyboard_defaults?.video_style_custom ?? updates.storyboard_defaults?.video_style_custom ?? state.builderStoryboardDefaults?.video_style_custom,
+          temporal_world_effect: updates.temporal_world_effect ?? updates.temporalWorldEffect ?? updates.builder_storyboard_defaults?.temporal_world_effect ?? updates.storyboard_defaults?.temporal_world_effect ?? state.builderStoryboardDefaults?.temporal_world_effect,
+          temporal_world_effect_custom: updates.temporal_world_effect_custom ?? updates.temporalWorldEffectCustom ?? updates.builder_storyboard_defaults?.temporal_world_effect_custom ?? updates.storyboard_defaults?.temporal_world_effect_custom ?? state.builderStoryboardDefaults?.temporal_world_effect_custom,
+          temporal_allow_background_extras: updates.temporal_allow_background_extras ?? updates.temporalAllowBackgroundExtras ?? updates.builder_storyboard_defaults?.temporal_allow_background_extras ?? updates.storyboard_defaults?.temporal_allow_background_extras ?? state.builderStoryboardDefaults?.temporal_allow_background_extras,
+          temporal_background_intensity: updates.temporal_background_intensity ?? updates.temporalBackgroundIntensity ?? updates.builder_storyboard_defaults?.temporal_background_intensity ?? updates.storyboard_defaults?.temporal_background_intensity ?? state.builderStoryboardDefaults?.temporal_background_intensity,
+          temporal_environment_time_passage: updates.temporal_environment_time_passage ?? updates.temporalEnvironmentTimePassage ?? updates.builder_storyboard_defaults?.temporal_environment_time_passage ?? updates.storyboard_defaults?.temporal_environment_time_passage ?? state.builderStoryboardDefaults?.temporal_environment_time_passage,
+          temporal_protected_characters: updates.temporal_protected_characters ?? updates.temporalProtectedCharacters ?? updates.builder_storyboard_defaults?.temporal_protected_characters ?? updates.storyboard_defaults?.temporal_protected_characters ?? state.builderStoryboardDefaults?.temporal_protected_characters,
+          temporal_protected_custom: updates.temporal_protected_custom ?? updates.temporalProtectedCustom ?? updates.builder_storyboard_defaults?.temporal_protected_custom ?? updates.storyboard_defaults?.temporal_protected_custom ?? state.builderStoryboardDefaults?.temporal_protected_custom,
+          short_film_planning_mode: updates.short_film_planning_mode ?? updates.shortFilmPlanningMode ?? updates.builder_storyboard_defaults?.short_film_planning_mode ?? updates.storyboard_defaults?.short_film_planning_mode ?? state.builderStoryboardDefaults?.short_film_planning_mode,
           camera_motion_speed: updates.camera_motion_speed ?? updates.cameraMotionSpeed ?? updates.motion_defaults?.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed,
           character_motion_speed: updates.character_motion_speed ?? updates.characterMotionSpeed ?? updates.motion_defaults?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed,
         });
@@ -35628,6 +36496,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           || segments.find((candidate, index) => Number(index + 1) === Number(scene.scene_number));
         if (!segment) continue;
         ensureSegmentRuntimeFields(segment);
+        if (Object.prototype.hasOwnProperty.call(scene, "lyric_no_lip_sync") || Object.prototype.hasOwnProperty.call(scene, "no_lip_sync")) {
+          segment.lyric_no_lip_sync = Boolean(scene.lyric_no_lip_sync || scene.no_lip_sync);
+        }
+        if (Array.isArray(scene.speaker_assignments) || Array.isArray(scene.minimax_speaker_assignments) || Array.isArray(scene.dialogue_cues)) {
+          segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(scene.speaker_assignments || scene.minimax_speaker_assignments || scene.dialogue_cues);
+          syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+          speakerChanged = true;
+        }
         const imagePrompt = String(scene.image_prompt || "").trim();
         const videoPrompt = String(scene.video_prompt || scene.i2v_prompt || scene.t2v_prompt || "").trim();
         const videoType = String(scene.video_prompt_type || "").trim();
@@ -35645,6 +36521,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           : String(segment.story_beat || "").trim();
         if (segment.story_beat !== nextStoryBeat) beatChanged = true;
         segment.story_beat = nextStoryBeat;
+        if (Object.prototype.hasOwnProperty.call(scene, "audio_direction")) segment.audio_direction = String(scene.audio_direction || "").trim();
+        if (Object.prototype.hasOwnProperty.call(scene, "continuity") || Object.prototype.hasOwnProperty.call(scene, "continuity_direction")) {
+          segment.continuity = String(scene.continuity || scene.continuity_direction || "").trim();
+        }
         segment.flf_start_state = String(scene.flf_start_state || segment.flf_start_state || "").trim();
         segment.flf_transformation = String(scene.flf_transformation || segment.flf_transformation || "").trim();
         segment.flf_end_state = String(scene.flf_end_state || segment.flf_end_state || "").trim();
@@ -35654,13 +36534,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (segment.facial_performance !== nextFacial || segment.facial_performance_custom !== nextFacialCustom) facialChanged = true;
         segment.facial_performance = nextFacial;
         segment.facial_performance_custom = nextFacialCustom;
+        if (Object.prototype.hasOwnProperty.call(scene, "video_style")) segment.minimax_h3_video_style = String(scene.video_style || "").trim();
+        if (Object.prototype.hasOwnProperty.call(scene, "video_style_custom")) segment.minimax_h3_video_style_custom = String(scene.video_style_custom || "").trim();
+        if (Object.prototype.hasOwnProperty.call(scene, "temporal_world_effect_override")) segment.temporal_world_effect_override = String(scene.temporal_world_effect_override || "global").trim();
+        if (Object.prototype.hasOwnProperty.call(scene, "temporal_world_effect_custom")) segment.temporal_world_effect_custom = String(scene.temporal_world_effect_custom || "").trim();
         if (imagePrompt) {
           setSegmentPromptForEdit(segment, "t2i", imagePrompt);
           applied += 1;
         }
         if (videoPrompt) {
           if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
-            segment.minimax_h3_prompt = videoPrompt;
+            segment.minimax_h3_prompt = applyMiniMaxH3NativeVoiceBlock(videoPrompt, segment);
             segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(scene.video_prompt_origin);
           } else {
             setSegmentPromptForEdit(segment, "i2v", videoPrompt, {
@@ -35677,7 +36561,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.builderStoryLayer = normalizeBuilderStoryLayer(updates.story_layer || updates.storyLayer);
         storyChanged = true;
       }
-      if (applied || storyChanged || facialChanged || beatChanged) {
+      if (applied || storyChanged || facialChanged || beatChanged || speakerChanged) {
         ensureAllSegmentRuntimeFields();
         syncInspector();
         render();
@@ -35695,6 +36579,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     };
     const storyboardVideoExtraNotes = (scene = {}, storyboardPayload = {}) => {
       const selectedScene = Array.isArray(storyboardPayload?.scenes) && storyboardPayload.scenes.length ? storyboardPayload.scenes[0] : {};
+      const fullyCustomShortFilm = normalizeMiniMaxShortFilmPlanningMode(storyboardPayload?.short_film_planning_mode) === "fully_custom";
       const storyLayer = selectedScene.story_layer || {};
       const vocalStatus = selectedScene.vocal_status || {};
       const startingShot = selectedScene.starting_shot && typeof selectedScene.starting_shot === "object"
@@ -35705,6 +36590,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (text) parts.push(`${title}:\n${text}`);
       };
       const parts = [];
+      if (fullyCustomShortFilm) {
+        parts.push("FULLY CUSTOM SHORT FILM SOURCE CONTRACT:\nUse only the populated manual scene-card fields below. Do not infer or invent missing dialogue, speakers, actions, story beats, shots, camera moves, settings, sound, or continuity.");
+      }
       if (startingShot?.required) {
         add(
           parts,
@@ -35713,15 +36601,21 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         );
       }
       add(parts, "Storyboard scene story beat", storyLayer.scene_story_beat || scene.story_beat);
+      add(parts, "REQUIRED Storyboard video style", selectedScene.video_style);
+      add(parts, "MANDATORY exact Storyboard video style verbiage — copy word-for-word", selectedScene.video_style_verbiage);
+      add(parts, "MANDATORY exact temporal / world effect verbiage — copy word-for-word", selectedScene.temporal_world_effect_verbiage);
       const customMotionSummary = String(selectedScene.motion_summary || scene.motion_summary || scene.video_notes || "").trim();
       add(parts, "Storyboard motion/video summary", customMotionSummary);
-      if (!customMotionSummary) add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
-      add(parts, "Storyboard camera motion speed guidance", selectedScene.camera_motion_speed_guidance || selectedScene.camera_guidance?.camera_motion_speed_guidance);
+        if (!customMotionSummary) add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
+        if (!fullyCustomShortFilm) add(parts, "REQUIRED Storyboard camera-flow framing", selectedScene.camera_flow_guidance);
+        add(parts, "Storyboard camera motion speed guidance", selectedScene.camera_motion_speed_guidance || selectedScene.camera_guidance?.camera_motion_speed_guidance);
       add(parts, "Storyboard character motion guidance", selectedScene.character_motion_guidance || scene.character_motion);
       add(parts, "Storyboard performance direction", selectedScene.performance_direction || scene.performance_style);
       add(parts, "Storyboard facial performance direction", selectedScene.facial_performance_direction || scene.facial_performance_custom || scene.facial_performance);
       add(parts, "Storyboard lyric section", vocalStatus.lyric_section || scene.lyric_section);
       add(parts, "Storyboard first-frame visual inventory", selectedScene.first_frame_visual_inventory?.text || "");
+      add(parts, "Exact manual audio / sound direction", selectedScene.audio_direction || scene.audio_direction);
+      add(parts, "Exact manual continuity requirements", selectedScene.continuity || scene.continuity || scene.continuity_direction);
       return parts.join("\n\n");
     };
     const ensureStoryboardRequiredStartingShot = (prompt, segment, scene = {}, storyboardPayload = {}) => {
@@ -35760,12 +36654,118 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         { ensureTransitionLast: true },
       );
     };
+    const ensureStoryboardRequiredVideoStyle = (prompt, storyboardPayload = {}) => {
+      const text = String(prompt || "").trim();
+      const selectedScene = Array.isArray(storyboardPayload?.scenes) && storyboardPayload.scenes.length
+        ? storyboardPayload.scenes[0]
+        : {};
+      const verbiage = String(selectedScene.video_style_verbiage || "").trim();
+      if (!text || !verbiage || text.includes(verbiage)) return text;
+      const requiredLine = verbiage;
+      const firstParagraphEnd = text.indexOf("\n\n");
+      if (firstParagraphEnd >= 0) {
+        return `${text.slice(0, firstParagraphEnd)}\n\n${requiredLine}${text.slice(firstParagraphEnd)}`;
+      }
+      const firstLineEnd = text.indexOf("\n");
+      if (firstLineEnd >= 0) {
+        return `${text.slice(0, firstLineEnd)}\n\n${requiredLine}\n${text.slice(firstLineEnd + 1)}`;
+      }
+      return `${text}\n\n${requiredLine}`;
+    };
+    const ensureStoryboardRequiredTemporalWorldEffect = (prompt, storyboardPayload = {}) => {
+      let text = String(prompt || "").trim();
+      const selectedScene = Array.isArray(storyboardPayload?.scenes) && storyboardPayload.scenes.length
+        ? storyboardPayload.scenes[0]
+        : {};
+      const effect = selectedScene.temporal_world_effect || {};
+      const verbiage = String(selectedScene.temporal_world_effect_verbiage || effect.exact_verbiage || "").trim();
+      if (!text || !verbiage) return text;
+
+      // Canonicalize the exact contract before the timeline. Gemma sometimes embeds it
+      // inside the first beat or appends it after Continuity, where H3 treats it as an
+      // afterthought instead of a governing instruction.
+      text = text.split(verbiage).join("").replace(/\n{3,}/g, "\n\n").trim();
+      const firstTimestamp = text.search(/^\s*\[\d+(?:\.\d+)?s\s*[-–—]\s*\d+(?:\.\d+)?s\]/m);
+      text = firstTimestamp >= 0
+        ? `${text.slice(0, firstTimestamp).trimEnd()}\n\n${verbiage}\n\n${text.slice(firstTimestamp).trimStart()}`
+        : `${text}\n\n${verbiage}`;
+
+      // Enforce a visible temporal-layer action in every beat even when the LLM only
+      // copied the global contract. This makes high-intensity presets reach H3 as
+      // timestamped action rather than passive metadata.
+      const timestampAction = String(effect.timestamp_action || effect.timestampAction || "").trim();
+      if (timestampAction) {
+        const timestampPattern = /(\[\d+(?:\.\d+)?s\s*[-–—]\s*\d+(?:\.\d+)?s\]\s*\n)([\s\S]*?)(?=\n\s*\[\d+(?:\.\d+)?s\s*[-–—]\s*\d+(?:\.\d+)?s\]|\n\s*Audio:|\n\s*Continuity:|$)/g;
+        const blockCount = Array.from(text.matchAll(timestampPattern)).length;
+        let blockIndex = 0;
+        text = text.replace(timestampPattern, (whole, header, body) => {
+          const phase = blockIndex === 0
+            ? "begins visibly"
+            : blockIndex === blockCount - 1
+              ? "reaches its strongest readable payoff"
+              : "continues and develops visibly";
+          blockIndex += 1;
+          const cleanBody = String(body || "").trim();
+          if (cleanBody.includes(timestampAction)) return `${header}${cleanBody}\n`;
+          return `${header}${cleanBody}\n\nTemporal-layer action ${phase}: ${timestampAction}\n`;
+        }).trim();
+      }
+
+      // Location references often describe an empty source image with “no people.”
+      // When extras are enabled, prevent Continuity from accidentally turning that
+      // source-image description into an output-wide ban.
+      if (effect.allow_background_extras === true || effect.allowBackgroundExtras === true) {
+        text = text.replace(/(\n\s*Continuity:\s*)([^\n]*)/i, (whole, heading, body) => {
+          let corrected = String(body || "")
+            .replace(/\b(no (?:new|added|additional) [^.\n]{0,120}?)(?:people|characters)\b/gi, (match, prefix) => `${prefix}named or referenced characters`)
+            .replace(/\bno new people\b/gi, "no new named or referenced characters")
+            .replace(/\bno added people\b/gi, "no added named or referenced characters")
+            .replace(/\bno people\b/gi, "no named or referenced characters")
+            .replace(/\bno new characters\b/gi, "no new named or referenced characters")
+            .replace(/\bdo not (add|introduce) ((?:any )?(?:new )?)[^.\n]{0,120}?(?:people|characters)\b/gi, (match, verb, qualifier) => `do not ${verb} ${qualifier}named or referenced characters`)
+            .replace(/\bdo not (?:add|introduce) (?:any )?(?:new )?people\b/gi, "do not add named or referenced characters")
+            .trim();
+          const permission = "Anonymous unreferenced background extras are permitted, remain secondary, and receive the selected temporal/world effect; they must never duplicate or replace a mapped/reference character.";
+          if (!corrected.includes(permission)) corrected = `${corrected}${corrected ? " " : ""}${permission}`;
+          return `${heading}${corrected}`;
+        });
+      }
+      return text.trim();
+    };
+    const normalizeStoryboardInputAudioVocalTimeline = (prompt, segment) => {
+      let text = String(prompt || "").trim();
+      const settings = miniMaxH3SettingsForSegment(segment);
+      const lyric = isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+      if (!text || !lyric || settings.audio_mode !== "input_audio" || effectiveVideoPerformanceModeForSegment(segment) !== "singing") return text;
+      const timestampPattern = /(\[\d+(?:\.\d+)?s\s*[-–—]\s*\d+(?:\.\d+)?s\]\s*\n)([\s\S]*?)(?=\n\s*\[\d+(?:\.\d+)?s\s*[-–—]\s*\d+(?:\.\d+)?s\]|\n\s*Audio:|\n\s*Continuity:|$)/g;
+      const blockCount = Array.from(text.matchAll(timestampPattern)).length;
+      if (!blockCount) return text;
+      const repeatedVocalBoilerplate = /During only the portion of this interval where the sung lyric is audible in Audio 1,[\s\S]*?never stretch, restart, or repeat the line to fill the interval\./gi;
+      const quotedLyricVariants = [`“${lyric}”`, `\"${lyric}\"`];
+      let blockIndex = 0;
+      text = text.replace(timestampPattern, (whole, header, body) => {
+        const phaseDirection = blockIndex === 0
+          ? "Only while vocals are actually audible in this interval, the assigned singer begins the currently audible portion of the assigned lyric in exact sync with Audio 1."
+          : blockIndex === blockCount - 1
+            ? "Only while vocals remain audible in this interval, the assigned singer completes any remaining portion of the assigned lyric in exact sync with Audio 1; once the supplied vocal ends, the mouth closes or relaxes naturally."
+            : "Only while vocals are actually audible in this interval, the assigned singer continues the currently audible portion of the assigned lyric in exact sync with Audio 1 without restarting or repeating it.";
+        blockIndex += 1;
+        let cleanBody = String(body || "").replace(repeatedVocalBoilerplate, "").trim();
+        quotedLyricVariants.forEach((quoted) => {
+          cleanBody = cleanBody.split(quoted).join("the assigned lyric");
+        });
+        if (!cleanBody.includes(phaseDirection)) cleanBody = `${cleanBody}\n\n${phaseDirection}`.trim();
+        return `${header}${cleanBody}\n`;
+      });
+      return text.trim();
+    };
     const storyboardSceneCloneForI2V = (segment, scene = {}) => {
       const clone = {
         ...segment,
         lyric_text: String(scene.lyrics || scene.lyric_text || segment.lyric_text || "").trim(),
         lyric_section: String(scene.lyric_section || scene.section || scene.song_section || segment.lyric_section || "").trim(),
         lyric_singers: Array.isArray(scene.lyric_singers) ? scene.lyric_singers : segment.lyric_singers,
+        minimax_speaker_assignments: normalizeMiniMaxSpeakerAssignments(scene.speaker_assignments || scene.minimax_speaker_assignments || segment.minimax_speaker_assignments),
         lyric_no_lip_sync: Boolean(scene.lyric_no_lip_sync || scene.no_lip_sync || segmentUsesNoLipSyncPerformance(segment)),
         no_character_present: Boolean(scene.no_character_present || scene.noCharacterPresent || segment.no_character_present),
         story_beat: String(scene.story_beat || scene.scene_story_beat || scene.narrative_beat || segment.story_beat || "").trim(),
@@ -35775,6 +36775,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         flf_carry_forward: String(scene.flf_carry_forward || segment.flf_carry_forward || "").trim(),
         shot_type: String(scene.shot_type || segment.shot_type || "").trim(),
         camera_motion: String(scene.camera_motion || segment.camera_motion || "").trim(),
+        camera_motion_speed: Number(scene.camera_motion_speed ?? segment.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed ?? 4),
+        camera_motion_speed_guidance: String(scene.camera_motion_speed_guidance || segment.camera_motion_speed_guidance || state.builderStoryboardDefaults?.camera_guidance || "").trim(),
+        character_motion: String(scene.character_motion || segment.character_motion || "").trim(),
+        character_motion_speed: Number(scene.character_motion_speed ?? segment.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed ?? 4),
+        character_motion_guidance: String(scene.character_motion_guidance || segment.character_motion_guidance || state.builderStoryboardDefaults?.character_guidance || "").trim(),
         subject_refs: Array.isArray(scene.subject_refs) ? scene.subject_refs : Array.isArray(segment.subject_refs) ? segment.subject_refs : [],
         mapped_subjects: Array.isArray(scene.subject_refs)
           ? scene.subject_refs.map((subject) => [subject?.name, subject?.description].filter(Boolean).join(": ")).filter(Boolean).join("\n")
@@ -35784,6 +36789,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         performance_mode: String(scene.performance_mode || scene.performanceMode || segment.performance_mode || "").trim(),
         prompt_summary: String(scene.prompt_summary || scene.summary || segment.prompt_summary || segment.summary || "").trim(),
         summary: String(scene.prompt_summary || scene.summary || segment.prompt_summary || segment.summary || "").trim(),
+        audio_direction: String(scene.audio_direction || segment.audio_direction || "").trim(),
+        continuity: String(scene.continuity || scene.continuity_direction || segment.continuity || "").trim(),
+        temporal_world_effect_override: String(scene.temporal_world_effect_override || segment.temporal_world_effect_override || "global").trim(),
+        temporal_world_effect_custom: String(scene.temporal_world_effect_custom || segment.temporal_world_effect_custom || "").trim(),
       };
       const imageData = String(scene.image_data || scene.image_reference_data || "").trim();
       const imagePath = String(scene.image_path || scene.approved_image_path || "").trim();
@@ -35821,6 +36830,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           .join("\n\n");
         const mode = miniMaxH3ModeForSegment(segment);
         const modeLabel = miniMaxH3ModeLabel(mode);
+        const storyboardPlanningMode = normalizeMiniMaxShortFilmPlanningMode(
+          options.storyboardPayload?.short_film_planning_mode
+          || options.storyboardPayload?.shortFilmPlanningMode
+          || state.builderStoryboardDefaults?.short_film_planning_mode,
+        );
+        const isMiniMaxShortFilmPrompt = effectiveVideoPerformanceModeForSegment(workingSegment) === "speaking";
+        const storyboardInstructionKey = isMiniMaxShortFilmPrompt
+          ? miniMaxH3ShortFilmInstructionKey(mode, storyboardPlanningMode)
+          : miniMaxH3InstructionKey(mode);
+        const customSourceContract = storyboardPlanningMode === "fully_custom"
+          ? "FULLY CUSTOM SHORT FILM: Every populated scene-card field is authoritative. Format only what the user supplied. Do not invent, rewrite, reorder, merge, omit, or replace dialogue, speakers, story beats, actions, shot/framing, camera motion, setting, references, audio direction, sound, or continuity. Leave unspecified choices unspecified."
+          : "GUIDED SHORT FILM: Preserve exact dialogue and speaker order while using the supplied film-planning fields to stage a coherent narrative scene.";
         workingSegment.minimax_h3_mode = mode;
         workingSegment.minimax_h3_reference_keys = Array.isArray(segment.minimax_h3_reference_keys)
           ? [...segment.minimax_h3_reference_keys]
@@ -35849,19 +36870,25 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           ...textGemmaRunnerPayload(),
           project_folder: activeProjectFolderForSave(),
           scene_id: segment.id || "",
-          builder_instruction_key: miniMaxH3InstructionKey(mode),
-          model_file: visionImages.length ? i2vGemmaModelSelect.value : i2vTextGemmaModelSelect.value,
-          repair_model_file: i2vTextGemmaModelSelect.value,
-          mmproj_file: visionImages.length ? i2vMmprojSelect.value : "",
+          builder_instruction_key: storyboardInstructionKey,
+          model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
+          repair_model_file: miniMaxTextGemmaModelSelect.value,
+          mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
           t2i_prompt: miniMaxH3PromptContextForSegment(workingSegment, mode),
-          user_notes: "Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.",
+          user_notes: `Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.\n\n${customSourceContract}`,
           subject_context: workingSegment.no_character_present ? "" : segmentMappedSubjectText(workingSegment),
           location_context: segmentMappedLocationText(workingSegment),
           no_character_present: Boolean(workingSegment.no_character_present),
           image_references: visionImages,
           performance_mode: effectiveVideoPerformanceModeForSegment(workingSegment),
-          lyric_text: isInstrumentalLyricText(workingSegment.lyric_text) ? "" : flattenLyricForPrompt(workingSegment.lyric_text),
-          singers: Array.isArray(workingSegment.lyric_singers) ? workingSegment.lyric_singers : [],
+          lyric_text: segmentUsesNoLipSyncPerformance(workingSegment) || isInstrumentalLyricText(workingSegment.lyric_text) ? "" : flattenLyricForPrompt(workingSegment.lyric_text),
+          singers: segmentUsesNoLipSyncPerformance(workingSegment) ? [] : (Array.isArray(workingSegment.lyric_singers) ? workingSegment.lyric_singers : []),
+          audio_mode: miniMaxH3SettingsForSegment(workingSegment).audio_mode,
+          speaker_assignments: segmentUsesNoLipSyncPerformance(workingSegment) ? [] : miniMaxDialogueAssignmentsForSegment(workingSegment),
+          camera_motion_speed: workingSegment.camera_motion_speed,
+          camera_motion_speed_guidance: workingSegment.camera_motion_speed_guidance,
+          character_motion_speed: workingSegment.character_motion_speed,
+          character_motion_guidance: workingSegment.character_motion_guidance,
           theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
           story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
           subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
@@ -35870,8 +36897,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           top_p: 0.92,
           max_new_tokens: 4000,
         }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-        const prompt = String(data.prompt || "").trim();
-        if (!prompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
+        const generatedPrompt = String(data.prompt || "").trim();
+        if (!generatedPrompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
+        const prompt = applyMiniMaxH3NativeVoiceBlock(
+          normalizeStoryboardInputAudioVocalTimeline(
+            ensureStoryboardRequiredTemporalWorldEffect(
+              ensureStoryboardRequiredVideoStyle(generatedPrompt, options.storyboardPayload || {}),
+              options.storyboardPayload || {},
+            ),
+            workingSegment,
+          ),
+          workingSegment,
+        );
         return {
           ...data,
           prompt,
@@ -36053,6 +37090,99 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         message: `Applied ${nextSegments.length} ID-LoRA dialogue scene${nextSegments.length === 1 ? "" : "s"} to Video Builder.`,
       };
     };
+    const applyMiniMaxDialoguePlanFromStoryboard = async (updates = {}) => {
+      const scenes = Array.isArray(updates.scenes)
+        ? updates.scenes.filter((scene) => String(scene?.lyrics || scene?.story_beat || scene?.image_prompt || "").trim())
+        : [];
+      if (!scenes.length) throw new Error("No reviewed MiniMax storyboard scenes were found to create timeline segments.");
+      const hasSceneWork = (segment) => [
+        segment?.lyric_text,
+        segment?.story_beat,
+        segment?.notes,
+        segment?.i2v_notes,
+        segment?.t2i_prompt,
+        segment?.minimax_h3_prompt,
+        segment?.video_path,
+        selectedSegmentImagePath(segment),
+      ].some((value) => String(value || "").trim());
+      const currentBase = Array.isArray(state.segments) ? state.segments : [];
+      const currentOverlays = Array.isArray(state.overlaySegments) ? state.overlaySegments : [];
+      const starterIsBlank = currentBase.length <= 1 && currentOverlays.length === 0 && currentBase.every((segment) => !hasSceneWork(segment));
+      if (!starterIsBlank) {
+        const ok = window.confirm(`Create ${scenes.length} MiniMax timeline segment${scenes.length === 1 ? "" : "s"}?\n\nThis will replace the current base timeline scenes and clear insert scenes.`);
+        if (!ok) return { message: "Create MiniMax timeline segments cancelled." };
+      }
+      pushHistory();
+      const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+      refs.subject_scene_map = {};
+      refs.scene_map = {};
+      const validSubjectIds = new Set((refs.subjects || []).map((subject) => String(subject.id || "")).filter(Boolean));
+      const validLocationIds = new Set((refs.locations || []).map((location) => String(location.id || "")).filter(Boolean));
+      const nextSegments = [];
+      let cursor = 0;
+      scenes.forEach((scene, index) => {
+        const dialogue = String(scene.lyrics || scene.dialogue || scene.lyric_text || "").trim();
+        const requestedDuration = Number(scene.exact_duration || scene.duration || 0);
+        const duration = requestedDuration > 0
+          ? Math.max(1, Math.min(15, requestedDuration))
+          : Math.max(1, Math.min(15, estimateIdLoraDialogueDuration(dialogue || scene.story_beat || scene.image_prompt)));
+        const segment = ensureSegmentRuntimeFields(newSegment(cursor, cursor + duration));
+        segment.label = String(scene.label || `Scene ${index + 1}`).trim() || `Scene ${index + 1}`;
+        segment.lyric_text = dialogue;
+        segment.lyric_section = String(scene.lyric_section || "").trim();
+        segment.lyric_singers = Array.isArray(scene.lyric_singers) ? scene.lyric_singers.map(String).filter(Boolean) : [];
+        segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(scene.speaker_assignments || scene.dialogue_cues || []);
+        syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+        segment.performance_mode = "speaking";
+        segment.story_beat = String(scene.story_beat || "").trim();
+        segment.notes = String(scene.prompt_summary || scene.summary || scene.notes || scene.image_prompt || "").trim();
+        segment.i2v_notes = [scene.motion_summary, scene.character_motion, scene.camera_motion ? `Camera: ${scene.camera_motion}` : ""]
+          .map((value) => String(value || "").trim()).filter(Boolean).join("\n");
+        segment.audio_direction = String(scene.audio_direction || "").trim();
+        segment.continuity = String(scene.continuity || scene.continuity_direction || "").trim();
+        segment.minimax_h3_mode = normalizeMiniMaxH3Mode(scene.minimax_h3_mode || state.miniMaxH3Settings?.video_mode);
+        segment.facial_performance = String(scene.facial_performance || "").trim();
+        segment.facial_performance_custom = String(scene.facial_performance_custom || "").trim();
+        segment.shot_type = String(scene.shot_type || "").trim();
+        segment.camera_motion = String(scene.camera_motion || "").trim();
+        segment.character_motion = String(scene.character_motion || "").trim();
+        segment.temporal_world_effect_override = String(scene.temporal_world_effect_override || "global").trim();
+        segment.temporal_world_effect_custom = String(scene.temporal_world_effect_custom || "").trim();
+        const imagePrompt = String(scene.image_prompt || scene.t2i_prompt || "").trim();
+        if (imagePrompt) setSegmentPromptForEdit(segment, "t2i", imagePrompt);
+        const videoPrompt = String(scene.video_prompt || "").trim();
+        if (videoPrompt) {
+          segment.minimax_h3_prompt = applyMiniMaxH3NativeVoiceBlock(videoPrompt, segment);
+          segment.minimax_h3_prompt_origin = normalizeVideoPromptOrigin(scene.video_prompt_origin);
+        }
+        const subjectIds = (Array.isArray(scene.subject_refs) ? scene.subject_refs : [])
+          .map((subject) => String(subject?.id || ""))
+          .filter((id) => validSubjectIds.has(id));
+        if (subjectIds.length) refs.subject_scene_map[segment.id] = subjectIds;
+        const locationId = String(scene.location_ref?.id || scene.location_id || "").trim();
+        if (locationId && validLocationIds.has(locationId)) refs.scene_map[segment.id] = locationId;
+        nextSegments.push(segment);
+        cursor += duration;
+      });
+      state.segments = nextSegments;
+      state.overlaySegments = [];
+      state.activeId = nextSegments[0]?.id || "";
+      state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
+      state.builderStoryLayer = normalizeBuilderStoryLayer(updates.story_layer || updates.storyLayer || state.builderStoryLayer);
+      state.builderStoryboardDefaults = normalizeBuilderStoryboardDefaults({
+        ...state.builderStoryboardDefaults,
+        short_film_planning_mode: updates.short_film_planning_mode || "guided_film",
+      });
+      sortSegments(state.segments);
+      state.duration = timelineDuration();
+      ensureAllSegmentRuntimeFields();
+      syncVideoModePanel();
+      syncI2VVideoSettingsPanel();
+      syncInspector();
+      render();
+      await autoSaveSessionQuiet("MiniMax timeline segments created from storyboard");
+      return { message: `Created ${nextSegments.length} MiniMax timeline segment${nextSegments.length === 1 ? "" : "s"} from the reviewed storyboard.` };
+    };
     window.VRGDGStoryboardBuilder.open({
       projectFolder: projectInput.value || state.projectFolder || "",
       projectVideoEngine: normalizeProjectVideoEngine(state.projectVideoEngine),
@@ -36060,12 +37190,26 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       imageMode: state.imageModelMode || "zimage",
       imageModeLabel: imageModeDisplayLabel(state.imageModelMode || "zimage"),
       videoPromptType: currentVideoMode(),
+      miniMaxH3Mode: storyboardOpeningMiniMaxMode,
+      miniMaxH3AudioMode: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"
+        ? normalizeMiniMaxH3AudioMode(miniMaxH3SettingsForSegment(activeSegment()).audio_mode)
+        : "",
       performanceMode: normalizeVideoType(state.videoType),
       videoType: normalizeVideoType(state.videoType),
+      shortFilmPlanningMode: state.builderStoryboardDefaults?.short_film_planning_mode || "guided_film",
       facialPerformance: state.defaultFacialPerformance || "",
       facialPerformanceCustom: state.defaultFacialPerformanceCustom || "",
       globalConsistencyPhrase: state.builderStoryboardDefaults?.global_consistency_phrase || "",
       performanceStyle: state.builderStoryboardDefaults?.performance_style || "",
+      videoStyle: state.builderStoryboardDefaults?.video_style || "",
+      videoStyleCustom: state.builderStoryboardDefaults?.video_style_custom || "",
+      temporalWorldEffect: state.builderStoryboardDefaults?.temporal_world_effect || "",
+      temporalWorldEffectCustom: state.builderStoryboardDefaults?.temporal_world_effect_custom || "",
+      temporalAllowBackgroundExtras: state.builderStoryboardDefaults?.temporal_allow_background_extras !== false,
+      temporalBackgroundIntensity: state.builderStoryboardDefaults?.temporal_background_intensity ?? 8,
+      temporalEnvironmentTimePassage: state.builderStoryboardDefaults?.temporal_environment_time_passage !== false,
+      temporalProtectedCharacters: state.builderStoryboardDefaults?.temporal_protected_characters || "all_referenced",
+      temporalProtectedCustom: state.builderStoryboardDefaults?.temporal_protected_custom || "",
       cameraMotionSpeed: state.builderStoryboardDefaults?.camera_motion_speed ?? 4,
       characterMotionSpeed: state.builderStoryboardDefaults?.character_motion_speed ?? 4,
       motion_defaults: {
@@ -36092,6 +37236,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       onPromptsExported: applyStoryboardPrompts,
       onCreateVideoPrompt: createStoryboardVideoPromptViaBuilder,
       onApplyIdLoraDialoguePlan: applyIdLoraDialoguePlanFromStoryboard,
+      onApplyMiniMaxDialoguePlan: applyMiniMaxDialoguePlanFromStoryboard,
     }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
   }
 
@@ -36154,11 +37299,39 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (mode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
       missing.push(`${name}: MiniMax Reference to Video is set to use the scene image as its start frame, but no scene image is saved.`);
     }
-    if (mode === "reference_to_video" && !miniMaxOrderedImageReferenceItemsForSegment(segment, mode).length) {
+    const continuityMode = miniMaxH3ContinuityModeForSegment(segment);
+    const continuityReserved = miniMaxH3ContinuityReferenceReserved(segment);
+    if (continuityMode === "exact_start_frame" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+      missing.push(`${name}: choose either the scene image or the previous rendered final frame as the exact start frame, not both.`);
+    }
+    const orderedReferenceCount = miniMaxOrderedImageReferenceItemsForSegment(segment, mode).length;
+    if (orderedReferenceCount + (continuityReserved ? 1 : 0) > 9) {
+      missing.push(`${name}: MiniMax continuity needs one image slot. Remove one Reference Builder image so the total stays at nine.`);
+    }
+    if (mode === "reference_to_video" && !orderedReferenceCount && !continuityReserved) {
       missing.push(`${name}: MiniMax Reference to Video needs a start frame or at least one ordered Reference Builder image.`);
     }
     if (mode === "video_to_video" && !(segment?.minimax_h3_video_references || []).some((item) => String(item?.path || "").trim())) {
       missing.push(`${name}: MiniMax Video to Video needs at least one reference-video path.`);
+    }
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (settings.audio_mode === "built_in_audio" && effectiveVideoPerformanceModeForSegment(segment) === "speaking") {
+      const mappedSubjects = storyboardReferenceDataForSegment(segment).subject_refs || [];
+      const mappedIds = new Set(mappedSubjects.map((subject) => String(subject.id || "")).filter(Boolean));
+      const dialogueCues = miniMaxDialogueAssignmentsForSegment(segment);
+      const speakingIds = new Set(dialogueCues.map((cue) => String(cue.speaker_id || "")).filter(Boolean));
+      for (const cue of dialogueCues) {
+        if (!cue.speaker_id || !mappedIds.has(String(cue.speaker_id))) {
+          missing.push(`${name}: dialogue cue “${cue.text.slice(0, 80)}${cue.text.length > 80 ? "..." : ""}” needs a speaker currently mapped to this scene.`);
+        }
+      }
+      for (const subject of mappedSubjects) {
+        if (dialogueCues.length && !speakingIds.has(String(subject.id || ""))) continue;
+        const voice = normalizeMiniMaxH3Voice(subject.minimax_voice);
+        if (voice.preset_id.endsWith("_custom") && (!voice.preset_name || !voice.description)) {
+          missing.push(`${name}: ${subject.name || "a mapped character"}'s custom MiniMax voice needs both an exact preset name and an exact voice description in Reference Builder.`);
+        }
+      }
     }
     return missing;
   }
@@ -37130,7 +38303,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         progress,
         (value) => Math.min(93, base + (value - 90) * 0.5),
         "",
-        { preserveAudio: false, encodeCrf: POST_PROCESS_STITCH_CRF },
+        { preserveAudio: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" && miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio", encodeCrf: POST_PROCESS_STITCH_CRF },
       );
       activateSegmentVideoPath(segment, result.video_path || videoPath, result.thumbnail_path || segment.video_thumbnail_path || "");
       segment.video_cache_bust = Date.now();
@@ -37164,7 +38337,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         progress,
         (value) => Math.min(95, base + (value - 90) * 0.3),
         "",
-        { preserveAudio: false, encodeCrf: POST_PROCESS_STITCH_CRF },
+        { preserveAudio: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" && miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio", encodeCrf: POST_PROCESS_STITCH_CRF },
       );
       activateSegmentVideoPath(segment, result.video_path || videoPath, result.thumbnail_path || segment.video_thumbnail_path || "");
       segment.video_cache_bust = Date.now();
@@ -37197,7 +38370,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         progress,
         (value) => Math.min(97, base + (value - 90) * 0.4),
         "",
-        { preserveAudio: false, encodeCrf: POST_PROCESS_STITCH_CRF },
+        { preserveAudio: normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3" && miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio", encodeCrf: POST_PROCESS_STITCH_CRF },
       );
       activateSegmentVideoPath(segment, result.video_path || videoPath, result.thumbnail_path || segment.video_thumbnail_path || "");
       segment.video_cache_bust = Date.now();
@@ -37220,7 +38393,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (miniMaxProject) {
       if (!String(projectInput.value || state.projectFolder || "").trim()) missing.push("Project folder is missing.");
       scenesToRender.forEach(({ segment, index }) => {
-        if (!String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
+        if (miniMaxH3SettingsForSegment(segment).audio_mode !== "built_in_audio"
+          && !String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
           missing.push(`${sceneDisplayName(segment, index)}: MiniMax H3 needs project audio or custom scene audio.`);
         }
         missing.push(...validateMiniMaxSceneReadyForVideo(segment, index));
@@ -37277,6 +38451,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function ensureAudioOrOfferSilentTimeline(options = {}) {
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+      const targetScenes = audioFallbackTargetScenes(options);
+      if (targetScenes.length && targetScenes.every((segment) => miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio")) return true;
+    }
     if (normalizeProjectVideoEngine(state.projectVideoEngine) !== "minimax_h3" && currentVideoMode() === "id_lora") return true;
     if (currentProjectAudioPath()) return true;
     const scenes = audioFallbackTargetScenes(options);
@@ -37696,6 +38874,39 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return segment.video_path;
   }
 
+  async function prepareMiniMaxH3ContinuityReference(segment, progress = null, percent = 3, label = "MiniMax continuity") {
+    if (!segment || segmentTrack(segment) === "overlay") return null;
+    const continuityMode = miniMaxH3ContinuityModeForSegment(segment);
+    if (continuityMode === "off") return null;
+    if (continuityMode === "exact_start_frame" && segment.minimax_h3_use_scene_image_as_start_frame) {
+      throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)} cannot use both its scene image and the previous rendered final frame as the exact start frame.`);
+    }
+    const previousSegment = previousAutoChainSourceSegment(segment);
+    if (!previousSegment) return null;
+    const previousVideoPath = String(selectedSegmentVideoPath(previousSegment) || "").trim();
+    if (!previousVideoPath) {
+      progress?.set(`${label}: the previous scene has no rendered video, so this scene will render without a continuity frame.`, percent);
+      segment.minimax_h3_continuity_frame_path = "";
+      segment.minimax_h3_continuity_source_video_path = "";
+      return null;
+    }
+    const projectFolder = String(projectInput.value || state.projectFolder || "").trim();
+    if (!projectFolder) throw new Error("Project folder is missing.");
+    progress?.set(`${label}: extracting the previous scene's actual final frame...`, percent);
+    const extracted = await postJson("/vrgdg/music_builder/extract_video_final_frame", {
+      project_folder: projectFolder,
+      source_path: previousVideoPath,
+      scene_number: sceneSlotNumber(segment),
+    }, 120000);
+    const framePath = String(extracted.saved_path || "").trim();
+    if (!framePath) throw new Error("MiniMax continuity final-frame extraction did not return an image path.");
+    segment.minimax_h3_continuity_frame_path = framePath;
+    segment.minimax_h3_continuity_source_video_path = previousVideoPath;
+    segment.minimax_h3_continuity_source_scene_id = String(previousSegment.id || "");
+    segment.minimax_h3_continuity_mode_used = continuityMode;
+    return { framePath, continuityMode, previousSegment, previousVideoPath };
+  }
+
   async function renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, options = {}) {
     const progressBase = Number(options.progressBase ?? 0);
     const progressSpan = Number(options.progressSpan ?? 100);
@@ -37707,23 +38918,33 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const timelineEnd = Number(segment?.end);
     const sceneDuration = timelineEnd - timelineStart;
     const miniMaxSettings = miniMaxH3SettingsForSegment(segment);
+    const builtInAudio = miniMaxSettings.audio_mode === "built_in_audio";
     const mode = normalizeMiniMaxH3Mode(options.mode ?? miniMaxSettings.video_mode);
     if (!projectFolder) throw new Error("Save or select a project folder before rendering MiniMax H3.");
     if (!Number.isFinite(timelineStart) || !Number.isFinite(timelineEnd) || sceneDuration <= 0) {
       throw new Error(`${sceneDisplayName(segment, sceneIndex)} has invalid timeline boundaries.`);
     }
 
-    const prompt = String(
+    const continuityInput = options.continuityInput === undefined
+      ? await prepareMiniMaxH3ContinuityReference(
+        segment,
+        progress,
+        pct(3),
+        `${batchLabel}MiniMax continuity`,
+      )
+      : options.continuityInput;
+
+    let prompt = applyMiniMaxH3NativeVoiceBlock(String(
       options.prompt
       ?? (segment?.minimax_h3_prompt || segment?.i2v_prompt || "")
-    ).trim();
+    ), segment);
     if (!prompt) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a MiniMax H3 prompt.`);
 
     const sourceAudioPath = String(
       options.audioPath
       ?? (segment?.custom_audio_path || currentProjectAudioPath() || audioInput.value || "")
     ).trim();
-    if (!sourceAudioPath) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs source audio for MiniMax H3.`);
+    if (!builtInAudio && !sourceAudioPath) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs source audio for MiniMax H3.`);
     const sourceStartSeconds = Number(
       options.sourceStartSeconds
       ?? (segment?.custom_audio_path ? audioSourceStart(segment) : timelineStart)
@@ -37764,6 +38985,26 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const selectedImage = String(selectedSegmentImagePath(segment) || "").trim();
       if (selectedImage) imagePaths = [selectedImage];
     }
+    let continuityImageNumber = 0;
+    if (continuityInput?.framePath) {
+      const continuityKey = mediaPathKey(continuityInput.framePath);
+      const alreadyIncluded = imagePaths.some((path) => mediaPathKey(path) === continuityKey);
+      if (!alreadyIncluded) {
+        if (imagePaths.length >= 9) {
+          throw new Error(
+            `${sceneDisplayName(segment, sceneIndex)} has nine MiniMax image references already. `
+            + "Remove one Reference Builder image so the previous-scene continuity frame can use the reserved ninth slot."
+          );
+        }
+        imagePaths.push(continuityInput.framePath);
+      }
+      continuityImageNumber = imagePaths.findIndex((path) => mediaPathKey(path) === continuityKey) + 1;
+      segment.minimax_h3_continuity_image_number = continuityImageNumber;
+      prompt = applyMiniMaxH3ContinuityPromptBlock(prompt, segment, continuityInput, continuityImageNumber);
+    } else {
+      segment.minimax_h3_continuity_image_number = 0;
+      prompt = applyMiniMaxH3ContinuityPromptBlock(prompt, segment, null, 0);
+    }
     const rawVideoReferences = options.videoReferences
       ?? segment?.minimax_h3_video_references
       ?? segment?.minimax_video_references
@@ -37778,6 +39019,35 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (mode === "video_to_video" && !videoReferences.some((item) => String(item?.path || "").trim())) {
       throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs at least one reference video path.`);
     }
+    const orderedReferenceItems = miniMaxOrderedImageReferenceItemsForSegment(segment, mode);
+    const progressImages = imagePaths.map((path, index) => {
+      const matched = orderedReferenceItems.find((item) => mediaPathKey(item?.image?.path) === mediaPathKey(path));
+      const isContinuity = continuityImageNumber === index + 1;
+      let label = String(matched?.label || "").trim();
+      if (isContinuity) {
+        label = continuityInput?.continuityMode === "exact_start_frame"
+          ? "Previous scene final frame — exact start"
+          : "Previous scene final frame — spatial continuity";
+      } else if (!label && mode === "image_to_video" && index === 0) {
+        label = "Scene image — exact start frame";
+      }
+      return {
+        path,
+        data: String(matched?.image?.data || "").trim(),
+        label: label || String(path || "").split(/[\\/]/).pop() || "Reference",
+      };
+    });
+    const progressDialogue = miniMaxDialogueOrderText(segment);
+    const progressLyric = progressDialogue
+      || String(segment?.lyric_text || "").trim()
+      || (segmentUsesNoLipSyncPerformance(segment) ? "[No visible vocal / no lip sync]" : "");
+    progress?.setSceneDetails?.({
+      sceneLabel: sceneDisplayName(segment, sceneIndex),
+      modeLabel: `${miniMaxH3ModeLabel(mode)} · ${builtInAudio ? "Built-in MiniMax Audio" : "Input Audio"}`,
+      images: progressImages,
+      lyric: progressLyric,
+      prompt,
+    });
     const warmupFrames = Math.max(0, Math.trunc(Number(
       options.warmupFrames
       ?? miniMaxSettings.warmup_frames
@@ -37790,17 +39060,20 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     state.activeId = segment.id;
     segment.video_status = "running";
     renderList();
-    progress?.set(`${batchLabel}Preparing exact MiniMax H3 scene timing and audio...`, pct(8));
+    progress?.set(`${batchLabel}Preparing exact MiniMax H3 scene timing and ${builtInAudio ? "native audio generation" : "input audio"}...`, pct(8));
 
     try {
       const payload = {
         project_folder: projectFolder,
         scene_number: slotNumber,
-        audio_path: sourceAudioPath,
+        audio_mode: miniMaxSettings.audio_mode,
+        audio_path: builtInAudio ? "" : sourceAudioPath,
         prompt,
         timeline_start_seconds: timelineStart,
         timeline_end_seconds: timelineEnd,
-        source_start_seconds: Number.isFinite(sourceStartSeconds) ? Math.max(0, sourceStartSeconds) : timelineStart,
+        source_start_seconds: builtInAudio
+          ? timelineStart
+          : (Number.isFinite(sourceStartSeconds) ? Math.max(0, sourceStartSeconds) : timelineStart),
         pre_frames: warmupFrames,
         tail_loss_frames: cooldownFrames,
         seed: Number(options.seed ?? miniMaxSettings.seed),
@@ -37824,7 +39097,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         image_paths: imagePaths,
         video_references: videoReferences,
       };
-      if (Number.isFinite(sourceDurationSeconds) && sourceDurationSeconds > 0) {
+      if (!builtInAudio && Number.isFinite(sourceDurationSeconds) && sourceDurationSeconds > 0) {
         payload.source_duration_seconds = sourceDurationSeconds;
       }
 
@@ -37846,7 +39119,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       progress?.set(
         `${batchLabel}Queueing MiniMax H3...\n`
         + `Timeline: ${sceneDuration.toFixed(3)}s\n`
-        + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`,
+        + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`
+        + (continuityImageNumber ? `\nContinuity: ${continuityInput.continuityMode === "exact_start_frame" ? "exact start" : "spatial reference"} (Image ${continuityImageNumber})` : ""),
         pct(30),
       );
       const queued = await queueWorkflowPrompt(built.prompt);
@@ -37971,7 +39245,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         label: segment.label || `Insert ${index + 1}`,
       }));
     const globalAudioPath = currentProjectAudioPath();
-    const embeddedSceneAudioMode = (!miniMaxProject && currentVideoMode() === "id_lora") || !!options.useEmbeddedSceneAudio;
+    const miniMaxBuiltInAudioMode = miniMaxProject && baseSegments.length > 0
+      && baseSegments.every((segment) => miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio");
+    const embeddedSceneAudioMode = miniMaxBuiltInAudioMode || (!miniMaxProject && currentVideoMode() === "id_lora") || !!options.useEmbeddedSceneAudio;
     const sceneAudioMode = !embeddedSceneAudioMode && !globalAudioPath && usingSceneAudioMode();
     const audioPaths = sceneAudioMode ? baseSegments.map((segment) => String(segment.custom_audio_path || "").trim()) : [];
     const audioItems = sceneAudioMode ? baseSegments.map((segment) => ({
@@ -38144,7 +39420,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
 
     const missing = validateMiniMaxSceneReadyForVideo(segment, sceneIndex);
     if (!String(projectInput.value || state.projectFolder || "").trim()) missing.push("Project folder is missing.");
-    if (!String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
+    if (miniMaxH3SettingsForSegment(segment).audio_mode !== "built_in_audio"
+      && !String(segment.custom_audio_path || currentProjectAudioPath() || audioInput.value || "").trim()) {
       missing.push("Load global audio or add custom audio for this scene.");
     }
     if (missing.length) {
@@ -41283,6 +42560,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     try {
       const data = await postJson("/vrgdg/music_builder/new_project", {
         project_folder: projectName,
+        project_root: getPreferredProjectRoot(),
       }, 60000);
       resetProjectState(data.project_folder || "", data.session_path || "", data.srt_path || "");
       await loadGlobalModelDefaultsQuiet();
@@ -41472,6 +42750,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const data = await postJson("/vrgdg/music_builder/save_project_as", {
         source_project_folder: currentProject,
         target_project_folder: targetProject,
+        project_root: getPreferredProjectRoot(),
         audio_path: audioInput.value,
         session: currentSessionData(),
       }, 120000);
@@ -44230,6 +45509,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const data = await postJson("/vrgdg/music_builder/save_project_as", {
         source_project_folder: currentProject,
         target_project_folder: choice.target,
+        project_root: getPreferredProjectRoot(),
         audio_path: audioInput.value,
         session,
       }, 120000);
@@ -44686,14 +45966,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       if (String(settings.text_gemma_model || "").trim()) {
         t2iTextGemmaModelSelect.value = settings.text_gemma_model;
         i2vTextGemmaModelSelect.value = settings.text_gemma_model;
+        miniMaxTextGemmaModelSelect.value = settings.text_gemma_model;
       }
       if (String(settings.vision_gemma_model || "").trim()) {
         gemmaModelSelect.value = settings.vision_gemma_model;
         i2vGemmaModelSelect.value = settings.vision_gemma_model;
+        miniMaxGemmaModelSelect.value = settings.vision_gemma_model;
       }
       if (String(settings.mmproj_file || "").trim()) {
         mmprojSelect.value = settings.mmproj_file;
         i2vMmprojSelect.value = settings.mmproj_file;
+        miniMaxMmprojSelect.value = settings.mmproj_file;
       }
       syncKrea2TwoPassLlmSelectsFromShared();
       syncI2VVideoModelPickerVisibility();
@@ -44865,6 +46148,22 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         toast(String(error?.message || error), true);
         return { mapped: 0, error: String(error?.message || error) };
       }
+    };
+    chooseProjectRootButton.onclick = async () => {
+      const path = await pickPath("project_root", projectRootInput);
+      if (path) projectRootInput.value = path;
+    };
+    saveProjectRootButton.onclick = () => {
+      const root = setPreferredProjectRoot(projectRootInput.value);
+      projectRootInput.value = root;
+      toast(root
+        ? `New projects will be created under:\n${root}`
+        : "New projects will use the ComfyUI output folder.");
+    };
+    clearProjectRootButton.onclick = () => {
+      projectRootInput.value = "";
+      setPreferredProjectRoot("");
+      toast("New projects will use the ComfyUI output folder.");
     };
     const applyWizardSceneDefaultSettingsToState = (settings = {}) => {
       const cameraSpeed = Math.max(0, Math.min(10, Number(settings.cameraMotionSpeed ?? settings.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed ?? 4)));
@@ -45290,7 +46589,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           const finalizedPrompt = miniMaxProject
             ? String(data.prompt || "").trim()
             : segment ? finalizeVideoPromptDraftOnly(segment, data.prompt) : String(data.prompt || "").trim();
-          const prompt = miniMaxProject ? finalizedPrompt : applyWizardStoryboardTriggerPhrases(finalizedPrompt, scene);
+          const prompt = miniMaxProject
+            ? applyMiniMaxH3NativeVoiceBlock(finalizedPrompt, segment)
+            : applyWizardStoryboardTriggerPhrases(finalizedPrompt, scene);
           if (!prompt) throw new Error(`${scene.label || `Scene ${index + 1}`}: ${runnerGenericName} returned an empty Storyboard video prompt.`);
           if (segment) {
             if (miniMaxProject) {
@@ -45430,6 +46731,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           cameraFlow: state.builderStoryboardDefaults?.camera_flow || "balanced",
           imageShotFlow: state.builderStoryboardDefaults?.image_shot_flow || "intimate",
           imageAesthetic: state.builderStoryboardDefaults?.image_aesthetic || "",
+          videoStyle: state.builderStoryboardDefaults?.video_style || "",
+          videoStyleCustom: state.builderStoryboardDefaults?.video_style_custom || "",
+          temporalWorldEffect: state.builderStoryboardDefaults?.temporal_world_effect || "",
+          temporalWorldEffectCustom: state.builderStoryboardDefaults?.temporal_world_effect_custom || "",
+          temporalAllowBackgroundExtras: state.builderStoryboardDefaults?.temporal_allow_background_extras !== false,
+          temporalBackgroundIntensity: state.builderStoryboardDefaults?.temporal_background_intensity ?? 8,
+          temporalEnvironmentTimePassage: state.builderStoryboardDefaults?.temporal_environment_time_passage !== false,
+          temporalProtectedCharacters: state.builderStoryboardDefaults?.temporal_protected_characters || "all_referenced",
+          temporalProtectedCustom: state.builderStoryboardDefaults?.temporal_protected_custom || "",
           globalConsistencyPhrase: state.builderStoryboardDefaults?.global_consistency_phrase || "",
           performanceStyle: state.builderStoryboardDefaults?.performance_style || "",
           facialPerformance: state.defaultFacialPerformance || "",
@@ -45602,6 +46912,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     control.addEventListener("input", () => updateActiveFromInputs({ skipHistory: true }));
     control.addEventListener("change", () => updateActiveFromInputs({ skipHistory: true }));
   }
+  lyricTextInput.addEventListener("focus", pushHistory);
+  lyricTextInput.addEventListener("input", () => {
+    lyricTextInput.dataset.vrgdgUserEdited = "1";
+    updateActiveFromInputs({ skipHistory: true });
+  });
+  lyricTextInput.addEventListener("change", () => {
+    lyricTextInput.dataset.vrgdgUserEdited = "1";
+    updateActiveFromInputs({ skipHistory: true });
+  });
   freezeTimingControl.input.addEventListener("change", () => {
     pushHistory();
     state.timingFrozen = Boolean(freezeTimingControl.input.checked);
@@ -46374,7 +47693,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   loadLastProjectButton.onclick = loadLastProject;
   promptCreatorButton.onclick = confirmOpenLegacyPromptCreator;
   wizardButton.onclick = openWizardFromBuilder;
-  storyboardBuilderButton.onclick = openStoryboardBuilderFromProject;
+  storyboardBuilderButton.onclick = () => {
+    try {
+      openStoryboardBuilderFromProject();
+    } catch (error) {
+      console.error("VRGDG Storyboard Builder failed to open", error);
+      toast(`Storyboard Builder failed to open:\n${String(error?.message || error)}`, true);
+    }
+  };
   fluxReferenceBuilderButton.onclick = openReferenceBuilderTargetChooser;
   lyricMapperButton.onclick = openLyricMappingWorkflowModal;
   sendToPromptCreatorButton.onclick = sendCurrentProjectToPromptCreator;
@@ -46454,7 +47780,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   closeTimelineGapsButton.onclick = closeTimelineGapsFromMenu;
   snapSceneEdgeButton.onclick = openSnapSceneEdgeMenu;
   idLoraTrimModeButton.onclick = () => {
-    if (currentVideoMode() !== "id_lora") return;
+    const miniMaxBuiltInAudio = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"
+      && miniMaxH3SettingsForSegment(activeSegment()).audio_mode === "built_in_audio";
+    if (currentVideoMode() !== "id_lora" && !miniMaxBuiltInAudio) return;
     state.timelineTrimEditMode = !state.timelineTrimEditMode;
     if (state.timelineTrimEditMode) pauseTimelineForEditing();
     syncTimelineTrimModeButton();
@@ -47108,7 +48436,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const mmproj = data.mmproj || [];
     const validMmproj = mmproj.filter((item) => item && !/^\[No mmproj/i.test(item));
     const singleMmproj = validMmproj.length === 1 ? validMmproj[0] : "";
-    for (const select of [t2iTextGemmaModelSelect, gemmaModelSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, zEnhanceGemmaModelSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, fluxGemmaModelSelect, nbGemmaModelSelect]) {
+    for (const select of [t2iTextGemmaModelSelect, gemmaModelSelect, ernieTextGemmaModelSelect, ernieGemmaModelSelect, zEnhanceGemmaModelSelect, i2vTextGemmaModelSelect, i2vGemmaModelSelect, miniMaxTextGemmaModelSelect, miniMaxGemmaModelSelect, fluxGemmaModelSelect, nbGemmaModelSelect]) {
       select.textContent = "";
       for (const model of models) {
         const option = document.createElement("option");
@@ -47122,11 +48450,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       || models.find((model) => /supergemma/i.test(model))
       || "";
     if (preferredNonVision) {
-      for (const select of [t2iTextGemmaModelSelect, ernieTextGemmaModelSelect, i2vTextGemmaModelSelect]) {
+      for (const select of [t2iTextGemmaModelSelect, ernieTextGemmaModelSelect, i2vTextGemmaModelSelect, miniMaxTextGemmaModelSelect]) {
         select.value = preferredNonVision;
       }
     }
-    for (const select of [mmprojSelect, ernieMmprojSelect, zEnhanceMmprojSelect, i2vMmprojSelect, fluxMmprojSelect, nbMmprojSelect]) {
+    for (const select of [mmprojSelect, ernieMmprojSelect, zEnhanceMmprojSelect, i2vMmprojSelect, miniMaxMmprojSelect, fluxMmprojSelect, nbMmprojSelect]) {
       const previousValue = select.value;
       select.textContent = "";
       for (const item of mmproj) {
@@ -47141,6 +48469,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         select.value = singleMmproj;
       }
     }
+    syncMiniMaxLlmSelectsFromShared();
     syncKrea2TwoPassLlmSelectsFromShared();
   }
 
@@ -47487,6 +48816,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
   for (const control of [
     miniMaxAspectRatio,
+    miniMaxAudioMode,
+    miniMaxContinuityMode,
     miniMaxMegapixels,
     miniMaxSeed,
     miniMaxWarmupFrames,
@@ -47516,11 +48847,53 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       await autoSaveSessionQuiet(segment.use_scene_minimax_h3_settings ? "MiniMax H3 locked scene mode" : "MiniMax H3 project mode");
     };
   }
+  miniMaxAudioMode.addEventListener("change", syncMiniMaxH3Panel);
+  miniMaxContinuityMode.addEventListener("change", () => {
+    const segment = activeSegment();
+    const continuityMode = normalizeMiniMaxH3ContinuityMode(miniMaxContinuityMode.value);
+    const affectedSegments = segment?.use_scene_minimax_h3_settings
+      ? [segment]
+      : allEditableSegments().filter((item) => miniMaxH3ContinuityModeForSegment(item) === "exact_start_frame");
+    const clearedStartFrames = continuityMode === "exact_start_frame"
+      ? affectedSegments.filter((item) => item?.minimax_h3_use_scene_image_as_start_frame)
+      : [];
+    for (const item of clearedStartFrames) item.minimax_h3_use_scene_image_as_start_frame = false;
+    if (clearedStartFrames.length) {
+      miniMaxUseSceneImageAsStartFrame.input.checked = false;
+      toast(`Previous-frame exact continuation is now the sole exact start frame. Turned off the scene-image exact start-frame option for ${clearedStartFrames.length} scene${clearedStartFrames.length === 1 ? "" : "s"}.`);
+    }
+    syncMiniMaxH3Panel();
+    syncMiniMaxReferenceButtons();
+    autoSaveSessionQuiet("MiniMax H3 continuity mode changed").catch(() => null);
+  });
+  miniMaxAddSpeakerCueButton.onclick = () => {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    const speakers = miniMaxMappedSpeakersForSegment(segment);
+    if (!speakers.length) {
+      toast("Map at least one character to this scene in Reference Builder first.", true);
+      return;
+    }
+    pushHistory();
+    const cues = ensureMiniMaxSpeakerAssignments(segment, speakers);
+    const speaker = speakers[0];
+    cues.push(...normalizeMiniMaxSpeakerAssignments([{ speaker_id: speaker.id, speaker_name: speaker.name, text: "" }]));
+    segment.minimax_speaker_assignments = cues;
+    syncMiniMaxSpeakerAssignmentLegacyFields(segment);
+    renderMiniMaxSpeakerAssignmentPanel();
+    autoSaveSessionQuiet("MiniMax dialogue cue added").catch(() => null);
+  };
   miniMaxPrompt.addEventListener("input", saveMiniMaxSceneInputsFromPanel);
   miniMaxPrompt.addEventListener("change", () => autoSaveSessionQuiet("MiniMax H3 scene prompt").catch(() => null));
   miniMaxUseSceneImageAsStartFrame.input.addEventListener("change", async () => {
     const segment = requireActiveSegment();
     if (!segment) return;
+    if (miniMaxUseSceneImageAsStartFrame.input.checked
+      && normalizeMiniMaxH3ContinuityMode(miniMaxH3SettingsForSegment(segment).continuity_mode) === "exact_start_frame") {
+      miniMaxUseSceneImageAsStartFrame.input.checked = false;
+      toast("Choose either the scene image as the exact start frame or the previous rendered final frame as the exact start frame—not both.", true);
+      return;
+    }
     pushHistory();
     saveMiniMaxSceneInputsFromPanel();
     syncMiniMaxReferenceButtons();

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -161,6 +161,442 @@ function escapeHtml(text) {
     .replace(/"/g, "&quot;");
 }
 
+function storyboardScriptWordCount(value) {
+  return (String(value || "").match(/[\p{L}\p{N}'’-]+/gu) || []).length;
+}
+
+function storyboardScriptSpeakerMatchKey(value) {
+  return String(value || "")
+    .toLocaleLowerCase()
+    .replace(/[’']/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/^(?:the|a|an)\s+/, "")
+    .replace(/\s+/g, " ");
+}
+
+function suggestStoryboardScriptSpeakerMatch(speakerName, characters = []) {
+  const speakerKey = storyboardScriptSpeakerMatchKey(speakerName);
+  if (!speakerKey) return null;
+  const speakerTokens = speakerKey.split(" ").filter(Boolean);
+  const scored = (Array.isArray(characters) ? characters : []).map((character) => {
+    const characterKey = storyboardScriptSpeakerMatchKey(character?.name);
+    if (!characterKey) return null;
+    const characterTokens = characterKey.split(" ").filter(Boolean);
+    let score = 0;
+    if (speakerKey === characterKey) score = 100;
+    else if (characterKey.startsWith(`${speakerKey} `) || characterKey.endsWith(` ${speakerKey}`) || characterKey.includes(` ${speakerKey} `)) score = 85;
+    else if (speakerKey.startsWith(`${characterKey} `) || speakerKey.endsWith(` ${characterKey}`) || speakerKey.includes(` ${characterKey} `)) score = 80;
+    else if (speakerTokens.length && speakerTokens.every((token) => characterTokens.includes(token))) score = 70;
+    return score ? { character, score } : null;
+  }).filter(Boolean).sort((left, right) => right.score - left.score);
+  if (!scored.length) return null;
+  if (scored.length > 1 && scored[0].score === scored[1].score) return null;
+  return scored[0].character || null;
+}
+
+function estimateStoryboardScriptCueSeconds(text) {
+  const value = String(text || "").trim();
+  if (!value) return 0;
+  const words = storyboardScriptWordCount(value);
+  // MiniMax native dialogue tends to complete short lines faster than a measured
+  // read. Keep the planned clip close to the spoken line so the model is not
+  // given several empty seconds that it can fill with invented speech.
+  const baseSeconds = (words / 160) * 60;
+  const commaPauses = (value.match(/[,;]/g) || []).length * 0.12;
+  const strongPauses = (value.match(/[.!?](?=\s|$)/g) || []).length * 0.22;
+  const dramaticPauses = (value.match(/[—…]/g) || []).length * 0.18;
+  return Math.max(0.75, baseSeconds + commaPauses + strongPauses + dramaticPauses);
+}
+
+function splitStoryboardScriptCueForDuration(cue, maxSpeechSeconds) {
+  const text = String(cue?.text || "").trim();
+  if (!text || estimateStoryboardScriptCueSeconds(text) <= maxSpeechSeconds) {
+    return [{ ...cue, source_cue_index: Number(cue?.index || 0), part_index: 1, part_count: 1, was_split: false }];
+  }
+  const tokens = text.match(/\S+(?:\s+|$)/g) || [text];
+  const tokenCount = tokens.length;
+  const textCache = new Map();
+  const durationCache = new Map();
+  const chunkText = (start, end) => {
+    const key = `${start}:${end}`;
+    if (!textCache.has(key)) textCache.set(key, tokens.slice(start, end).join("").trim());
+    return textCache.get(key);
+  };
+  const chunkDuration = (start, end) => {
+    const key = `${start}:${end}`;
+    if (!durationCache.has(key)) durationCache.set(key, estimateStoryboardScriptCueSeconds(chunkText(start, end)));
+    return durationCache.get(key);
+  };
+  const boundaryPenalty = (end) => {
+    if (end >= tokenCount) return 0;
+    const previousToken = tokens[end - 1].trim();
+    if (/[.!?]["')\]]?$/.test(previousToken)) return 0;
+    if (/[;—…]["')\]]?$/.test(previousToken)) return 3;
+    if (/[:,]["')\]]?$/.test(previousToken)) return 12;
+    // Never favor a visually balanced split that leaves a dangling grammar word.
+    // MiniMax is much more likely to mumble or restart when a clip ends on words
+    // such as "a", "the", "and", or "to" instead of a complete spoken phrase.
+    const normalizedPrevious = previousToken.toLocaleLowerCase().replace(/[^a-z']/g, "");
+    if (/^(?:a|an|the|and|or|but|to|of|for|with|from|in|on|at|by|as|than|that|this|these|those|my|your|his|her|its|our|their)$/.test(normalizedPrevious)) return 900;
+    const nextToken = tokens[end]?.trim().toLocaleLowerCase().replace(/[^a-z']/g, "") || "";
+    if (/^(?:and|or|but|while|then)$/.test(nextToken)) return 40;
+    return 400;
+  };
+  const bestFrom = Array(tokenCount + 1).fill(null);
+  bestFrom[tokenCount] = { cost: 0, parts: [] };
+  for (let start = tokenCount - 1; start >= 0; start -= 1) {
+    let best = null;
+    for (let end = start + 1; end <= tokenCount; end += 1) {
+      const duration = chunkDuration(start, end);
+      if (duration > maxSpeechSeconds + 1e-6 && end > start + 1) break;
+      const remainder = bestFrom[end];
+      if (!remainder) continue;
+      const wordCount = storyboardScriptWordCount(chunkText(start, end));
+      const isFinalPart = end === tokenCount;
+      let shortPartPenalty = 0;
+      if (wordCount <= 1) shortPartPenalty += isFinalPart ? 300 : 100;
+      else if (wordCount === 2) shortPartPenalty += isFinalPart ? 40 : 20;
+      else if (duration < 1.25) shortPartPenalty += isFinalPart ? 25 : 12;
+      const fullness = Math.max(0, maxSpeechSeconds - duration) / Math.max(0.75, maxSpeechSeconds);
+      const balancePenalty = fullness * fullness * 3;
+      // The large per-part cost guarantees the fewest possible clips first.
+      // Within that clip count, punctuation quality, orphan avoidance, and balance decide the split.
+      const cost = 1000 + boundaryPenalty(end) + shortPartPenalty + balancePenalty + remainder.cost;
+      if (!best || cost < best.cost) {
+        best = {
+          cost,
+          parts: [chunkText(start, end), ...remainder.parts],
+        };
+      }
+    }
+    bestFrom[start] = best;
+  }
+  const parts = bestFrom[0]?.parts?.filter(Boolean) || [text];
+  return parts.map((part, index) => ({
+    ...cue,
+    text: part,
+    word_count: storyboardScriptWordCount(part),
+    source_cue_index: Number(cue?.index || 0),
+    part_index: index + 1,
+    part_count: parts.length,
+    was_split: parts.length > 1,
+  }));
+}
+
+function planStoryboardScriptScenes(cues = [], options = {}) {
+  const maxSceneSeconds = Math.max(3, Math.min(15, Number(options.max_scene_seconds || 8)));
+  const openingBuffer = 0.15;
+  const closingBuffer = 0.25;
+  const sameSpeakerGap = 0.12;
+  const speakerChangeGap = 0.2;
+  const maxSpeechSeconds = Math.max(0.75, maxSceneSeconds - openingBuffer - closingBuffer);
+  const sourceCues = Array.isArray(cues) ? cues : [];
+  const groupKeyForCue = (cue) => Number(cue?.scene_index || 0) > 0
+    ? `scene:${Number(cue.scene_index)}`
+    : String(cue?.scene_label || "").trim() ? `label:${String(cue.scene_label).trim().toLocaleLowerCase()}` : "script:1";
+  const participantsByGroup = new Map();
+  for (const cue of sourceCues) {
+    const key = groupKeyForCue(cue);
+    const participants = participantsByGroup.get(key) || new Map();
+    const participantKey = String(cue?.speaker_id || storyboardScriptSpeakerMatchKey(cue?.speaker_name || cue?.speaker));
+    if (participantKey) participants.set(participantKey, {
+      id: String(cue?.speaker_id || ""),
+      name: String(cue?.speaker_name || cue?.speaker || ""),
+      alias: String(cue?.speaker_alias || cue?.speaker || ""),
+    });
+    participantsByGroup.set(key, participants);
+  }
+  const expandedCues = sourceCues.flatMap((cue) => splitStoryboardScriptCueForDuration(cue, maxSpeechSeconds));
+  const scenes = [];
+  const warnings = [];
+  let pending = [];
+  let pendingGroupKey = "";
+  const estimatedPackedSeconds = (rows) => {
+    if (!rows.length) return 0;
+    let total = openingBuffer + closingBuffer;
+    rows.forEach((cue, index) => {
+      if (index) total += storyboardScriptSpeakerMatchKey(rows[index - 1]?.speaker) === storyboardScriptSpeakerMatchKey(cue?.speaker) ? sameSpeakerGap : speakerChangeGap;
+      total += estimateStoryboardScriptCueSeconds(cue?.text);
+    });
+    return total;
+  };
+  const flushScene = () => {
+    if (!pending.length) return;
+    let cursor = openingBuffer;
+    const timedCues = pending.map((cue, index) => {
+      if (index) cursor += storyboardScriptSpeakerMatchKey(pending[index - 1]?.speaker) === storyboardScriptSpeakerMatchKey(cue?.speaker) ? sameSpeakerGap : speakerChangeGap;
+      const startSeconds = cursor;
+      const spokenSeconds = estimateStoryboardScriptCueSeconds(cue?.text);
+      cursor += spokenSeconds;
+      return {
+        ...cue,
+        planned_start_seconds: Number(startSeconds.toFixed(2)),
+        planned_end_seconds: Number(cursor.toFixed(2)),
+        estimated_spoken_seconds: Number(spokenSeconds.toFixed(2)),
+      };
+    });
+    const rawDuration = cursor + closingBuffer;
+    const duration = Math.min(maxSceneSeconds, Math.ceil((rawDuration - 1e-6) * 10) / 10);
+    const previousScene = scenes[scenes.length - 1];
+    const timelineStartSeconds = scenes.reduce((total, scene) => total + Number(scene.duration_seconds || 0), 0);
+    const sourceCueIndexes = Array.from(new Set(timedCues.map((cue) => Number(cue.source_cue_index || cue.index || 0)).filter(Boolean)));
+    const participants = Array.from(participantsByGroup.get(pendingGroupKey)?.values() || []);
+    const sourceSceneLabel = String(timedCues[0]?.scene_label || "").trim();
+    scenes.push({
+      index: scenes.length + 1,
+      label: sourceSceneLabel || `Script Segment ${scenes.length + 1}`,
+      source_scene_index: Number(timedCues[0]?.scene_index || 0),
+      source_scene_label: sourceSceneLabel,
+      continuation_of_previous: Boolean(previousScene && previousScene.source_group_key === pendingGroupKey),
+      source_group_key: pendingGroupKey,
+      maximum_scene_seconds: maxSceneSeconds,
+      duration_seconds: Number(duration.toFixed(2)),
+      timeline_start_seconds: Number(timelineStartSeconds.toFixed(2)),
+      timeline_end_seconds: Number((timelineStartSeconds + duration).toFixed(2)),
+      estimated_dialogue_seconds: Number(timedCues.reduce((total, cue) => total + Number(cue.estimated_spoken_seconds || 0), 0).toFixed(2)),
+      source_cue_indexes: sourceCueIndexes,
+      participant_ids: participants.map((participant) => participant.id).filter(Boolean),
+      participant_names: participants.map((participant) => participant.name).filter(Boolean),
+      participants,
+      speaker_assignments: timedCues.map((cue) => ({
+        speaker_id: String(cue.speaker_id || ""),
+        speaker_name: String(cue.speaker_name || cue.speaker || ""),
+        speaker_alias: String(cue.speaker_alias || cue.speaker || ""),
+        text: String(cue.text || ""),
+        source_cue_index: Number(cue.source_cue_index || cue.index || 0),
+        part_index: Number(cue.part_index || 1),
+        part_count: Number(cue.part_count || 1),
+        planned_start_seconds: Number(cue.planned_start_seconds || 0),
+        planned_end_seconds: Number(cue.planned_end_seconds || 0),
+        estimated_spoken_seconds: Number(cue.estimated_spoken_seconds || 0),
+      })),
+    });
+    pending = [];
+  };
+  for (const cue of expandedCues) {
+    const groupKey = groupKeyForCue(cue);
+    if (pending.length && groupKey !== pendingGroupKey) flushScene();
+    pendingGroupKey = groupKey;
+    const pendingSourceCueIndex = Number(pending[0]?.source_cue_index || pending[0]?.index || 0);
+    const incomingSourceCueIndex = Number(cue?.source_cue_index || cue?.index || 0);
+    const crossesSplitCueBoundary = pending.length
+      && pendingSourceCueIndex !== incomingSourceCueIndex
+      && (pending.some((item) => item.was_split) || (cue.was_split && Number(cue.part_index || 1) > 1));
+    if (crossesSplitCueBoundary) flushScene();
+    pendingGroupKey = groupKey;
+    if (pending.length && estimatedPackedSeconds([...pending, cue]) > maxSceneSeconds + 1e-6) flushScene();
+    pendingGroupKey = groupKey;
+    pending.push(cue);
+  }
+  flushScene();
+  const splitSourceCueIndexes = Array.from(new Set(expandedCues.filter((cue) => cue.was_split).map((cue) => Number(cue.source_cue_index || 0)).filter(Boolean)));
+  if (splitSourceCueIndexes.length) warnings.push(`${splitSourceCueIndexes.length} long dialogue cue${splitSourceCueIndexes.length === 1 ? " was" : "s were"} split at natural phrase boundaries when possible to stay within ${maxSceneSeconds} seconds.`);
+  return {
+    maximum_scene_seconds: maxSceneSeconds,
+    scene_count: scenes.length,
+    split_cue_count: splitSourceCueIndexes.length,
+    estimated_total_seconds: Number(scenes.reduce((total, scene) => total + Number(scene.duration_seconds || 0), 0).toFixed(2)),
+    scenes,
+    warnings,
+  };
+}
+
+function normalizeStoryboardScriptImportState(value = {}) {
+  const source = value && typeof value === "object" ? value : {};
+  const maximumSceneSeconds = Math.max(3, Math.min(15, Number(source.maximum_scene_seconds || source.max_scene_seconds || 8) || 8));
+  const cues = (Array.isArray(source.cues) ? source.cues : []).slice(0, 1000).map((cue, index) => ({
+    index: Number(cue?.index || index + 1),
+    line_number: Number(cue?.line_number || 0),
+    scene_index: Number(cue?.scene_index || 0),
+    scene_label: String(cue?.scene_label || "").trim(),
+    speaker: String(cue?.speaker_alias || cue?.speaker || cue?.speaker_name || "").trim(),
+    speaker_alias: String(cue?.speaker_alias || cue?.speaker || cue?.speaker_name || "").trim(),
+    speaker_id: String(cue?.speaker_id || cue?.reference_subject_id || ""),
+    speaker_name: String(cue?.speaker_name || cue?.reference_subject_name || cue?.speaker || "").trim(),
+    reference_subject_id: String(cue?.reference_subject_id || cue?.speaker_id || ""),
+    reference_subject_name: String(cue?.reference_subject_name || cue?.speaker_name || "").trim(),
+    speaker_match_method: String(cue?.speaker_match_method || "manual"),
+    text: String(cue?.text || cue?.dialogue || cue?.line || "").trim(),
+    word_count: storyboardScriptWordCount(cue?.text || cue?.dialogue || cue?.line || ""),
+  })).filter((cue) => cue.speaker && cue.text);
+  const speakersByKey = new Map();
+  for (const cue of cues) {
+    const key = storyboardScriptSpeakerMatchKey(cue.speaker);
+    const existing = speakersByKey.get(key) || {
+      name: cue.speaker,
+      speaker_alias: cue.speaker,
+      cue_count: 0,
+      word_count: 0,
+      reference_subject_id: cue.reference_subject_id,
+      reference_subject_name: cue.reference_subject_name,
+      match_method: cue.reference_subject_id ? cue.speaker_match_method || "manual" : "unmatched",
+    };
+    existing.cue_count += 1;
+    existing.word_count += cue.word_count;
+    if (!existing.reference_subject_id && cue.reference_subject_id) {
+      existing.reference_subject_id = cue.reference_subject_id;
+      existing.reference_subject_name = cue.reference_subject_name;
+      existing.match_method = cue.speaker_match_method || "manual";
+    }
+    speakersByKey.set(key, existing);
+  }
+  const speakers = Array.from(speakersByKey.values());
+  const speakerMatches = speakers.map((speaker) => ({
+    speaker_alias: speaker.speaker_alias,
+    reference_subject_id: speaker.reference_subject_id,
+    reference_subject_name: speaker.reference_subject_name,
+    match_method: speaker.match_method,
+  }));
+  const scenePlan = planStoryboardScriptScenes(cues, { max_scene_seconds: maximumSceneSeconds });
+  return {
+    enabled: source.enabled !== false && cues.length > 0,
+    authoritative: source.authoritative !== false,
+    format: String(source.format || "text"),
+    raw_text: String(source.raw_text || source.rawText || ""),
+    imported_at: String(source.imported_at || source.importedAt || ""),
+    maximum_scene_seconds: maximumSceneSeconds,
+    word_count: cues.reduce((total, cue) => total + cue.word_count, 0),
+    cues,
+    speakers,
+    speaker_matches: speakerMatches,
+    unmatched_speakers: speakers.filter((speaker) => !speaker.reference_subject_id).map((speaker) => speaker.name),
+    scene_plan: scenePlan,
+  };
+}
+
+function parseStoryboardScriptImport(value) {
+  const source = String(value || "").replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+  const result = {
+    format: "text",
+    cues: [],
+    speakers: [],
+    metadata: [],
+    errors: [],
+    word_count: 0,
+    estimated_spoken_seconds: 0,
+  };
+  const speakerMap = new Map();
+  const reservedLabels = new Set(["scene", "scene label", "location", "setting", "present", "characters", "action", "camera", "audio", "audio direction", "continuity"]);
+  const addCue = (speakerValue, textValue, details = {}) => {
+    const speaker = String(speakerValue || "").trim();
+    const text = String(textValue || "").trim();
+    if (!speaker || !text) {
+      result.errors.push({
+        line_number: Number(details.line_number || 0),
+        source: String(details.source || "").trim(),
+        message: !speaker ? "Speaker name is missing." : "Dialogue text is missing.",
+      });
+      return;
+    }
+    const wordCount = storyboardScriptWordCount(text);
+    const cue = {
+      index: result.cues.length + 1,
+      line_number: Number(details.line_number || 0),
+      scene_index: Number(details.scene_index || 0),
+      scene_label: String(details.scene_label || "").trim(),
+      speaker,
+      text,
+      word_count: wordCount,
+    };
+    result.cues.push(cue);
+    const key = speaker.toLocaleLowerCase();
+    const summary = speakerMap.get(key) || { name: speaker, cue_count: 0, word_count: 0 };
+    summary.cue_count += 1;
+    summary.word_count += wordCount;
+    speakerMap.set(key, summary);
+  };
+  const parseTextLines = (textValue, details = {}) => {
+    let activeSceneLabel = String(details.scene_label || "").trim();
+    String(textValue || "").split("\n").forEach((rawLine, index) => {
+      const line = String(rawLine || "").trim();
+      if (!line) return;
+      const lineNumber = Number(details.line_offset || 0) + index + 1;
+      const match = line.match(/^([^:\n]{1,80}?)\s*:\s*(.*)$/);
+      if (!match) {
+        result.errors.push({ line_number: lineNumber, source: line, message: "Expected speaker: dialogue." });
+        return;
+      }
+      const label = String(match[1] || "").trim();
+      const text = String(match[2] || "").trim();
+      const labelKey = label.toLocaleLowerCase();
+      if (reservedLabels.has(labelKey)) {
+        result.metadata.push({ label, value: text, line_number: lineNumber });
+        if (labelKey === "scene" || labelKey === "scene label") activeSceneLabel = text;
+        return;
+      }
+      addCue(label, text, {
+        line_number: lineNumber,
+        source: line,
+        scene_index: details.scene_index,
+        scene_label: activeSceneLabel,
+      });
+    });
+  };
+  const addJsonCueRows = (rows, details = {}) => {
+    if (typeof rows === "string") {
+      parseTextLines(rows, details);
+      return;
+    }
+    if (!Array.isArray(rows)) {
+      result.errors.push({ line_number: 0, source: details.scene_label || "JSON", message: "Dialogue cues must be an array or speaker: dialogue text." });
+      return;
+    }
+    rows.forEach((item, index) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        result.errors.push({ line_number: 0, source: `JSON cue ${index + 1}`, message: "Cue must be an object with speaker and text fields." });
+        return;
+      }
+      addCue(
+        item.speaker_name || item.speaker || item.character || item.name,
+        item.text || item.dialogue || item.line,
+        {
+          source: `JSON cue ${index + 1}`,
+          scene_index: details.scene_index,
+          scene_label: details.scene_label,
+        },
+      );
+    });
+  };
+
+  const trimmed = source.trim();
+  if (!trimmed) {
+    result.errors.push({ line_number: 0, source: "", message: "Paste a script or load a .txt/.json file first." });
+    return result;
+  }
+  if (/^[\[{]/.test(trimmed)) {
+    result.format = "json";
+    try {
+      const parsed = JSON.parse(trimmed);
+      const scenes = !Array.isArray(parsed) && Array.isArray(parsed?.scenes) ? parsed.scenes : null;
+      if (scenes) {
+        scenes.forEach((scene, sceneIndex) => {
+          if (!scene || typeof scene !== "object" || Array.isArray(scene)) {
+            result.errors.push({ line_number: 0, source: `JSON scene ${sceneIndex + 1}`, message: "Scene must be an object." });
+            return;
+          }
+          const sceneLabel = String(scene.label || scene.scene_label || scene.title || `Scene ${sceneIndex + 1}`).trim();
+          const rows = scene.speaker_assignments || scene.dialogue_cues || scene.cues || scene.dialogue || [];
+          addJsonCueRows(rows, { scene_index: sceneIndex + 1, scene_label: sceneLabel });
+        });
+      } else {
+        const rows = Array.isArray(parsed)
+          ? parsed
+          : parsed?.speaker_assignments || parsed?.dialogue_cues || parsed?.cues || parsed?.dialogue;
+        addJsonCueRows(rows, {});
+      }
+    } catch (error) {
+      result.errors.push({ line_number: 0, source: "JSON", message: `Invalid JSON: ${String(error?.message || error)}` });
+    }
+  } else {
+    parseTextLines(source);
+  }
+  result.speakers = Array.from(speakerMap.values());
+  result.word_count = result.cues.reduce((total, cue) => total + Number(cue.word_count || 0), 0);
+  result.estimated_spoken_seconds = result.word_count ? (result.word_count / 145) * 60 : 0;
+  return result;
+}
+
 function makeStoryboardImageUrl(path) {
   return `/vrgdg/video_editor/image?path=${encodeURIComponent(path)}&rand=${Date.now()}`;
 }
@@ -676,6 +1112,7 @@ export const STORYBOARD_CAMERA_FLOW_PRESETS = {
   balanced: {
     label: "Balanced cinematic flow",
     description: "Alternates wide, medium, close, lateral, reveal, and reset shots without repeating inward zooms.",
+    guidance: "Use the selected starting shot as the literal first generated frame. Do not add a wider, farther-away, establishing, or full-body lead-in before it. Preserve the selected framing unless the selected camera move explicitly changes scale. Treat inward moves as rare accents, never as a default pattern.",
     sequence: [
       { shot: "wide shot", camera: "slow cinematic drift" },
       { shot: "medium close-up shot", camera: "pull back" },
@@ -687,6 +1124,23 @@ export const STORYBOARD_CAMERA_FLOW_PRESETS = {
       { shot: "intimate close-up shot", camera: "slow zoom out" },
       { shot: "over-the-shoulder shot", camera: "reveal right" },
       { shot: "full-body shot", camera: "track backward" },
+    ],
+  },
+  intimate_closeups: {
+    label: "Intimate close-ups",
+    description: "Keeps the character close and frame-filling with face, head, neck-up, chest-up, waist-up, and upper-body coverage; full-body framing is used only for a compact seated or close pose.",
+    guidance: "Keep the character close to the camera and visually dominant for the entire shot. Use only up-close face, tight headshot, neck-up, chest-up, waist-up, or tight upper-body framing. A full-body composition is allowed only when the character is seated, crouched, curled, reclining, or held in another compact pose that still fills most of the frame. Never use a wide, long, establishing, distant, small-in-frame, or far-away composition, and never pull back far enough to make the character feel remote.",
+    sequence: [
+      { shot: "up-close face shot", camera: "subtle handheld movement" },
+      { shot: "tight headshot", camera: "slow orbit left" },
+      { shot: "neck-up close-up shot", camera: "gentle lateral drift" },
+      { shot: "chest-up close-up shot", camera: "slow orbit right" },
+      { shot: "waist-up close shot", camera: "subtle handheld follow" },
+      { shot: "tight upper-body shot", camera: "gentle pan reveal" },
+      { shot: "close-framed seated full-body shot with the compact pose filling most of the frame", camera: "slow lateral drift" },
+      { shot: "intimate face close-up shot", camera: "rack focus" },
+      { shot: "chest-up portrait shot", camera: "slow tilt up" },
+      { shot: "close-framed full-body shot in a compact crouched or reclining pose that fills most of the frame", camera: "subtle orbit movement" },
     ],
   },
   music_video: {
@@ -1166,6 +1620,302 @@ export const STORYBOARD_IMAGE_AESTHETIC_PRESETS = [
   { value: "35mm_analog_film", label: "35mm analog film", description: "Film grain, practical lighting, imperfect texture, grounded color, and documentary-like realism.", prompt_guidance: "Build a 35mm analog film still with visible grain, practical lighting, imperfect surfaces, grounded color response, natural posture, textured wardrobe, shallow lens character, and a lived-in environment. Avoid glossy music-video polish unless the scene asks for it." },
 ];
 
+const MINIMAX_VIDEO_STYLE_LABELS = [
+  "Cinematic realism", "Gothic romance", "Dark fantasy", "Ethereal dreamscape", "Surrealism", "Cosmic horror",
+  "Psychological horror", "Found footage", "Analog horror", "Body horror", "Occult ritual", "Silent Hill-inspired",
+  "Cyberpunk", "Biopunk", "Dieselpunk", "Steampunk", "Post-apocalyptic", "Dystopian sci-fi", "Retro-futurism",
+  "Y2K futurism", "Vaporwave", "Synthwave", "Dreamcore", "Weirdcore", "Liminal space", "Dark academia",
+  "Cottagecore", "Fairycore", "Angelcore", "Goblincore", "Whimsigoth", "Baroque", "Rococo", "Art Nouveau",
+  "Art Deco", "Victorian gothic", "Renaissance-inspired", "Medieval fantasy", "Mythological epic", "Film noir",
+  "Neo-noir", "Expressionism", "Giallo horror", "Grindhouse", "1970s psychedelic", "1980s music video",
+  "1990s grunge", "Early-2000s pop", "Indie sleaze", "Lo-fi VHS", "Super 8 film", "Vintage Hollywood",
+  "High-fashion editorial", "Avant-garde fashion", "Runway glamour", "Luxury commercial", "Beauty campaign",
+  "Pop-star music video", "Industrial metal", "Gothic metal", "Alternative rock", "Punk rock", "Dark pop",
+  "Hyperpop", "K-pop-inspired", "R&B glamour", "Eerie claymation", "Stop-motion", "Paper-cut animation",
+  "Hand-painted animation", "Anime-inspired", "Graphic novel", "Comic-book", "Cel-shaded 3D", "Photorealistic CGI",
+  "Low-poly 3D", "Miniature diorama", "Dollhouse surrealism", "Liquid chrome", "Holographic iridescence",
+  "Neon noir", "Monochrome minimalism", "High-key white studio", "Low-key chiaroscuro", "Soft pastel",
+  "Desaturated melancholy", "Crimson-and-black", "Teal-and-orange blockbuster", "Golden-hour nostalgia",
+  "Moonlit blue", "Underwater ethereal", "Elemental fantasy", "Nature mysticism", "Apocalyptic biblical",
+  "Glitch art", "Datamosh", "CRT distortion", "Kaleidoscopic", "Double exposure", "Infrared", "Thermal vision",
+  "Fisheye distortion", "Security-camera footage", "Documentary realism", "Social-media selfie", "TikTok transformation",
+  "Dreamlike slow motion", "Frenetic montage", "One-take immersive", "Music-video performance",
+  "Narrative short film", "Movie-trailer aesthetic",
+];
+
+const MINIMAX_VIDEO_STYLE_VERBIAGE = {
+  "Cinematic realism": "Naturalistic practical lighting, restrained color grading, balanced contrast, subtle film grain, realistic skin texture, neutral tones, believable materials, and polished cinematic clarity throughout.",
+  "Gothic romance": "Deep burgundy, black, and ivory tones, soft shadows, luminous highlights, ornate details, rich velvet and lace textures, candlelit atmosphere, and melancholic visual softness throughout.",
+  "Dark fantasy": "Shadow-heavy lighting, desaturated earth tones, metallic accents, dramatic contrast, weathered textures, monumental fantasy production design, atmospheric haze, and richly cinematic grading throughout.",
+  "Ethereal dreamscape": "Pastel colors, diffused highlights, soft focus, glowing edges, translucent layers, pearlescent haze, low contrast, and weightless dreamlike beauty throughout.",
+  "Surrealism": "Unexpected proportions, distorted perspective, symbolic abstraction, unnatural colors, impossible spatial relationships, uncanny objects, and deliberately illogical dream imagery throughout.",
+  "Cosmic horror": "Near-black palettes, cold highlights, immense scale, distorted geometry, oppressive shadows, ancient textures, unsettling negative space, and incomprehensible otherworldly detail throughout.",
+  "Psychological horror": "Sickly restrained color, oppressive shadow, uneasy negative space, subtly distorted interiors, harsh practical light, clammy skin tones, ambiguous background details, and persistent visual dread throughout.",
+  "Found footage": "Authentic in-world consumer-camera imagery with practical available light, imperfect exposure, mild autofocus softness, sensor noise, compression artifacts, clipped highlights, noisy shadows, subdued color, and an unpolished documentary texture. Keep faces readable; avoid glossy grading, studio polish, pristine sharpness, and cinematic glamour.",
+  "Analog horror": "Degraded videotape imagery, faded color, tracking noise, scan lines, chromatic bleed, warped edges, crushed blacks, blown highlights, timestamp-like visual language without readable text, and ominous broadcast-era texture throughout.",
+  "Body horror": "Visceral organic textures, pallid flesh tones, wet highlights, anatomical distortion, diseased surfaces, clinical details, bruised color accents, harsh close detail, and deeply unsettling physical materiality throughout.",
+  "Occult ritual": "Candlelit darkness, ceremonial symbols, weathered stone, smoke, wax, ash, deep red and black accents, antique ritual objects, symmetrical arrangements, and secretive sacred atmosphere throughout.",
+  "Silent Hill-inspired": "Dense pale fog, rusted industrial surfaces, damp concrete, peeling walls, muted gray-green color, dirty amber light, corroded metal, abandoned spaces, and oppressive psychological decay throughout.",
+  "Cyberpunk": "Neon magenta, cyan, and electric blue light, rain-slick surfaces, holographic signage shapes without readable text, dense urban technology, reflective synthetic materials, high contrast, and gritty futuristic detail throughout.",
+  "Biopunk": "Organic technology, translucent membranes, bone-like structures, cultured tissue, surgical hardware, sickly green and amber light, wet biological surfaces, laboratory grime, and engineered-life detail throughout.",
+  "Dieselpunk": "Oil-stained metal, riveted machinery, soot, heavy industrial architecture, military-era styling, muted olive and rust colors, hard smoky light, analog gauges, and imposing mechanical detail throughout.",
+  "Steampunk": "Aged brass, copper pipes, leather, polished wood, intricate gears, Victorian tailoring, warm amber light, steam-filled atmosphere, engraved ornament, and handcrafted mechanical detail throughout.",
+  "Post-apocalyptic": "Sun-bleached ruins, scavenged materials, dust, rust, broken infrastructure, weathered clothing, harsh natural light, muted earth colors, and layered environmental decay throughout.",
+  "Dystopian sci-fi": "Monumental controlled architecture, cold gray-blue palettes, severe uniforms, sterile surfaces, surveillance motifs without readable text, stark artificial light, rigid visual order, and oppressive technological detail throughout.",
+  "Retro-futurism": "Optimistic vintage future design, chrome, molded plastic, analog controls, bold geometric forms, saturated period color, glowing panels, clean illustrative surfaces, and nostalgic speculative detail throughout.",
+  "Y2K futurism": "Glossy silver, translucent plastics, icy blue and white palettes, bubble-like interfaces without readable text, chrome accessories, soft digital glow, clean synthetic surfaces, and early-digital optimism throughout.",
+  "Vaporwave": "Pastel pink, lavender, aqua, and sunset gradients, marble surfaces, retro computer textures, classical-statue motifs, soft haze, luminous grid-like design, and nostalgic digital unreality throughout.",
+  "Synthwave": "Hot magenta, violet, and electric cyan palettes, deep black silhouettes, neon grids, glossy reflections, dramatic sunset gradients, chrome accents, and polished retro-electronic atmosphere throughout.",
+  "Dreamcore": "Soft familiar spaces, hazy pastel light, washed color, low-detail backgrounds, uncanny childhood objects, gentle bloom, empty interiors, and comforting yet disorienting dream imagery throughout.",
+  "Weirdcore": "Low-resolution digital texture, awkward cropping, mismatched color, uncanny ordinary objects, liminal interiors, crude graphic shapes without readable text, visual noise, and deliberately unsettling internet-era imagery throughout.",
+  "Liminal space": "Empty transitional architecture, fluorescent or sodium lighting, repetitive corridors, vacant rooms, muted institutional color, dated surfaces, deep vanishing points, and eerily familiar stillness throughout.",
+  "Dark academia": "Deep brown, charcoal, forest green, and oxblood tones, old books, dark wood, worn leather, classical architecture, window light, dust, tweed textures, and scholarly melancholy throughout.",
+  "Cottagecore": "Warm natural light, wildflowers, handmade fabrics, rustic wood, ceramics, baskets, soft earth colors, pastoral interiors, gentle weathering, and cozy rural detail throughout.",
+  "Fairycore": "Mossy forests, tiny flowers, luminous dust, translucent wings, dewdrops, soft green and pastel color, miniature natural details, glowing mushrooms, and delicate enchanted atmosphere throughout.",
+  "Angelcore": "Ivory and pale gold palettes, luminous white fabric, soft clouds, radiant backlight, delicate feathers, sacred ornament, pearlescent highlights, and serene celestial atmosphere throughout.",
+  "Goblincore": "Muddy greens and browns, moss, mushrooms, stones, bones, jars, tarnished trinkets, damp forest textures, cluttered natural collections, and earthy mischievous detail throughout.",
+  "Whimsigoth": "Midnight blue, plum, black, and antique gold tones, celestial patterns, velvet, candles, stained glass, ornate jewelry, mystical clutter, and romantic witchy atmosphere throughout.",
+  "Baroque": "Deep jewel tones, dramatic light and shadow, gilded ornament, rich fabric, carved architecture, elaborate decoration, painterly highlights, and theatrical seventeenth-century grandeur throughout.",
+  "Rococo": "Powder pink, pale blue, cream, and gold palettes, delicate florals, curved ornament, silk, porcelain, airy light, playful luxury, and ornate eighteenth-century elegance throughout.",
+  "Art Nouveau": "Flowing botanical lines, stained glass, wrought metal, muted jewel colors, floral ornament, organic symmetry, decorative illustration, and elegant turn-of-the-century craftsmanship throughout.",
+  "Art Deco": "Bold geometry, black and gold contrast, polished stone, lacquer, chrome, stepped forms, symmetrical ornament, rich jewel tones, and glamorous machine-age luxury throughout.",
+  "Victorian gothic": "Black lace, dark carved wood, aged stone, gaslight, heavy drapery, mourning attire, tarnished silver, deep wine tones, and haunted nineteenth-century atmosphere throughout.",
+  "Renaissance-inspired": "Warm earth pigments, rich red and blue fabric, classical architecture, fresco-like color, soft directional light, fine textile detail, balanced humanist elegance, and old-master visual richness throughout.",
+  "Medieval fantasy": "Weathered stone, timber halls, chainmail, wool, leather, heraldic color, torchlight, misty landscapes, handcrafted props, and grounded legendary-world detail throughout.",
+  "Mythological epic": "Monumental temples, heroic silhouettes, carved stone, bronze and gold accents, dramatic skies, ceremonial fabric, divine light, vast landscapes, and timeless legendary grandeur throughout.",
+  "Film noir": "High-contrast black-and-white imagery, hard key light, venetian-blind shadows, wet streets, cigarette haze, deep blacks, bright highlights, period interiors, and morally shadowed atmosphere throughout.",
+  "Neo-noir": "Deep shadows, saturated neon accents, reflective night surfaces, controlled color contrast, urban grime, practical light, smoky atmosphere, and sleek contemporary darkness throughout.",
+  "Expressionism": "Angular sets, exaggerated shadows, distorted architecture, stark color or monochrome contrast, theatrical makeup, painted surfaces, and emotionally warped visual design throughout.",
+  "Giallo horror": "Saturated red, yellow, blue, and green light, glossy black surfaces, ornate interiors, sharp shadows, glamorous styling, lurid practical effects, and stylish Italian horror atmosphere throughout.",
+  "Grindhouse": "Faded color, heavy grain, scratched film, dirty highlights, crushed shadows, cheap practical effects, lurid wardrobe, distressed print texture, and raw exploitation-era finish throughout.",
+  "1970s psychedelic": "Burnt orange, avocado, violet, and acid color, bold patterns, soft film grain, optical layering, warped graphic forms, warm haze, and richly hallucinatory period design throughout.",
+  "1980s music video": "Saturated neon color, glossy highlights, smoky studio atmosphere, dramatic backlight, bold makeup, metallic wardrobe, soft diffusion, analog video texture, and theatrical pop imagery throughout.",
+  "1990s grunge": "Muted dirty color, fluorescent interiors, distressed denim and flannel, photocopied graphic texture without readable text, harsh flash, visible grain, urban wear, and unpolished alternative-era realism throughout.",
+  "Early-2000s pop": "Glossy candy color, icy highlights, metallic accessories, low-rise era styling, bright studio surfaces, soft skin diffusion, digital-camera crispness, and playful Y2K polish throughout.",
+  "Indie sleaze": "Direct-flash nightlife imagery, blown skin highlights, deep black backgrounds, messy styling, grainy digital texture, smoky clubs, saturated accents, and deliberately careless downtown glamour throughout.",
+  "Lo-fi VHS": "Soft analog resolution, tape grain, color bleed, scan lines, tracking instability, crushed blacks, clipped whites, oversaturated consumer color, and worn home-video texture throughout.",
+  "Super 8 film": "Warm faded color, pronounced small-gauge grain, soft focus, halation, light leaks, flickering exposure texture, rounded highlights, and intimate home-movie character throughout.",
+  "Vintage Hollywood": "Elegant studio lighting, luminous skin, rich black-and-white or restrained Technicolor tones, soft diffusion, tailored wardrobe, painted-set refinement, and classic star-era glamour throughout.",
+  "High-fashion editorial": "Sculptural wardrobe, immaculate makeup, controlled color, premium fabric detail, bold graphic styling, clean luxury surfaces, precise beauty lighting, and magazine-grade visual polish throughout.",
+  "Avant-garde fashion": "Experimental silhouettes, unexpected materials, abstract makeup, severe color blocking, sculptural sets, conceptual styling, high-detail fabric texture, and art-gallery fashion imagery throughout.",
+  "Runway glamour": "Luxury garments, luminous skin, glossy hair, dramatic show lighting, polished surfaces, rich color, crisp textile detail, and elevated fashion-week spectacle throughout.",
+  "Luxury commercial": "Pristine product-grade surfaces, controlled highlights, rich neutral color, immaculate materials, elegant reflections, premium environments, clean contrast, and expensive advertising polish throughout.",
+  "Beauty campaign": "Luminous skin, refined makeup detail, soft controlled highlights, clean backgrounds, flattering color, glossy hair, delicate texture, and premium cosmetic-advertising finish throughout.",
+  "Pop-star music video": "Bold saturated color, glamorous wardrobe, luminous skin, dramatic set lighting, glossy production design, metallic accents, atmospheric haze, and polished superstar imagery throughout.",
+  "Industrial metal": "Cold steel, concrete, rust, oil, black leather, harsh white and red light, smoke, abrasive texture, heavy machinery, and severe high-contrast atmosphere throughout.",
+  "Gothic metal": "Black leather and lace, deep crimson accents, cathedral stone, silver ornament, smoke, dramatic pale skin, low-key light, and dark romantic grandeur throughout.",
+  "Alternative rock": "Lived-in rehearsal spaces, worn instruments, denim and leather, practical stage light, muted color, visible grain, textured walls, and grounded independent-band authenticity throughout.",
+  "Punk rock": "Photocopied texture without readable text, torn fabric, studs, leather, raw club interiors, harsh flash, red and black accents, grime, and confrontational DIY visual energy throughout.",
+  "Dark pop": "Deep black palettes, jewel-tone accents, glossy shadows, dramatic beauty light, surreal luxury details, refined makeup, controlled haze, and sleek ominous pop polish throughout.",
+  "Hyperpop": "Acid neon color, chrome, glossy plastic, exaggerated digital texture, candy gradients, iridescent makeup, maximal graphic detail, and intensely synthetic internet-pop imagery throughout.",
+  "K-pop-inspired": "Immaculate styling, vivid coordinated color, glossy sets, luminous skin, detailed fashion, polished hair and makeup, clean highlights, and high-budget pop perfection throughout.",
+  "R&B glamour": "Warm bronze skin tones, black and gold accents, soft practical light, satin and velvet textures, elegant interiors, luminous highlights, and intimate luxury throughout.",
+  "Eerie claymation": "Hand-sculpted clay surfaces, visible fingerprints, miniature sets, muted uncanny color, uneven handmade forms, soft practical miniature lighting, and tactile unsettling charm throughout.",
+  "Stop-motion": "Tactile handcrafted materials, miniature practical sets, visible fabrication seams, slightly stepped pose character, controlled tabletop lighting, and charming physical-animation texture throughout.",
+  "Paper-cut animation": "Layered cut-paper shapes, visible fibers, flat illustrated color, crisp silhouettes, handmade edges, shadowed paper depth, decorative patterns, and crafted collage texture throughout.",
+  "Hand-painted animation": "Visible brushwork, layered pigment, painterly backgrounds, softened outlines, rich handcrafted color, canvas or watercolor texture, and expressive illustrated detail throughout.",
+  "Anime-inspired": "Clean expressive linework, stylized facial features, cel-painted color, luminous eyes, graphic shadows, detailed illustrated backgrounds, controlled highlights, and polished animation-art finish throughout.",
+  "Graphic novel": "Bold ink lines, dramatic shadow blocks, limited accent color, textured paper, illustrated crosshatching, high contrast, and sophisticated sequential-art atmosphere throughout.",
+  "Comic-book": "Crisp outlines, saturated primary colors, halftone texture, graphic shadow shapes, stylized anatomy, printed-paper character, and energetic illustrated spectacle throughout.",
+  "Cel-shaded 3D": "Three-dimensional forms with clean graphic outlines, flat color regions, stepped shadows, controlled highlights, simplified materials, and polished illustrated-game rendering throughout.",
+  "Photorealistic CGI": "Physically accurate materials, realistic global illumination, detailed skin and hair, precise reflections, volumetric atmosphere, clean high-resolution rendering, and seamless digital realism throughout.",
+  "Low-poly 3D": "Faceted geometry, simplified forms, flat-shaded surfaces, restrained texture, clean geometric color, stylized lighting, and intentionally economical digital design throughout.",
+  "Miniature diorama": "Clearly handcrafted miniature environments, tiny scaled props, model-making textures, shallow miniature depth, painted surfaces, practical tabletop lighting, and charming physical detail throughout.",
+  "Dollhouse surrealism": "Miniature domestic rooms, toy-like furniture, porcelain or plastic textures, artificial pastel color, uncanny scale relationships, pristine tiny details, and dreamlike domestic unease throughout.",
+  "Liquid chrome": "Mirror-bright silver surfaces, fluid metallic forms, warped reflections, cool specular highlights, deep black contrast, futuristic polish, and glossy sculptural abstraction throughout.",
+  "Holographic iridescence": "Prismatic rainbow highlights, pearlescent surfaces, translucent layers, shifting cyan-magenta color, glossy reflections, soft luminous haze, and futuristic iridescent finish throughout.",
+  "Neon noir": "Near-black environments, saturated neon red, blue, and violet accents, wet reflections, hard silhouettes, smoky atmosphere, glossy urban surfaces, and brooding futuristic contrast throughout.",
+  "Monochrome minimalism": "Single-hue or black-and-white palette, clean negative space, simple materials, restrained contrast, sparse production design, precise tonal separation, and elegant visual reduction throughout.",
+  "High-key white studio": "Bright seamless white surroundings, soft wraparound light, low shadow density, clean neutral color, crisp product-grade detail, airy surfaces, and immaculate studio clarity throughout.",
+  "Low-key chiaroscuro": "Deep black shadows, narrow pools of directional light, sculpted facial highlights, rich tonal contrast, restrained color, and dramatic painterly darkness throughout.",
+  "Soft pastel": "Powder pink, pale blue, lavender, mint, and cream color, diffused light, gentle contrast, matte surfaces, delicate texture, and calm airy softness throughout.",
+  "Desaturated melancholy": "Muted color, cool gray and faded earth tones, soft overcast light, low saturation, restrained highlights, subtle grain, weathered surfaces, and quiet visual sadness throughout.",
+  "Crimson-and-black": "Dominant black surfaces with vivid crimson accents, deep shadows, hard red highlights, dark wardrobe, severe contrast, and intense graphic drama throughout.",
+  "Teal-and-orange blockbuster": "Cool teal shadows, warm amber skin and highlights, strong complementary contrast, polished surfaces, atmospheric depth, controlled saturation, and large-scale commercial cinema finish throughout.",
+  "Golden-hour nostalgia": "Warm amber sunlight, long soft shadows, gentle haze, faded earth color, glowing skin, subtle grain, sunlit dust, and tender memory-like warmth throughout.",
+  "Moonlit blue": "Deep navy and cobalt tones, cool silver highlights, soft night haze, pale skin light, subdued warm accents, dark silhouettes, and luminous nocturnal atmosphere throughout.",
+  "Underwater ethereal": "Aqua and deep blue palettes, diffused caustic light, suspended particles, translucent fabric, softened detail, pearlescent highlights, and immersive aquatic beauty throughout.",
+  "Elemental fantasy": "Visually dominant fire, water, air, earth, ice, or lightning motifs, richly textured natural materials, luminous energy, dramatic atmospheric light, and mythic environmental detail throughout.",
+  "Nature mysticism": "Ancient forests, moss, stone, roots, mist, filtered natural light, symbolic organic details, muted green and earth color, and sacred wilderness atmosphere throughout.",
+  "Apocalyptic biblical": "Monumental skies, ash and fire, stark divine light, ancient stone, distressed earth tones, ceremonial silhouettes, vast destruction, and solemn prophetic grandeur throughout.",
+  "Glitch art": "Digital fragmentation, RGB channel separation, block corruption, pixel noise, scan errors, broken color fields, displaced image sections, and deliberate electronic artifacting throughout.",
+  "Datamosh": "Compressed digital smearing, macroblock trails, color displacement, broken codec texture, fragmented silhouettes, melted pixel fields, and aggressive corrupted-video appearance throughout.",
+  "CRT distortion": "Curved glass-screen appearance, scan lines, phosphor glow, chromatic fringing, barrel distortion, soft analog resolution, bloom, static noise, and vintage monitor texture throughout.",
+  "Kaleidoscopic": "Mirrored geometric repetition, radial symmetry, jewel-like color, layered reflections, intricate patterning, luminous fragments, and hypnotic prismatic imagery throughout.",
+  "Double exposure": "Layered translucent imagery, overlapping silhouettes, blended environments, luminous tonal merging, photographic grain, controlled negative space, and poetic composite texture throughout.",
+  "Infrared": "False-color foliage, pale luminous skin, dark skies, unusual magenta or cyan tonal mapping, high contrast, bright vegetation, and uncanny infrared-photography texture throughout.",
+  "Thermal vision": "Heat-map color ranging from deep violet and blue through red, orange, yellow, and white, simplified surface detail, glowing warm bodies, and sensor-like thermal imaging throughout.",
+  "Fisheye distortion": "Pronounced barrel distortion, curved edges, expanded center perspective, compressed borders, close spatial exaggeration, and distinctive ultra-wide optical appearance throughout.",
+  "Security-camera footage": "Fixed surveillance-system image quality, high or corner-mounted viewpoint appearance, wide utilitarian lens, low resolution, digital noise, flat exposure, limited color, and institutional monitoring texture without readable overlays.",
+  "Documentary realism": "Available practical light, natural skin and material texture, restrained color, modest contrast, believable environments, subtle sensor grain, and honest unembellished observational realism throughout.",
+  "Social-media selfie": "Front-facing phone-camera appearance, close personal perspective, wide phone-lens facial character, automatic exposure, digital sharpening, casual available light, and immediate user-generated authenticity throughout.",
+  "TikTok transformation": "Bright mobile-video color, crisp phone-camera detail, bold styling contrast, clean vertical-content polish without requiring a vertical aspect ratio, beauty-filter sheen, and highly legible before-and-after visual design throughout.",
+  "Dreamlike slow motion": "Soft temporal blur, luminous highlight bloom, gentle pastel or muted color, floating particles, delicate fabric detail, low contrast, and romantic dreamlike image softness throughout.",
+  "Frenetic montage": "Punchy high-contrast imagery, varied but coordinated color treatments, bold graphic details, sharp texture changes, intense highlights, and fragmented editorial visual energy throughout.",
+  "One-take immersive": "Naturalistic spatial continuity, consistent practical lighting, coherent production design, believable environmental depth, uninterrupted visual realism, and an immediate lived-in atmosphere throughout.",
+  "Music-video performance": "Expressive stage styling, dramatic practical and colored light, atmospheric haze, polished wardrobe and makeup, rich contrast, glossy highlights, and premium performance-world production design throughout.",
+  "Narrative short film": "Grounded production design, believable wardrobe, motivated practical lighting, restrained cinematic grading, detailed environments, natural skin texture, and cohesive story-world realism throughout.",
+  "Movie-trailer aesthetic": "Large-scale cinematic contrast, dramatic skies and practical light, rich production design, deep blacks, luminous highlights, atmospheric depth, premium color grading, and event-film visual polish throughout.",
+};
+
+export const MINIMAX_VIDEO_STYLE_PRESETS = [
+  {
+    value: "",
+    label: "Default / let prompt decide",
+    description: "No additional global video aesthetic is imposed.",
+    prompt_guidance: "",
+  },
+  ...MINIMAX_VIDEO_STYLE_LABELS.map((label) => ({
+    value: label.toLowerCase().replace(/&/g, "and").replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, ""),
+    label,
+    description: `${label} visual direction for MiniMax video generation.`,
+    prompt_guidance: MINIMAX_VIDEO_STYLE_VERBIAGE[label],
+  })),
+  {
+    value: "custom",
+    label: "Custom — type exact wording",
+    description: "Use custom visual-style wording exactly as entered in every eligible prompt.",
+    prompt_guidance: "",
+  },
+];
+
+function storyboardMiniMaxVideoStylePreset(value = "") {
+  return MINIMAX_VIDEO_STYLE_PRESETS.find((item) => item.value === value) || MINIMAX_VIDEO_STYLE_PRESETS[0];
+}
+
+function storyboardMiniMaxVideoStyleVerbiage(value = "", custom = "") {
+  const preset = storyboardMiniMaxVideoStylePreset(value);
+  const direction = preset.value === "custom" ? String(custom || "").trim() : String(preset.prompt_guidance || "").trim();
+  if (!direction) return "";
+  return preset.value === "custom" ? direction : `${preset.label}: ${direction}`;
+}
+
+function storyboardSceneSupportsMiniMaxVideoStyle(scene = {}) {
+  return normalizeStoryboardProjectVideoEngine(scene.project_video_engine || scene.projectVideoEngine) === "minimax_h3"
+    && ["text_to_video", "reference_to_video"].includes(normalizeStoryboardMiniMaxH3Mode(scene.minimax_h3_mode || scene.minimaxH3Mode));
+}
+
+export const MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS = [
+  { value: "", label: "Off / natural time", description: "All people and the environment move in the same natural time." },
+  { value: "realtime_subjects_timelapse_world", label: "Real-time characters / time-lapse world", description: "Mapped characters stay natural while anonymous extras, location activity, and optional light changes race around them.", prompt_guidance: "Create a clearly separated two-speed reality: protected characters remain in natural real time while only the unprotected background world moves in smooth accelerated time-lapse." },
+  { value: "frozen_world", label: "Characters move / world frozen", description: "Protected characters move naturally through a world held almost perfectly still.", prompt_guidance: "Protected characters move naturally through a world frozen at one instant. Unprotected people, particles, vehicles, liquids, smoke, weather, and environmental motion remain suspended unless the scene explicitly releases one element." },
+  { value: "reverse_world", label: "Characters forward / world reverses", description: "Protected characters continue normally while unprotected background action runs backward.", prompt_guidance: "Protected characters move and perform forward in natural time while unprotected background people and environmental events visibly run in reverse, including recoverable spills, retracing traffic, returning debris, and reversed weather or smoke." },
+  { value: "day_night_sweep", label: "Real-time characters / day-to-night sweep", description: "Characters stay natural while daylight, shadows, windows, and practical lights rapidly change.", prompt_guidance: "Protected characters remain in natural time while the environment passes rapidly through a readable day-to-night or night-to-day cycle, with accelerated sky color, sunlight angle, shadow travel, window light, and practical lights switching on or off." },
+  { value: "seasonal_passage", label: "Real-time characters / seasons pass", description: "The location visibly crosses seasons around stable real-time characters.", prompt_guidance: "Protected characters remain in natural time while the environment transitions through accelerated seasonal change: vegetation, weather, ground cover, atmospheric color, and daylight evolve coherently without changing the characters' identities or wardrobe unless explicitly requested." },
+  { value: "crowd_flow", label: "Real-time characters / crowd river", description: "Anonymous extras stream around the referenced cast while the cast remains readable.", prompt_guidance: "Protected characters remain sharply readable in natural time while anonymous unreferenced extras flow around them as an accelerated crowd river, forming continuous directional streams without duplicating, replacing, or obscuring the protected cast." },
+  { value: "looping_background", label: "Real-time characters / looping background", description: "Background actions repeat in visible cycles while the referenced cast continues normally.", prompt_guidance: "Protected characters continue naturally while unprotected background actions repeat in deliberate seamless temporal loops. Keep each loop spatially anchored and visually distinct from the protected characters' unrepeated performance." },
+  { value: "delayed_world", label: "Characters lead / world echoes behind", description: "The environment responds a beat late, creating a temporal echo.", prompt_guidance: "Protected characters move in natural time while unprotected environmental reactions lag behind them in visible delayed echoes, as though the world responds one beat late. Preserve physical readability and avoid duplicating the protected characters." },
+  { value: "living_shadows", label: "Real-time characters / living shadows", description: "Characters remain normal while unprotected shadows move independently or at accelerated speed.", prompt_guidance: "Protected characters remain in natural time while cast shadows and environmental shadows move independently at accelerated speed, changing direction and shape without changing the protected characters' bodies, faces, or identity." },
+  { value: "reflection_delay", label: "Real-time characters / delayed reflections", description: "Mirrors and reflective surfaces lag behind the real-time cast.", prompt_guidance: "Protected characters move in natural time while their reflections and the environment's reflections respond with a deliberate temporal delay. Keep the real characters singular and stable; the delayed imagery exists only inside physically plausible reflective surfaces." },
+  { value: "gravity_separation", label: "Real-time characters / altered-gravity world", description: "The cast stays grounded while loose environmental objects behave in surreal gravity.", prompt_guidance: "Protected characters remain grounded and move in natural time while unprotected loose objects, dust, fabric scraps, droplets, leaves, and environmental debris rise, fall, or drift under visibly altered gravity." },
+  { value: "custom", label: "Custom temporal effect", description: "Use the user's exact temporal-effect wording while retaining the selected protection and extras rules." },
+];
+
+function storyboardTemporalWorldEffectPreset(value = "") {
+  return MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS.find((item) => item.value === value) || MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS[0];
+}
+
+function storyboardTemporalProtectedMode(value = "") {
+  return ["all_referenced", "lead_only", "custom"].includes(String(value || "")) ? String(value) : "all_referenced";
+}
+
+function storyboardTemporalIntensity(value = 8) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.min(10, Math.round(number))) : 8;
+}
+
+function storyboardTemporalLocationExamples(scene = {}) {
+  const location = scene.location_ref || scene.locationRef || {};
+  const context = [
+    location.name,
+    location.description,
+    scene.setting,
+    scene.location,
+    scene.story_beat,
+    scene.prompt_summary,
+  ].map((value) => String(value || "").toLowerCase()).join(" ");
+  if (/store|shop|market|liquor|grocery|retail|checkout/.test(context)) {
+    return "customers and staff crossing aisles, checkout activity, shelf restocking, changing window light, and accelerated reflections";
+  }
+  if (/kitchen|dining|restaurant|cafe|bar|diner/.test(context)) {
+    return "location-appropriate patrons or household activity, staff movement, changing practical light, drifting steam, and accelerated shadows";
+  }
+  if (/street|road|alley|sidewalk|parking|overpass|city|urban/.test(context)) {
+    return "pedestrians, passing traffic, moving reflections, changing signs or practical lights, fast clouds, and traveling shadows";
+  }
+  if (/laundromat|laundry/.test(context)) {
+    return "customers cycling through the room, spinning machines, baskets changing position, shifting fluorescent light, and window reflections";
+  }
+  if (/bedroom|apartment|living room|house|home|hallway|corridor|stair/.test(context)) {
+    return "location-appropriate household or neighbor activity, rapidly shifting window light, traveling shadows, changing practical lights, weather, and moving reflections";
+  }
+  if (/forest|woods|field|garden|park|outdoor|beach|mountain/.test(context)) {
+    return "location-appropriate passersby when permitted, fast clouds, traveling sunlight or moonlight, moving shadows, weather, vegetation, smoke, and airborne particles";
+  }
+  return "location-appropriate anonymous activity when permitted, changing light and shadows, weather, traffic or reflections, smoke, particles, and moving environmental details";
+}
+
+function storyboardTemporalWorldEffectForScene(scene = {}, state = {}) {
+  const override = String(scene.temporal_world_effect_override || scene.temporalWorldEffectOverride || "global").trim();
+  const globalKey = String(state.temporalWorldEffect || state.temporal_world_effect || "").trim();
+  const key = override === "off" ? "" : (override && override !== "global" ? override : globalKey);
+  const preset = storyboardTemporalWorldEffectPreset(key);
+  const custom = String(
+    key === "custom" && override && override !== "global"
+      ? (scene.temporal_world_effect_custom || scene.temporalWorldEffectCustom || "")
+      : (state.temporalWorldEffectCustom || state.temporal_world_effect_custom || ""),
+  ).trim();
+  const baseDirection = key === "custom" ? custom : String(preset.prompt_guidance || "").trim();
+  if (!key || !baseDirection) return null;
+
+  const protectedMode = storyboardTemporalProtectedMode(state.temporalProtectedCharacters || state.temporal_protected_characters);
+  const protectedCustom = String(state.temporalProtectedCustom || state.temporal_protected_custom || "").trim();
+  const protectedDirection = protectedMode === "lead_only"
+    ? "Protect only the first mapped/reference character at natural 1x real-time speed; other mapped characters may receive the selected temporal effect."
+    : protectedMode === "custom" && protectedCustom
+      ? `Protect only these named mapped/reference characters at natural 1x real-time speed: ${protectedCustom}.`
+      : "Protect every mapped/reference character in the scene at natural 1x real-time speed, including secondary referenced characters. Never accelerate, freeze, reverse, echo, duplicate, or temporally distort any protected character.";
+  const allowExtras = state.temporalAllowBackgroundExtras !== false && state.temporal_allow_background_extras !== false;
+  const extrasDirection = allowExtras
+    ? "Anonymous unreferenced background extras are allowed. Infer only extras that naturally belong in the mapped location—for example customers or staff in a store, family or household activity in a kitchen, and pedestrians or traffic on a street. Keep them clearly secondary; never turn an extra into a principal character or duplicate a mapped/reference character."
+    : "Do not add anonymous background people. Apply the temporal effect only to existing unprotected scene elements and the environment.";
+  const environmentTimePassage = state.temporalEnvironmentTimePassage !== false && state.temporal_environment_time_passage !== false;
+  const environmentDirection = environmentTimePassage
+    ? "Environmental time passage is enabled: when appropriate, accelerate or transform daylight, shadows, practical lighting, weather, traffic, smoke, particles, and location activity while preserving spatial continuity."
+    : "Do not add a day/night, lighting, weather, or seasonal time passage unless the scene notes explicitly request it.";
+  const intensity = storyboardTemporalIntensity(state.temporalBackgroundIntensity ?? state.temporal_background_intensity ?? 8);
+  const intensityDirection = intensity <= 3
+    ? `Use a subtle ${intensity}/10 background-effect intensity with restrained, readable temporal separation.`
+    : intensity <= 6
+      ? `Use a clear ${intensity}/10 background-effect intensity that is immediately visible but does not overpower the protected characters.`
+      : intensity <= 8
+        ? `Use a strong ${intensity}/10 background-effect intensity with unmistakable temporal separation while keeping protected faces and actions readable.`
+        : `Use an extreme ${intensity}/10 background-effect intensity with dramatic temporal contrast, while protected characters remain stable, singular, and readable.`;
+  const audioDirection = "Temporal speed separation is visual only. Keep supplied or generated dialogue, singing, lip sync, facial timing, and primary audio at normal speed; never time-stretch, reverse, or accelerate protected voices.";
+  const locationExamples = storyboardTemporalLocationExamples(scene);
+  const cueCount = intensity >= 9 ? "at least two concrete, clearly visible effect cues" : "at least one concrete, clearly visible effect cue";
+  const stagingRequirement = `TIMESTAMP STAGING REQUIREMENT: Every timestamp block must actively show ${cueCount} affecting only the unprotected background/world while protected characters continue at natural 1x speed. Use the mapped location to choose actions such as ${locationExamples}. At intensity 7 or higher, subtle flicker, ambience, drifting particles, or a vague mention of time passage alone does not satisfy this requirement. The temporal contrast must be immediately visible in the action itself. Any phrase such as “no people” inside a location-reference description describes only the source image and does not prohibit anonymous background extras when this contract permits them.`;
+  const timestampAction = `Visibly enact this temporal layer at ${intensity}/10: ${baseDirection} Use concrete location-appropriate activity such as ${locationExamples}. Protected mapped/reference characters remain singular and move at natural 1x speed; only the permitted unprotected background/world receives the effect.`;
+  const continuityRequirement = allowExtras
+    ? "CONTINUITY RULE: Do not add any new named, principal, mapped, or referenced characters. Anonymous unreferenced background extras are explicitly permitted and must remain secondary and subject to the selected temporal effect; never prohibit them with a generic ‘no new characters’ or ‘no people’ rule."
+    : "CONTINUITY RULE: Do not add new named, mapped, referenced, principal, or anonymous characters.";
+  const verbiage = `TEMPORAL / WORLD EFFECT — ${preset.label}: ${baseDirection} ${protectedDirection} ${extrasDirection} ${environmentDirection} ${intensityDirection} ${audioDirection} ${stagingRequirement} ${continuityRequirement}`;
+  return {
+    enabled: true,
+    key,
+    label: preset.label,
+    exact_verbiage: verbiage,
+    protected_characters: protectedMode,
+    protected_custom: protectedCustom,
+    allow_background_extras: allowExtras,
+    background_intensity: intensity,
+    environment_time_passage: environmentTimePassage,
+    timestamp_staging_requirement: stagingRequirement,
+    timestamp_action: timestampAction,
+    continuity_requirement: continuityRequirement,
+  };
+}
+
 export const ID_LORA_IMAGE_AESTHETIC_PRESETS = [
   { value: "film_default", label: "Default film still", description: "Balanced short-film still lighting, believable production design, natural texture, and cinematic composition.", prompt_guidance: "Build a polished short-film still, not a music-video still. Use believable character blocking, grounded wardrobe, practical lighting, lens/framing detail, textured production design, natural color contrast, and emotionally readable composition." },
   { value: "indie_film_naturalism", label: "Indie film naturalism", description: "Naturalistic indie-drama still with lived-in details, imperfect realism, and intimate character focus.", prompt_guidance: "Build an indie-film still with naturalistic lighting, lived-in wardrobe, imperfect textures, believable posture, intimate framing, subtle emotional detail, muted color response, and environment details that feel observed rather than staged." },
@@ -1245,6 +1995,7 @@ function normalizeReferenceBuilderCatalog(value = {}) {
       id: String(item.id || `subject_${index + 1}`),
       name: String(item.name || `Character ${index + 1}`),
       description: String(item.description || ""),
+      minimax_voice: item.minimax_voice && typeof item.minimax_voice === "object" ? { ...item.minimax_voice } : {},
       trigger_phrase: String(item.trigger_phrase || item.trigger || item.Trigger || ""),
       trigger_position: String(item.trigger_position || item.triggerPosition || item.trigger_placement || "start") === "end" ? "end" : "start",
       extra_reference_for: String(item.extra_reference_for || item.extraReferenceFor || item.same_subject_as || item.sameSubjectAs || ""),
@@ -1340,6 +2091,28 @@ function normalizeStoryboardMiniMaxH3Mode(value = "") {
     : "text_to_video";
 }
 
+function normalizeStoryboardMiniMaxH3AudioMode(value = "") {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return ["built_in_audio", "native_audio", "generated_audio"].includes(clean) ? "built_in_audio" : "input_audio";
+}
+
+function normalizeStoryboardShortFilmPlanningMode(value = "") {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return clean === "fully_custom" || clean === "custom" ? "fully_custom" : "guided_film";
+}
+
+function normalizeStoryboardSpeakerAssignments(value = []) {
+  return (Array.isArray(value) ? value : [])
+    .filter((item) => item && typeof item === "object")
+    .map((item, index) => ({
+      id: String(item.id || item.cue_id || item.cueId || `speaker_cue_${Date.now()}_${index}_${Math.floor(Math.random() * 10000)}`),
+      speaker_id: String(item.speaker_id || item.speakerId || item.subject_id || item.subjectId || ""),
+      speaker_name: String(item.speaker_name || item.speakerName || item.speaker || item.character || "").trim(),
+      text: String(item.text || item.dialogue || item.line || item.lyric || "").trim(),
+    }))
+    .slice(0, 40);
+}
+
 function storyboardStillFacialDirection(value = "") {
   return String(value || "")
     .replace(/\bsubtle natural eye movement\b/gi, "clear eye direction")
@@ -1388,6 +2161,7 @@ function normalizeScene(scene = {}, index = 0) {
     flf_carry_forward: scene.flf_carry_forward || scene.carry_forward_state || "",
     performance_mode: normalizeStoryboardPerformanceMode(scene.performance_mode || scene.performanceMode || scene.video_performance_mode || scene.videoPerformanceMode),
     lyric_singers: lyricSingers,
+    speaker_assignments: normalizeStoryboardSpeakerAssignments(scene.speaker_assignments || scene.minimax_speaker_assignments || scene.dialogue_cues),
     lyric_no_lip_sync: lyricNoLipSync,
     lyric_instrumental: lyricInstrumental,
     no_character_present: noCharacterPresent,
@@ -1402,6 +2176,11 @@ function normalizeScene(scene = {}, index = 0) {
     video_prompt_type: videoPromptType,
     project_video_engine: normalizeStoryboardProjectVideoEngine(scene.project_video_engine || scene.projectVideoEngine),
     minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(scene.minimax_h3_mode || scene.minimaxH3Mode),
+    minimax_h3_audio_mode: normalizeStoryboardMiniMaxH3AudioMode(scene.minimax_h3_audio_mode || scene.minimaxH3AudioMode),
+    video_style: String(scene.video_style || scene.videoStyle || ""),
+    video_style_custom: String(scene.video_style_custom || scene.videoStyleCustom || ""),
+    temporal_world_effect_override: String(scene.temporal_world_effect_override || scene.temporalWorldEffectOverride || "global"),
+    temporal_world_effect_custom: String(scene.temporal_world_effect_custom || scene.temporalWorldEffectCustom || ""),
     timeline_start: Number(scene.timeline_start ?? scene.start ?? 0),
     timeline_end: Number(scene.timeline_end ?? scene.end ?? 0),
     exact_duration: Math.max(0, Number(scene.exact_duration ?? scene.duration ?? 0)),
@@ -1419,6 +2198,8 @@ function normalizeScene(scene = {}, index = 0) {
     image_path: scene.image_path || scene.approved_image_path || "",
     image_data: scene.image_data || scene.image_reference_data || "",
     notes: scene.notes || "",
+    audio_direction: scene.audio_direction || scene.audioDirection || "",
+    continuity: scene.continuity || scene.continuity_direction || scene.continuityDirection || "",
     id_lora_character_id: scene.id_lora_character_id || scene.character_id || scene.subject_id || "",
     id_lora_location_id: scene.id_lora_location_id || scene.location_id || "",
   };
@@ -1478,6 +2259,7 @@ function scenesFromBuilderPayload(payload = {}) {
     flf_carry_forward: scene.flf_carry_forward || scene.carry_forward_state || "",
     performance_mode: scene.performance_mode || scene.performanceMode || payload.performance_mode || payload.performanceMode || "",
     lyric_singers: scene.lyric_singers || scene.singers || [],
+    speaker_assignments: scene.speaker_assignments || scene.minimax_speaker_assignments || scene.dialogue_cues || [],
     lyric_no_lip_sync: Boolean(scene.lyric_no_lip_sync || scene.no_lip_sync),
     lyric_instrumental: Boolean(scene.lyric_instrumental || scene.instrumental),
     no_character_present: Boolean(scene.no_character_present || scene.noCharacterPresent || scene.no_subject || scene.no_visible_subject),
@@ -1489,6 +2271,11 @@ function scenesFromBuilderPayload(payload = {}) {
     location_ref: scene.location_ref || null,
     project_video_engine: scene.project_video_engine || scene.projectVideoEngine || payload.project_video_engine || payload.projectVideoEngine || "",
     minimax_h3_mode: scene.minimax_h3_mode || scene.minimaxH3Mode || "",
+    minimax_h3_audio_mode: scene.minimax_h3_audio_mode || scene.minimaxH3AudioMode || payload.minimax_h3_audio_mode || payload.miniMaxH3AudioMode || "",
+    video_style: scene.video_style || scene.videoStyle || "",
+    video_style_custom: scene.video_style_custom || scene.videoStyleCustom || "",
+    temporal_world_effect_override: scene.temporal_world_effect_override || scene.temporalWorldEffectOverride || "global",
+    temporal_world_effect_custom: scene.temporal_world_effect_custom || scene.temporalWorldEffectCustom || "",
     timeline_start: scene.timeline_start ?? scene.start ?? 0,
     timeline_end: scene.timeline_end ?? scene.end ?? 0,
     exact_duration: scene.exact_duration ?? scene.duration ?? 0,
@@ -1506,6 +2293,8 @@ function scenesFromBuilderPayload(payload = {}) {
     image_path: scene.image_path || scene.approved_image_path || "",
     image_data: scene.image_data || scene.image_reference_data || "",
     notes: scene.notes || "",
+    audio_direction: scene.audio_direction || "",
+    continuity: scene.continuity || scene.continuity_direction || "",
   }, index));
 }
 
@@ -1573,6 +2362,7 @@ function slimReferenceForRequest(ref) {
     id: String(ref.id || ""),
     name: String(ref.name || ""),
     description: String(ref.description || ""),
+    minimax_voice: ref.minimax_voice && typeof ref.minimax_voice === "object" ? { ...ref.minimax_voice } : {},
     trigger_phrase: String(ref.trigger_phrase || ref.trigger || ref.Trigger || ""),
     trigger_position: String(ref.trigger_position || ref.triggerPosition || ref.trigger_placement || "start") === "end" ? "end" : "start",
     image: {
@@ -1641,25 +2431,52 @@ function storyboardSpeedGuidance(value, kind = "motion") {
   return `Character motion speed ${speed}/10: fast action character movement; require clear full-body action such as sprinting, explosive dance, striding, sharp turns, crossing the space, chase/action beats, rapid direction changes, forceful gestures, or intense physical set interaction when it fits the scene. Avoid only poised, still, standing, subtle, quiet, steady, or restrained body language.`;
 }
 
+function storyboardCameraMotionForSpeed(value, speedValue) {
+  let motion = String(value || "").trim();
+  const speed = storyboardSpeedValue(speedValue, 4);
+  if (!motion || speed < 7) return motion;
+  return motion
+    .replace(/\bslow cinematic drift\b/gi, "energetic cinematic tracking drift")
+    .replace(/\bslow orbit\b/gi, "energetic orbit")
+    .replace(/\bslow (left|right) orbit\b/gi, "energetic $1 orbit")
+    .replace(/\bslow zoom out\b/gi, "brisk pull-back reveal")
+    .replace(/\bslow (left|right|side|lateral) drift\b/gi, "brisk $1 tracking drift")
+    .replace(/\bslow (pan|tilt|track|tracking|pull[ -]?back|drift)\b/gi, "brisk $1")
+    .replace(/\bgentle lateral drift\b/gi, "energetic lateral tracking")
+    .replace(/\bgentle pan reveal\b/gi, "brisk pan reveal")
+    .replace(/\bgentle (pan|tilt|orbit|drift|camera movement)\b/gi, "brisk $1")
+    .replace(/\bsubtle handheld movement\b/gi, "active handheld tracking")
+    .replace(/\bsubtle handheld camera\b/gi, "active handheld camera")
+    .replace(/\bsubtle handheld follow\b/gi, "energetic handheld follow")
+    .replace(/\bsubtle rack focus\b/gi, "quick rack focus")
+    .replace(/\bsubtle energetic orbit\b/gi, "energetic orbit")
+    .replace(/\bsubtle settling pause\b/gi, "active reframing beat")
+    .replace(/\bsubtle orbit movement\b/gi, "energetic orbit movement")
+    .replace(/\b(?:quiet handheld hold|locked-off reaction hold|locked-off shot)\b/gi, "active handheld reaction tracking")
+    .replace(/\brestrained pan\b/gi, "brisk pan")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
 function enforceHighMotionPromptLanguage(prompt, scene = {}, state = {}) {
   let text = String(prompt || "").trim();
   if (!text) return text;
   const cameraSpeed = storyboardSpeedValue(scene.camera_motion_speed ?? scene.cameraMotionSpeed ?? state.cameraMotionSpeed, 4);
   const characterSpeed = storyboardSpeedValue(scene.character_motion_speed ?? scene.characterMotionSpeed ?? state.characterMotionSpeed, 4);
-  if (cameraSpeed >= 9) {
-    text = text
+  if (cameraSpeed >= 7) {
+    text = storyboardCameraMotionForSpeed(text, cameraSpeed)
       .replace(/\bthen\s+holds?\s+on\b/gi, "then continues moving across")
       .replace(/\bthen\s+holds?\b/gi, "then continues moving")
       .replace(/\bsettles?\s+into\s+a\s+(?:static\s+|steady\s+)?hold\b/gi, "flows into another coordinated camera move")
       .replace(/\b(?:static|steady)\s+hold\b/gi, "continued camera motion")
       .replace(/\bholds?\s+on\s+her\s+steady,\s*powerful\s+gaze\b/gi, "tracks her powerful gaze while the camera keeps moving")
       .replace(/\bholds?\s+on\s+(his|her|their|the)\s+([^,.]+)\b/gi, "keeps moving around $1 $2");
-    if (!/\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|push|dolly|handheld|reveal)\b.*\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|push|dolly|handheld|reveal)\b/i.test(text)) {
+    if (!/\b(?:tracking|orbit|whip pan|pan|tilt|crane|pullback|pull-back|push|dolly|handheld|reveal)\b/i.test(text)) {
       text = text.replace(/\.+\s*$/, "");
-      text += ", with the camera chaining multiple readable moves instead of stopping on a hold.";
+      text += ", with energetic camera tracking that keeps moving instead of settling into a static hold.";
     }
   }
-  if (characterSpeed >= 9) {
+  if (characterSpeed >= 4) {
     text = text
       .replace(/\bmoves?\s+with\s+a\s+quiet,\s*poised\s+authority\b/gi, "moves with forceful, physically active authority")
       .replace(/\bmoves?\s+with\s+quiet,\s*poised\s+authority\b/gi, "moves with forceful, physically active authority")
@@ -1669,9 +2486,9 @@ function enforceHighMotionPromptLanguage(prompt, scene = {}, state = {}) {
       .replace(/\bpoised\s+posture\b/gi, "active, commanding posture")
       .replace(/\bsubtle\s+body\s+motion\b/gi, "clear full-body movement")
       .replace(/\bstands?\s+still\b/gi, "moves through the space");
-    if (!/\b(?:strides?|runs?|sprints?|dances?|turns?|crosses?|lunges?|reaches?|pushes?|pulls?|climbs?|fights?|brushing|sweeping|gestures?)\b/i.test(text)) {
+    if (!/\b(?:walks?|steps?|strides?|runs?|sprints?|dances?|crosses?|lunges?|reaches?|pushes?|pulls?|climbs?|fights?|brushes?|sweeps?|gestures?|interacts?|grabs?|lifts?|paces?)\b/i.test(text)) {
       text = text.replace(/\.+\s*$/, "");
-      text += ", while the subject performs clear full-body movement through the set.";
+      text += ", while the subject performs a clear physical action with the body, hands, or surrounding set instead of relying on facial movement alone.";
     }
   }
   return text.replace(/\s{2,}/g, " ").trim();
@@ -1693,9 +2510,19 @@ function slimStoryboardForRequest(state) {
     mode: state.mode,
     project_video_engine: normalizeStoryboardProjectVideoEngine(state.projectVideoEngine),
     performance_mode: normalizeStoryboardPerformanceMode(state.performanceMode || state.performance_mode),
+    short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
     camera_flow: state.cameraFlow || "balanced",
     image_shot_flow: state.imageShotFlow || "intimate",
     image_aesthetic: state.imageAesthetic || "",
+    video_style: state.videoStyle || "",
+    video_style_custom: state.videoStyleCustom || "",
+    temporal_world_effect: state.temporalWorldEffect || "",
+    temporal_world_effect_custom: state.temporalWorldEffectCustom || "",
+    temporal_allow_background_extras: state.temporalAllowBackgroundExtras !== false,
+    temporal_background_intensity: storyboardTemporalIntensity(state.temporalBackgroundIntensity),
+    temporal_environment_time_passage: state.temporalEnvironmentTimePassage !== false,
+    temporal_protected_characters: storyboardTemporalProtectedMode(state.temporalProtectedCharacters),
+    temporal_protected_custom: state.temporalProtectedCustom || "",
     global_consistency_phrase: state.globalConsistencyPhrase || "",
     camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
     character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
@@ -1703,6 +2530,7 @@ function slimStoryboardForRequest(state) {
     facial_performance_default: state.facialPerformance || "",
     facial_performance_custom_default: state.facialPerformanceCustom || "",
     story_layer: normalizeStoryLayer(state.storyLayer),
+    script_import: normalizeStoryboardScriptImportState(state.scriptImport),
     reference_builder: {
       subjects: (state.referenceBuilder?.subjects || []).map(slimReferenceForRequest).filter(Boolean),
       locations: (state.referenceBuilder?.locations || []).map(slimReferenceForRequest).filter(Boolean),
@@ -1755,33 +2583,58 @@ function storyboardStartingShotInstruction(shotType) {
   const shot = String(shotType || "").trim();
   if (!shot) return "";
   if (shot.toLowerCase() === "eyes shot") {
-    return "Begin the final video prompt with an explicit sentence stating that the video begins with an extreme close-up of the subject's eyes. The selected camera motion must begin from that opening framing.";
+    return "The literal first generated frame must already be an extreme close-up of the subject's eyes. Do not use a wider or farther-away lead-in. The selected camera motion must begin from that opening framing.";
   }
-  return `Begin the final video prompt with an explicit sentence stating that the video begins with a ${shot}. The selected camera motion must begin from that opening framing.`;
+  return `The literal first generated frame must already be a ${shot}. Do not use a wider, farther-away, establishing, or full-body lead-in before reaching that framing. The selected camera motion must begin from that opening framing.`;
 }
 
 function storyboardScenesForGpt(state) {
   const imageMode = state.mode !== "image_to_video_prep";
   const idLoraMode = String(state.videoPromptType || state.video_prompt_type || "").trim() === "id_lora"
     || state.scenes.some((scene) => String(scene?.video_prompt_type || "").trim() === "id_lora");
-  const performancePresets = idLoraMode ? ID_LORA_PERFORMANCE_STYLE_PRESETS : PERFORMANCE_STYLE_PRESETS;
-  const facialPresets = idLoraMode ? ID_LORA_FACIAL_PERFORMANCE_PRESETS : FACIAL_PERFORMANCE_PRESETS;
+  const miniMaxShortFilmMode = normalizeStoryboardProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"
+    && normalizeStoryboardPerformanceMode(state.performanceMode || state.performance_mode) === "speaking";
+  const filmPlanningProfile = idLoraMode || miniMaxShortFilmMode;
+  const fullyCustomShortFilm = miniMaxShortFilmMode
+    && normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode) === "fully_custom";
+  const performancePresets = filmPlanningProfile ? ID_LORA_PERFORMANCE_STYLE_PRESETS : PERFORMANCE_STYLE_PRESETS;
+  const facialPresets = filmPlanningProfile ? ID_LORA_FACIAL_PERFORMANCE_PRESETS : FACIAL_PERFORMANCE_PRESETS;
   const performancePreset = (value = "") => performancePresets.find((item) => item.value === value) || performancePresets[0] || PERFORMANCE_STYLE_PRESETS[0];
   const facialPresetForPayload = (value = "") => facialPresets.find((item) => item.value === value) || facialPresets[0] || FACIAL_PERFORMANCE_PRESETS[0];
+  const cameraFlowKey = STORYBOARD_CAMERA_FLOW_PRESETS[state.cameraFlow] ? state.cameraFlow : "balanced";
+  const cameraFlowPreset = STORYBOARD_CAMERA_FLOW_PRESETS[cameraFlowKey];
+  const explicitLyricSections = state.scenes.map((scene, index) => String(normalizeScene(scene, index).lyric_section || "").trim());
+  const effectiveLyricSection = (index) => {
+    if (explicitLyricSections[index]) return explicitLyricSections[index];
+    for (let next = index + 1; next < explicitLyricSections.length; next += 1) {
+      if (explicitLyricSections[next]) return explicitLyricSections[next];
+    }
+    for (let previous = index - 1; previous >= 0; previous -= 1) {
+      if (explicitLyricSections[previous]) return explicitLyricSections[previous];
+    }
+    return "";
+  };
   let previousCameraMotion = "";
   return state.scenes.map((scene, index) => {
     const normalized = normalizeScene(scene, index);
+    const lyricSection = effectiveLyricSection(index);
+    if (!explicitLyricSections[index] && lyricSection && scene && typeof scene === "object") {
+      scene.lyric_section = lyricSection;
+    }
     const sceneNumberIndex = Math.max(0, Number(normalized.scene_number || index + 1) - 1);
-    const cameraFallback = storyboardCameraFlowEntry(state.cameraFlow || "balanced", sceneNumberIndex, previousCameraMotion);
+    const cameraFallback = fullyCustomShortFilm ? null : storyboardCameraFlowEntry(state.cameraFlow || "balanced", sceneNumberIndex, previousCameraMotion);
     const shotType = normalized.shot_type || cameraFallback?.shot || "";
     const requiresStartingShot = !imageMode && normalized.video_prompt_type !== "i2v" && Boolean(shotType);
-    const cameraMotion = normalized.camera_motion || (imageMode ? "" : cameraFallback?.camera) || "";
+    const rawCameraMotion = normalized.camera_motion || (imageMode ? "" : cameraFallback?.camera) || "";
+    const cameraMotion = imageMode || fullyCustomShortFilm
+      ? rawCameraMotion
+      : storyboardCameraMotionForSpeed(rawCameraMotion, state.cameraMotionSpeed);
     const motionSummary = String(normalized.motion_summary || "").trim();
     const cameraMotionForPrompt = motionSummary ? "" : cameraMotion;
     if (!imageMode) previousCameraMotion = cameraMotion || previousCameraMotion;
     const lyricText = String(normalized.lyrics || "").trim();
     const performanceMode = normalizeStoryboardPerformanceMode(normalized.performance_mode || state.performanceMode || state.videoType || state.performance_mode);
-    const selectedFacialPerformance = normalized.facial_performance || state.facialPerformance;
+    const selectedFacialPerformance = normalized.facial_performance || (fullyCustomShortFilm ? "" : state.facialPerformance);
     const facialPreset = facialPresetForPayload(selectedFacialPerformance);
     const facialCustom = String(normalized.facial_performance_custom || state.facialPerformanceCustom || "").trim();
     const facialDirection = selectedFacialPerformance === "off"
@@ -1789,8 +2642,19 @@ function storyboardScenesForGpt(state) {
       : selectedFacialPerformance === "custom" && facialCustom
       ? facialCustom
       : [facialPreset.direction, facialCustom].filter(Boolean).join(" ");
-    const selectedPerformanceStyle = normalized.performance_style || state.performanceStyle;
+    const selectedPerformanceStyle = normalized.performance_style || (fullyCustomShortFilm ? "" : state.performanceStyle);
     const selectedPerformancePreset = performancePreset(selectedPerformanceStyle);
+    const supportsVideoStyle = storyboardSceneSupportsMiniMaxVideoStyle(normalized);
+    const selectedVideoStyle = supportsVideoStyle ? String(state.videoStyle || normalized.video_style || "") : "";
+    const selectedVideoStyleCustom = selectedVideoStyle === "custom"
+      ? String(state.videoStyle === "custom" ? state.videoStyleCustom : (normalized.video_style_custom || state.videoStyleCustom || "")).trim()
+      : "";
+    const selectedVideoStylePreset = storyboardMiniMaxVideoStylePreset(selectedVideoStyle);
+    const selectedVideoStyleVerbiage = storyboardMiniMaxVideoStyleVerbiage(selectedVideoStyle, selectedVideoStyleCustom);
+    const temporalWorldEffect = !imageMode
+      && normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine) === "minimax_h3"
+      ? storyboardTemporalWorldEffectForScene(normalized, state)
+      : null;
     const instrumental = Boolean(normalized.lyric_instrumental);
     const noLipSync = Boolean(normalized.lyric_no_lip_sync || performanceMode === "no_lip_sync");
     const noCharacterPresent = Boolean(normalized.no_character_present);
@@ -1823,6 +2687,7 @@ function storyboardScenesForGpt(state) {
     return {
       scene_number: normalized.scene_number,
       label: normalized.label,
+      lyric_section: lyricSection,
       prompt_type: imageMode ? "text to image" : storyboardVideoPromptTypeLabel(normalized.video_prompt_type),
       project_video_engine: normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine),
       minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(normalized.minimax_h3_mode),
@@ -1830,12 +2695,16 @@ function storyboardScenesForGpt(state) {
       timeline_start: Number(normalized.timeline_start || 0),
       timeline_end: Number(normalized.timeline_end || 0),
       performance_mode: performanceMode,
+      short_film_planning_mode: miniMaxShortFilmMode ? normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode) : "",
+      manual_scene_contract: fullyCustomShortFilm
+        ? "Every populated scene-card field is authoritative. Format the supplied material only. Do not invent, rewrite, reorder, merge, omit, or replace dialogue, speakers, actions, story beats, shot/framing, camera motion, setting, references, sound direction, or continuity. Leave unspecified details unspecified instead of filling them in."
+        : "",
       lyric_line_to_sing: shouldLipSync && performanceMode === "singing" ? lyricText : "",
       line_to_say: shouldLipSync && performanceMode === "speaking" ? lyricText : "",
       vocal_status: {
         performance_mode: performanceMode,
         lyric_text: lyricText,
-        lyric_section: normalized.lyric_section,
+        lyric_section: lyricSection,
         singers,
         instrumental,
         no_lip_sync: noLipSync,
@@ -1866,7 +2735,7 @@ function storyboardScenesForGpt(state) {
       },
       scene_summary: imageMode ? "" : normalized.prompt_summary,
       story_layer: {
-        lyric_section: normalized.lyric_section,
+        lyric_section: lyricSection,
         scene_story_beat: normalized.story_beat,
         flf_start_state: normalized.flf_start_state,
         flf_transformation: normalized.flf_transformation,
@@ -1879,19 +2748,31 @@ function storyboardScenesForGpt(state) {
       },
       motion_summary: imageMode ? "" : motionSummary,
       still_image_notes: imageMode ? motionSummary : "",
-      image_aesthetic: imageMode ? storyboardImageAestheticGuidance(state.imageAesthetic, { idLoraMode }) : "",
+      image_aesthetic: imageMode ? storyboardImageAestheticGuidance(state.imageAesthetic, { idLoraMode: filmPlanningProfile }) : "",
       image_aesthetic_instruction: imageMode
         ? "Translate the selected image aesthetic into concrete prompt details: pose, wardrobe styling, hair, makeup, accessories, lighting setup, lens/framing, composition, environment treatment, texture, weather/time if useful, and art direction. Do not merely name the preset or append it as a short tag."
+        : "",
+      video_style: !imageMode && supportsVideoStyle && selectedVideoStyle ? selectedVideoStylePreset.label : "",
+      video_style_custom: !imageMode && supportsVideoStyle && selectedVideoStyle === "custom" ? selectedVideoStyleCustom : "",
+      video_style_guidance: !imageMode && supportsVideoStyle ? selectedVideoStyleVerbiage : "",
+      video_style_verbiage: !imageMode && supportsVideoStyle ? selectedVideoStyleVerbiage : "",
+      video_style_instruction: !imageMode && supportsVideoStyle && selectedVideoStyleVerbiage
+        ? "This exact video_style_verbiage is mandatory. Copy it word-for-word into the final prompt and use it only as the governing visual-appearance contract for lighting, color, texture, materials, production design, grading, and image finish. Do not paraphrase, shorten, rename, or omit it. Do not use it to select, replace, or modify camera motion, character motion, shot timing, editing, or transitions."
+        : "",
+      temporal_world_effect: temporalWorldEffect || { enabled: false },
+      temporal_world_effect_verbiage: temporalWorldEffect?.exact_verbiage || "",
+      temporal_world_effect_instruction: temporalWorldEffect
+        ? "This exact temporal_world_effect_verbiage is mandatory. Copy it word-for-word before the first timestamp. Treat it as a hard temporal-layer contract, and stage its concrete visible effect inside every timestamp block. Protected characters and their voices stay natural, stable, singular, and correctly synchronized while only the stated unprotected background/world elements receive the effect. Do not write a Continuity rule that contradicts its background-extras permission."
         : "",
       global_consistency_phrase: String(state.globalConsistencyPhrase || "").trim(),
       global_consistency_instruction: String(state.globalConsistencyPhrase || "").trim()
         ? "Incorporate the global_consistency_phrase naturally into the prompt where it fits. Preserve its key wording, but do not force it to the beginning unless that is the most natural phrasing."
         : "",
-      performance_style: selectedPerformanceStyle === "off" ? "" : selectedPerformancePreset.label,
-      performance_direction: selectedPerformanceStyle === "off" ? "" : selectedPerformancePreset.direction,
-      facial_performance: selectedFacialPerformance === "off" ? "" : facialPreset.label,
-      facial_performance_direction: imageMode ? storyboardStillFacialDirection(facialDirection) : facialDirection,
-      facial_performance_custom: selectedFacialPerformance === "off" ? "" : (imageMode ? storyboardStillFacialDirection(facialCustom) : facialCustom),
+      performance_style: !selectedPerformanceStyle || selectedPerformanceStyle === "off" ? "" : selectedPerformancePreset.label,
+      performance_direction: !selectedPerformanceStyle || selectedPerformanceStyle === "off" ? "" : selectedPerformancePreset.direction,
+      facial_performance: !selectedFacialPerformance || selectedFacialPerformance === "off" ? "" : facialPreset.label,
+      facial_performance_direction: !selectedFacialPerformance ? "" : (imageMode ? storyboardStillFacialDirection(facialDirection) : facialDirection),
+      facial_performance_custom: !selectedFacialPerformance || selectedFacialPerformance === "off" ? "" : (imageMode ? storyboardStillFacialDirection(facialCustom) : facialCustom),
       microphone: {
         include: Boolean(normalized.include_microphone),
         instruction: normalized.include_microphone
@@ -1917,6 +2798,8 @@ function storyboardScenesForGpt(state) {
         name: String(normalized.setting || "").trim(),
         description: String(normalized.setting || "").trim(),
       },
+      camera_flow: cameraFlowKey,
+      camera_flow_guidance: String(cameraFlowPreset?.guidance || "").trim(),
       shot_type: shotType,
       starting_shot: requiresStartingShot
         ? {
@@ -1928,7 +2811,7 @@ function storyboardScenesForGpt(state) {
       camera_motion: imageMode ? "" : cameraMotionForPrompt,
       still_camera_style: imageMode ? cameraMotion : "",
       camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
-      camera_motion_speed_guidance: imageMode ? "" : storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
+      camera_motion_speed_guidance: imageMode || (fullyCustomShortFilm && !cameraMotionForPrompt) ? "" : storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
       camera_guidance: imageMode
         ? {
             selected_still_camera_style: cameraMotion,
@@ -1945,7 +2828,7 @@ function storyboardScenesForGpt(state) {
           },
       character_motion: imageMode ? "" : normalized.character_motion,
       character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
-      character_motion_guidance: storyboardSpeedGuidance(state.characterMotionSpeed, "character"),
+      character_motion_guidance: fullyCustomShortFilm && !normalized.character_motion ? "" : storyboardSpeedGuidance(state.characterMotionSpeed, "character"),
       first_frame_visual_inventory: imageMode
         ? ""
         : {
@@ -1956,6 +2839,8 @@ function storyboardScenesForGpt(state) {
       text_to_image_prompt: imageMode ? normalized.image_prompt : "",
       video_prompt: normalized.video_prompt,
       notes: normalized.notes,
+      audio_direction: normalized.audio_direction,
+      continuity: normalized.continuity,
     };
   });
 }
@@ -1975,6 +2860,7 @@ export function storyboardGptPayload(state, scenesOverride = null) {
     scope: selectedScene ? "single_scene" : "all_scenes",
     selected_scene_number: selectedScene ? selectedScene.scene_number : null,
     performance_mode: normalizeStoryboardPerformanceMode(selectedScene?.performance_mode || state.performanceMode || state.videoType || state.performance_mode),
+    short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
     storyboard_mode: state.mode === "image_to_video_prep" ? "video prompt planning" : "text-to-image prompt planning",
     image_model_mode: selectedImageMode,
     image_model_label: selectedImageModeLabel,
@@ -1992,7 +2878,7 @@ export function storyboardGptPayload(state, scenesOverride = null) {
         },
       }
       : {
-        task_instruction: "Create detailed image-to-video prompts for Video Prep using a strict source hierarchy. The mapped location_ref is the required physical set for each scene: do not replace it with a location from story_layer, scene_story_beat, song_story_brief, user_story_arc, lyrics, or previous/next scene context. If story context mentions another place, translate only its emotion, tension, symbolism, or action into the mapped location_ref environment. The first_frame_visual_inventory field is only a first-frame inventory: visible subject identity, wardrobe, hair, makeup, props, setting, lighting, color palette, framing, and composition. Do not use first_frame_visual_inventory or any image prompt wording for body action, camera motion, performance energy, facial performance, lyric action, story action, or animation pacing. When starting_shot.required is true, the first sentence must explicitly state that the video begins with starting_shot.selected_starting_shot; do not merely imply that framing or use it later. For an eyes shot, explicitly say the video begins with an extreme close-up of the subject's eyes. The selected camera motion begins from that opening framing. Then build the rest of the video prompt in this order: 1) subject and vocal/performance sentence from vocal_status, performance_direction, and facial_performance_direction; 2) character movement sentence from character_motion, character_motion_guidance, character_motion_speed, and scene_story_beat; 3) camera movement sentence from camera_motion, camera_guidance, and camera_motion_speed_guidance; 4) environment/lighting sentence from first_frame_visual_inventory and location_ref; 5) final mood/style sentence from story_layer and image aesthetic only where visual. Each sentence has one job and must add new information. Do not repeat the same mood, trait, motion, authority/defiance language, setting adjective, or descriptive phrase across multiple sentences. If an idea appears in the face sentence, do not repeat it in the body, camera, environment, or atmosphere sentence; use a different concrete visual detail instead. Do not duplicate adjacent words such as 'tall, tall'. The motion priority is character_motion_guidance + camera_motion_speed_guidance + camera_guidance + performance_direction + vocal_status + scene_story_beat above story_layer, and all of those above first_frame_visual_inventory. At camera speed 9-10, do not write 'then holds', 'holds on', or static hold endings; use multiple coordinated readable camera moves. At character speed 9-10, do not leave the subject merely poised or standing; include clear full-body action or set interaction.",
+        task_instruction: "Create detailed image-to-video prompts for Video Prep using a strict source hierarchy. The mapped location_ref is the required physical set for each scene: do not replace it with a location from story_layer, scene_story_beat, song_story_brief, user_story_arc, lyrics, or previous/next scene context. If story context mentions another place, translate only its emotion, tension, symbolism, or action into the mapped location_ref environment. The first_frame_visual_inventory field is only a first-frame inventory: visible subject identity, wardrobe, hair, makeup, props, setting, lighting, color palette, framing, and composition. Do not use first_frame_visual_inventory or any image prompt wording for body action, camera motion, performance energy, facial performance, lyric action, story action, or animation pacing. Follow camera_flow_guidance as a hard framing constraint for the entire shot, every camera move, and the ending composition. When starting_shot.required is true, the first sentence must explicitly state that the video begins with starting_shot.selected_starting_shot; do not merely imply that framing or use it later. For an eyes shot, explicitly say the video begins with an extreme close-up of the subject's eyes. The selected camera motion begins from that opening framing. Then build the rest of the video prompt in this order: 1) subject and vocal/performance sentence from vocal_status, performance_direction, and facial_performance_direction; 2) character movement sentence from character_motion, character_motion_guidance, character_motion_speed, and scene_story_beat; 3) camera movement sentence from camera_motion, camera_guidance, and camera_motion_speed_guidance; 4) environment/lighting sentence from first_frame_visual_inventory and location_ref; 5) final mood/style sentence from story_layer and image aesthetic only where visual. Each sentence has one job and must add new information. Do not repeat the same mood, trait, motion, authority/defiance language, setting adjective, or descriptive phrase across multiple sentences. If an idea appears in the face sentence, do not repeat it in the body, camera, environment, or atmosphere sentence; use a different concrete visual detail instead. Do not duplicate adjacent words such as 'tall, tall'. The motion priority is character_motion_guidance + camera_motion_speed_guidance + camera_guidance + performance_direction + vocal_status + scene_story_beat above story_layer, and all of those above first_frame_visual_inventory. At camera speed 7-8, do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera wording; use energetic active movement. At camera speed 9-10, use multiple coordinated readable camera moves. At character speed 4 or higher, include at least one clear physical body action, gesture, step, or set interaction; facial movement alone does not count.",
       }),
     story_layer: normalizeStoryLayer(state.storyLayer),
     scenes: storyboardScenesForGpt(payloadState),
@@ -2022,17 +2908,31 @@ async function copyTextToClipboard(text) {
 
 function openStoryboardBuilder(payload = {}) {
   const projectFolder = String(payload.projectFolder || payload.project_folder || "").trim();
-  const projectVideoEngine = normalizeStoryboardProjectVideoEngine(payload.projectVideoEngine || payload.project_video_engine);
+  const incomingProjectVideoEngine = String(payload.projectVideoEngine || payload.project_video_engine || "").trim();
+  const hasIncomingProjectVideoEngine = Boolean(incomingProjectVideoEngine);
+  const projectVideoEngine = normalizeStoryboardProjectVideoEngine(incomingProjectVideoEngine);
+  const payloadMiniMaxH3Mode = projectVideoEngine === "minimax_h3"
+    ? normalizeStoryboardMiniMaxH3Mode(payload.miniMaxH3Mode || payload.minimax_h3_mode || payload.videoPromptType || payload.video_prompt_type)
+    : "";
+  const payloadMiniMaxH3AudioMode = projectVideoEngine === "minimax_h3"
+    ? normalizeStoryboardMiniMaxH3AudioMode(payload.miniMaxH3AudioMode || payload.minimax_h3_audio_mode)
+    : "input_audio";
   const payloadVideoPromptType = ["i2v", "id_lora", "t2v", "rtv", "ingredients", "flf"].includes(String(payload.videoPromptType || payload.video_prompt_type || "").trim())
     ? String(payload.videoPromptType || payload.video_prompt_type || "").trim()
     : "";
   const isIdLoraMode = payloadVideoPromptType === "id_lora";
   const payloadPerformanceMode = normalizeStoryboardPerformanceMode(payload.performanceMode || payload.performance_mode || payload.videoType || payload.video_type);
+  const isMiniMaxShortFilmMode = projectVideoEngine === "minimax_h3" && payloadPerformanceMode === "speaking";
+  const usesFilmPlanningProfile = isIdLoraMode || isMiniMaxShortFilmMode;
+  const openingMode = projectVideoEngine === "minimax_h3"
+    ? (payloadMiniMaxH3Mode === "image_to_video" ? "storyboard_prompts" : "image_to_video_prep")
+    : (payloadVideoPromptType === "i2v" ? "storyboard_prompts" : "image_to_video_prep");
   const state = {
     projectFolder,
     projectVideoEngine,
+    miniMaxH3AudioMode: payloadMiniMaxH3AudioMode,
     lineMappingLyrics: String(payload.lineMappingLyrics || payload.line_mapping_lyrics || payload.lyricMapper?.source_text || payload.lyric_mapper?.source_text || ""),
-    mode: "storyboard_prompts",
+    mode: openingMode,
     scenes: scenesFromBuilderPayload(payload).map((scene) => ({
       ...scene,
       video_prompt_type: payloadVideoPromptType || scene.video_prompt_type,
@@ -2040,26 +2940,44 @@ function openStoryboardBuilder(payload = {}) {
     })),
     referenceBuilder: normalizeReferenceBuilderCatalog(payload.referenceBuilder || payload.reference_builder || {}),
     storyLayer: normalizeStoryLayer(payload.storyLayer || payload.story_layer || {}),
+    scriptImport: normalizeStoryboardScriptImportState(payload.scriptImport || payload.script_import || {}),
     onReferenceMappingsChanged: typeof payload.onReferenceMappingsChanged === "function" ? payload.onReferenceMappingsChanged : null,
     onStoryLayerChanged: typeof payload.onStoryLayerChanged === "function" ? payload.onStoryLayerChanged : null,
     onPromptsExported: typeof payload.onPromptsExported === "function" ? payload.onPromptsExported : null,
     onApplyIdLoraDialoguePlan: typeof payload.onApplyIdLoraDialoguePlan === "function" ? payload.onApplyIdLoraDialoguePlan : null,
+    onApplyMiniMaxDialoguePlan: typeof payload.onApplyMiniMaxDialoguePlan === "function" ? payload.onApplyMiniMaxDialoguePlan : null,
     onCreateVideoPrompt: typeof payload.onCreateVideoPrompt === "function" ? payload.onCreateVideoPrompt : null,
     query: "",
     selected: new Set(),
     saving: false,
     gemmaSettings: payload.gemmaSettings || payload.gemma_settings || {},
     cameraFlow: String(payload.cameraFlow || payload.camera_flow || "balanced"),
-    imageShotFlow: String(payload.imageShotFlow || payload.image_shot_flow || (isIdLoraMode ? "film_dialogue_coverage" : "intimate")),
-    imageAesthetic: String(payload.imageAesthetic || payload.image_aesthetic || (isIdLoraMode ? "film_default" : "")),
+    imageShotFlow: String(payload.imageShotFlow || payload.image_shot_flow || (usesFilmPlanningProfile ? "film_dialogue_coverage" : "intimate")),
+    imageAesthetic: String(payload.imageAesthetic || payload.image_aesthetic || (usesFilmPlanningProfile ? "film_default" : "")),
+    videoStyle: String(payload.videoStyle || payload.video_style || ""),
+    videoStyleCustom: String(payload.videoStyleCustom || payload.video_style_custom || ""),
+    temporalWorldEffect: String(payload.temporalWorldEffect || payload.temporal_world_effect || ""),
+    temporalWorldEffectCustom: String(payload.temporalWorldEffectCustom || payload.temporal_world_effect_custom || ""),
+    temporalAllowBackgroundExtras: (payload.temporalAllowBackgroundExtras ?? payload.temporal_allow_background_extras) !== false,
+    temporalBackgroundIntensity: storyboardTemporalIntensity(payload.temporalBackgroundIntensity ?? payload.temporal_background_intensity ?? 8),
+    temporalEnvironmentTimePassage: (payload.temporalEnvironmentTimePassage ?? payload.temporal_environment_time_passage) !== false,
+    temporalProtectedCharacters: storyboardTemporalProtectedMode(payload.temporalProtectedCharacters || payload.temporal_protected_characters),
+    temporalProtectedCustom: String(payload.temporalProtectedCustom || payload.temporal_protected_custom || ""),
     globalConsistencyPhrase: String(payload.globalConsistencyPhrase || payload.global_consistency_phrase || ""),
-    performanceStyle: String(payload.performanceStyle || payload.performance_style || payload.performance_style_default || (isIdLoraMode ? "dialogue_naturalism" : "")),
+    performanceStyle: String(payload.performanceStyle || payload.performance_style || payload.performance_style_default || (usesFilmPlanningProfile ? "dialogue_naturalism" : "")),
     facialPerformance: String(payload.facialPerformance || payload.facial_performance || payload.facial_performance_default || ""),
     facialPerformanceCustom: String(payload.facialPerformanceCustom || payload.facial_performance_custom || payload.facial_performance_custom_default || ""),
     cameraMotionSpeed: storyboardSpeedValue(payload.cameraMotionSpeed ?? payload.camera_motion_speed ?? payload.motion_defaults?.camera_motion_speed, 4),
     characterMotionSpeed: storyboardSpeedValue(payload.characterMotionSpeed ?? payload.character_motion_speed ?? payload.motion_defaults?.character_motion_speed, 4),
     performanceMode: payloadPerformanceMode,
+    shortFilmPlanningMode: normalizeStoryboardShortFilmPlanningMode(
+      payload.shortFilmPlanningMode
+      || payload.short_film_planning_mode
+      || payload.builderStoryboardDefaults?.short_film_planning_mode
+      || payload.builder_storyboard_defaults?.short_film_planning_mode,
+    ),
     videoPromptType: payloadVideoPromptType,
+    miniMaxH3Mode: payloadMiniMaxH3Mode,
     imageMode: String(payload.imageMode || payload.image_mode || "zimage").trim() || "zimage",
     imageModeLabel: String(payload.imageModeLabel || payload.image_mode_label || "").trim(),
   };
@@ -2070,16 +2988,18 @@ function openStoryboardBuilder(payload = {}) {
     if (runner === "llm_api" || runner === "llmapi" || runner === "llm-api" || runner === "api") return "API LLM";
     return "Gemma";
   };
-  const imageShotFlowPresets = isIdLoraMode ? ID_LORA_IMAGE_SHOT_FLOW_PRESETS : STORYBOARD_IMAGE_SHOT_FLOW_PRESETS;
-  const imageAestheticPresets = isIdLoraMode ? ID_LORA_IMAGE_AESTHETIC_PRESETS : STORYBOARD_IMAGE_AESTHETIC_PRESETS;
-  const performanceStylePresets = isIdLoraMode ? ID_LORA_PERFORMANCE_STYLE_PRESETS : PERFORMANCE_STYLE_PRESETS;
-  const facialPerformancePresets = isIdLoraMode ? ID_LORA_FACIAL_PERFORMANCE_PRESETS : FACIAL_PERFORMANCE_PRESETS;
+  const imageShotFlowPresets = usesFilmPlanningProfile ? ID_LORA_IMAGE_SHOT_FLOW_PRESETS : STORYBOARD_IMAGE_SHOT_FLOW_PRESETS;
+  const imageAestheticPresets = usesFilmPlanningProfile ? ID_LORA_IMAGE_AESTHETIC_PRESETS : STORYBOARD_IMAGE_AESTHETIC_PRESETS;
+  const performanceStylePresets = usesFilmPlanningProfile ? ID_LORA_PERFORMANCE_STYLE_PRESETS : PERFORMANCE_STYLE_PRESETS;
+  const facialPerformancePresets = usesFilmPlanningProfile ? ID_LORA_FACIAL_PERFORMANCE_PRESETS : FACIAL_PERFORMANCE_PRESETS;
   const imageShotFlowPresetForMode = (value = "") => imageShotFlowPresets[value] || imageShotFlowPresets[Object.keys(imageShotFlowPresets)[0]] || STORYBOARD_IMAGE_SHOT_FLOW_PRESETS.intimate;
   const imageAestheticPresetForMode = (value = "") => imageAestheticPresets.find((item) => item.value === value) || imageAestheticPresets[0] || STORYBOARD_IMAGE_AESTHETIC_PRESETS[0];
   const performancePresetForMode = (value = "") => performanceStylePresets.find((item) => item.value === value) || performanceStylePresets[0] || PERFORMANCE_STYLE_PRESETS[0];
   const facialPresetForMode = (value = "") => facialPerformancePresets.find((item) => item.value === value) || facialPerformancePresets[0] || FACIAL_PERFORMANCE_PRESETS[0];
   if (!imageShotFlowPresets[state.imageShotFlow]) state.imageShotFlow = Object.keys(imageShotFlowPresets)[0] || "off";
   if (!imageAestheticPresets.some((item) => item.value === state.imageAesthetic)) state.imageAesthetic = imageAestheticPresets[0]?.value || "";
+  if (!MINIMAX_VIDEO_STYLE_PRESETS.some((item) => item.value === state.videoStyle)) state.videoStyle = "";
+  if (!MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS.some((item) => item.value === state.temporalWorldEffect)) state.temporalWorldEffect = "";
   if (!performanceStylePresets.some((item) => item.value === state.performanceStyle)) state.performanceStyle = performanceStylePresets[0]?.value || "";
   if (!facialPerformancePresets.some((item) => item.value === state.facialPerformance)) state.facialPerformance = facialPerformancePresets[0]?.value || "";
   const storyboardDefaultsPayload = () => ({
@@ -2090,12 +3010,32 @@ function openStoryboardBuilder(payload = {}) {
       camera_guidance: storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
       character_guidance: storyboardSpeedGuidance(state.characterMotionSpeed, "character"),
       performance_style: String(state.performanceStyle || ""),
+      short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
       camera_flow: String(state.cameraFlow || ""),
       image_shot_flow: String(state.imageShotFlow || ""),
       image_aesthetic: String(state.imageAesthetic || ""),
+      video_style: String(state.videoStyle || ""),
+      video_style_custom: String(state.videoStyleCustom || "").trim(),
+      temporal_world_effect: String(state.temporalWorldEffect || ""),
+      temporal_world_effect_custom: String(state.temporalWorldEffectCustom || "").trim(),
+      temporal_allow_background_extras: state.temporalAllowBackgroundExtras !== false,
+      temporal_background_intensity: storyboardTemporalIntensity(state.temporalBackgroundIntensity),
+      temporal_environment_time_passage: state.temporalEnvironmentTimePassage !== false,
+      temporal_protected_characters: storyboardTemporalProtectedMode(state.temporalProtectedCharacters),
+      temporal_protected_custom: String(state.temporalProtectedCustom || "").trim(),
     },
     global_consistency_phrase: String(state.globalConsistencyPhrase || "").trim(),
     performance_style_default: String(state.performanceStyle || ""),
+    short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
+    video_style: String(state.videoStyle || ""),
+    video_style_custom: String(state.videoStyleCustom || "").trim(),
+    temporal_world_effect: String(state.temporalWorldEffect || ""),
+    temporal_world_effect_custom: String(state.temporalWorldEffectCustom || "").trim(),
+    temporal_allow_background_extras: state.temporalAllowBackgroundExtras !== false,
+    temporal_background_intensity: storyboardTemporalIntensity(state.temporalBackgroundIntensity),
+    temporal_environment_time_passage: state.temporalEnvironmentTimePassage !== false,
+    temporal_protected_characters: storyboardTemporalProtectedMode(state.temporalProtectedCharacters),
+    temporal_protected_custom: String(state.temporalProtectedCustom || "").trim(),
     camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
     character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
     motion_defaults: {
@@ -2296,6 +3236,96 @@ function openStoryboardBuilder(payload = {}) {
   imageAestheticControls.append(imageAestheticLabel, imageAestheticSelect, imageAestheticApply, imageAestheticReplace);
   const imageAestheticInfo = document.createElement("div");
   imageAestheticInfo.style.cssText = "color:#94a3b8;line-height:1.35;";
+  const videoStyleControls = document.createElement("div");
+  videoStyleControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
+  const videoStyleLabel = document.createElement("div");
+  videoStyleLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
+  videoStyleLabel.textContent = "Video aesthetic";
+  const videoStyleSelect = makeSelect(MINIMAX_VIDEO_STYLE_PRESETS, state.videoStyle);
+  videoStyleSelect.style.width = "max-content";
+  videoStyleSelect.style.minWidth = "220px";
+  const videoStyleApply = makeButton("Fill Missing", "primary");
+  videoStyleApply.title = "Fill blank style fields only for MiniMax Text to Video and Reference to Video scenes.";
+  const videoStyleReplace = makeButton("Replace All");
+  videoStyleReplace.title = "Replace the style on all MiniMax Text to Video and Reference to Video scenes. Other modes are ignored.";
+  videoStyleControls.append(videoStyleLabel, videoStyleSelect, videoStyleApply, videoStyleReplace);
+  const videoStyleCustomControls = document.createElement("div");
+  videoStyleCustomControls.style.cssText = "display:flex;gap:8px;align-items:flex-start;";
+  const videoStyleCustomLabel = document.createElement("div");
+  videoStyleCustomLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;padding-top:9px;";
+  videoStyleCustomLabel.textContent = "Custom style wording";
+  const videoStyleCustomInput = makeTextarea(
+    state.videoStyleCustom,
+    "Type the exact visual-style wording that must appear unchanged in every eligible prompt...",
+    3,
+  );
+  videoStyleCustomInput.style.minWidth = "520px";
+  videoStyleCustomControls.append(videoStyleCustomLabel, videoStyleCustomInput);
+  const videoStyleInfo = document.createElement("div");
+  videoStyleInfo.style.cssText = "color:#94a3b8;line-height:1.35;";
+  const temporalEffectControls = document.createElement("div");
+  temporalEffectControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
+  const temporalEffectLabel = document.createElement("div");
+  temporalEffectLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
+  temporalEffectLabel.textContent = "Temporal / world effect";
+  const temporalEffectSelect = makeSelect(MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS, state.temporalWorldEffect);
+  temporalEffectSelect.style.width = "max-content";
+  temporalEffectSelect.style.minWidth = "300px";
+  temporalEffectControls.append(temporalEffectLabel, temporalEffectSelect);
+  const temporalEffectCustomControls = document.createElement("div");
+  temporalEffectCustomControls.style.cssText = "display:flex;gap:8px;align-items:flex-start;";
+  const temporalEffectCustomLabel = document.createElement("div");
+  temporalEffectCustomLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;padding-top:9px;";
+  temporalEffectCustomLabel.textContent = "Custom temporal wording";
+  const temporalEffectCustomInput = makeTextarea(state.temporalWorldEffectCustom, "Describe the exact temporal separation or world behavior. Character protection and audio-safety rules will be added automatically...", 3);
+  temporalEffectCustomInput.style.minWidth = "520px";
+  temporalEffectCustomControls.append(temporalEffectCustomLabel, temporalEffectCustomInput);
+  const temporalEffectOptions = document.createElement("div");
+  temporalEffectOptions.style.cssText = "display:flex;flex-wrap:wrap;gap:10px 18px;align-items:center;padding:9px 10px;border:1px solid #1f3347;border-radius:7px;background:#07111f;";
+  const temporalExtrasLabel = document.createElement("label");
+  temporalExtrasLabel.style.cssText = "display:flex;align-items:center;gap:7px;font-weight:800;color:#cbd5e1;";
+  const temporalExtrasInput = document.createElement("input");
+  temporalExtrasInput.type = "checkbox";
+  temporalExtrasInput.checked = state.temporalAllowBackgroundExtras !== false;
+  temporalExtrasLabel.append(temporalExtrasInput, document.createTextNode("Allow location-appropriate anonymous extras"));
+  const temporalEnvironmentLabel = document.createElement("label");
+  temporalEnvironmentLabel.style.cssText = "display:flex;align-items:center;gap:7px;font-weight:800;color:#cbd5e1;";
+  const temporalEnvironmentInput = document.createElement("input");
+  temporalEnvironmentInput.type = "checkbox";
+  temporalEnvironmentInput.checked = state.temporalEnvironmentTimePassage !== false;
+  temporalEnvironmentLabel.append(temporalEnvironmentInput, document.createTextNode("Allow lighting / weather / time passage"));
+  const temporalIntensityLabel = document.createElement("label");
+  temporalIntensityLabel.style.cssText = "display:flex;align-items:center;gap:7px;font-weight:800;color:#cbd5e1;min-width:290px;";
+  const temporalIntensityInput = makeInput(String(storyboardTemporalIntensity(state.temporalBackgroundIntensity)));
+  temporalIntensityInput.type = "range";
+  temporalIntensityInput.min = "0";
+  temporalIntensityInput.max = "10";
+  temporalIntensityInput.step = "1";
+  temporalIntensityInput.style.width = "170px";
+  temporalIntensityInput.style.accentColor = "#22d3ee";
+  const temporalIntensityValue = document.createElement("span");
+  temporalIntensityValue.style.cssText = "color:#cffafe;font-weight:900;min-width:38px;";
+  temporalIntensityLabel.append(document.createTextNode("World intensity"), temporalIntensityInput, temporalIntensityValue);
+  const temporalProtectedLabel = document.createElement("label");
+  temporalProtectedLabel.style.cssText = "display:flex;align-items:center;gap:7px;font-weight:800;color:#cbd5e1;min-width:360px;";
+  const temporalProtectedSelect = makeSelect([
+    { value: "all_referenced", label: "Protect all referenced characters (recommended)" },
+    { value: "lead_only", label: "Protect first referenced character only" },
+    { value: "custom", label: "Protect named referenced characters" },
+  ], state.temporalProtectedCharacters);
+  temporalProtectedSelect.style.minWidth = "280px";
+  temporalProtectedLabel.append(document.createTextNode("Real-time cast"), temporalProtectedSelect);
+  temporalEffectOptions.append(temporalExtrasLabel, temporalEnvironmentLabel, temporalIntensityLabel, temporalProtectedLabel);
+  const temporalProtectedCustomControls = document.createElement("div");
+  temporalProtectedCustomControls.style.cssText = "display:flex;gap:8px;align-items:center;";
+  const temporalProtectedCustomLabel = document.createElement("div");
+  temporalProtectedCustomLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
+  temporalProtectedCustomLabel.textContent = "Protected names";
+  const temporalProtectedCustomInput = makeInput(state.temporalProtectedCustom, "Exact mapped character names, comma separated");
+  temporalProtectedCustomInput.style.minWidth = "520px";
+  temporalProtectedCustomControls.append(temporalProtectedCustomLabel, temporalProtectedCustomInput);
+  const temporalEffectInfo = document.createElement("div");
+  temporalEffectInfo.style.cssText = "color:#94a3b8;line-height:1.35;white-space:pre-wrap;";
   const consistencyControls = document.createElement("div");
   consistencyControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
   const consistencyLabel = document.createElement("div");
@@ -2347,14 +3377,14 @@ function openStoryboardBuilder(payload = {}) {
   performanceControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
   const performanceLabel = document.createElement("div");
   performanceLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
-  performanceLabel.textContent = isIdLoraMode ? "Global acting style" : "Global performance style";
+  performanceLabel.textContent = usesFilmPlanningProfile ? "Global acting style" : "Global performance style";
   const performanceSelect = makeSelect(performanceStylePresets, state.performanceStyle);
   performanceSelect.style.width = "max-content";
   performanceSelect.style.minWidth = "180px";
   const performanceApply = makeButton("Fill Missing", "primary");
-  performanceApply.title = isIdLoraMode ? "Fill only blank per-scene acting style fields. Existing scene choices are kept." : "Fill only blank per-scene performance/song style fields. Existing scene choices are kept.";
+  performanceApply.title = usesFilmPlanningProfile ? "Fill only blank per-scene acting style fields. Existing scene choices are kept." : "Fill only blank per-scene performance/song style fields. Existing scene choices are kept.";
   const performanceReplace = makeButton("Replace All");
-  performanceReplace.title = isIdLoraMode ? "Replace every scene's acting style with the selected global style." : "Replace every scene's performance/song style with the selected global style.";
+  performanceReplace.title = usesFilmPlanningProfile ? "Replace every scene's acting style with the selected global style." : "Replace every scene's performance/song style with the selected global style.";
   performanceControls.append(performanceLabel, performanceSelect, performanceApply, performanceReplace);
   const performanceInfo = document.createElement("div");
   performanceInfo.style.cssText = "color:#94a3b8;line-height:1.35;";
@@ -2381,7 +3411,7 @@ function openStoryboardBuilder(payload = {}) {
   facialControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
   const facialLabel = document.createElement("div");
   facialLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
-  facialLabel.textContent = isIdLoraMode ? "Global screen face" : "Global facial performance";
+  facialLabel.textContent = usesFilmPlanningProfile ? "Global screen face" : "Global facial performance";
   const facialSelect = makeSelect(facialPerformancePresets, state.facialPerformance);
   facialSelect.style.width = "max-content";
   facialSelect.style.minWidth = "180px";
@@ -2432,6 +3462,12 @@ function openStoryboardBuilder(payload = {}) {
   const responsiveDefaultRows = [
     imageShotControls,
     imageAestheticControls,
+    videoStyleControls,
+    videoStyleCustomControls,
+    temporalEffectControls,
+    temporalEffectCustomControls,
+    temporalEffectOptions,
+    temporalProtectedCustomControls,
     imageWorldStyleControls,
     imageCustomStyleControls,
     consistencyControls,
@@ -2451,6 +3487,13 @@ function openStoryboardBuilder(payload = {}) {
   const responsiveDefaultInputs = [
     imageShotSelect,
     imageAestheticSelect,
+    videoStyleSelect,
+    videoStyleCustomInput,
+    temporalEffectSelect,
+    temporalEffectCustomInput,
+    temporalIntensityInput,
+    temporalProtectedSelect,
+    temporalProtectedCustomInput,
     imageWorldStyleSelect,
     imageCustomStyleInput,
     consistencyInput,
@@ -2465,13 +3508,15 @@ function openStoryboardBuilder(payload = {}) {
     control.style.minWidth = "0";
     control.style.maxWidth = "100%";
   }
-  for (const control of [imageCustomStyleInput, consistencyInput, cameraSpeedInput, characterSpeedInput, facialCustomInput]) {
+  for (const control of [videoStyleCustomInput, temporalEffectCustomInput, temporalProtectedCustomInput, imageCustomStyleInput, consistencyInput, cameraSpeedInput, characterSpeedInput, facialCustomInput]) {
     control.style.flex = "1 1 280px";
     control.style.width = "100%";
   }
   const responsiveDefaultInfo = [
     imageShotInfo,
     imageAestheticInfo,
+    videoStyleInfo,
+    temporalEffectInfo,
     imageWorldStyleInfo,
     imageCustomStyleInfo,
     consistencyInfo,
@@ -2487,7 +3532,7 @@ function openStoryboardBuilder(payload = {}) {
     info.style.maxWidth = "100%";
     info.style.overflowWrap = "anywhere";
   }
-  cameraFlowBar.append(imageShotControls, imageShotInfo, imageAestheticControls, imageAestheticInfo, imageWorldStyleControls, imageWorldStyleInfo, imageCustomStyleControls, imageCustomStyleInfo, consistencyControls, consistencyInfo, cameraFlowControls, cameraFlowInfo, cameraSpeedControls, cameraSpeedInfo, performanceControls, performanceInfo, characterSpeedControls, characterSpeedInfo, facialControls, facialInfo, facialCustomControls, facialCustomInfo);
+  cameraFlowBar.append(imageShotControls, imageShotInfo, imageAestheticControls, imageAestheticInfo, videoStyleControls, videoStyleCustomControls, videoStyleInfo, temporalEffectControls, temporalEffectCustomControls, temporalEffectOptions, temporalProtectedCustomControls, temporalEffectInfo, imageWorldStyleControls, imageWorldStyleInfo, imageCustomStyleControls, imageCustomStyleInfo, consistencyControls, consistencyInfo, cameraFlowControls, cameraFlowInfo, cameraSpeedControls, cameraSpeedInfo, performanceControls, performanceInfo, characterSpeedControls, characterSpeedInfo, facialControls, facialInfo, facialCustomControls, facialCustomInfo);
 
   const storyLayerBar = document.createElement("div");
   storyLayerBar.className = "vrgdg-storyboard-story-grid";
@@ -2496,8 +3541,8 @@ function openStoryboardBuilder(payload = {}) {
   storyLayerHeader.style.cssText = "grid-column:1/-1;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px;min-width:0;max-width:100%;";
   const storyLayerTitle = document.createElement("div");
   storyLayerTitle.style.cssText = "flex:1 1 420px;min-width:0;max-width:100%;overflow-wrap:anywhere;";
-  storyLayerTitle.innerHTML = isIdLoraMode
-    ? `<div style="font-weight:900;color:#cffafe;font-size:15px;">Short Film Story Layer</div><div style="color:#94a3b8;margin-top:2px;">Dialogue-first planning for ID-LoRA scenes, characters, and locations.</div>`
+  storyLayerTitle.innerHTML = usesFilmPlanningProfile
+    ? `<div style="font-weight:900;color:#cffafe;font-size:15px;">Short Film Story Layer</div><div style="color:#94a3b8;margin-top:2px;">Dialogue-first planning for ${isIdLoraMode ? "ID-LoRA" : "MiniMax H3"} scenes, characters, and locations.</div>`
     : `<div style="font-weight:900;color:#cffafe;font-size:15px;">Story Layer</div><div style="color:#94a3b8;margin-top:2px;">Optional narrative context for connecting lyrics, sections, subjects, and locations across scenes.</div>`;
   const storyLayerEnabledLabel = document.createElement("label");
   storyLayerEnabledLabel.style.cssText = "display:flex;align-items:center;gap:7px;font-weight:800;color:#cbd5e1;white-space:normal;max-width:100%;";
@@ -2506,6 +3551,19 @@ function openStoryboardBuilder(payload = {}) {
   storyLayerEnabledInput.checked = state.storyLayer.enabled !== false;
   storyLayerEnabledLabel.append(storyLayerEnabledInput, document.createTextNode("Use in Gemma prompts"));
   storyLayerHeader.append(storyLayerTitle, storyLayerEnabledLabel);
+  const shortFilmPlanningModeWrap = document.createElement("div");
+  shortFilmPlanningModeWrap.style.cssText = "grid-column:1/-1;display:none;grid-template-columns:minmax(180px,260px) minmax(0,1fr);gap:12px;align-items:start;border:1px solid #155e75;border-radius:8px;background:#071a2b;padding:12px;";
+  const shortFilmPlanningModeSelect = makeSelect([
+    { value: "guided_film", label: "Guided Film Automation" },
+    { value: "fully_custom", label: "Fully Custom" },
+  ], state.shortFilmPlanningMode);
+  const shortFilmPlanningModeField = document.createElement("label");
+  shortFilmPlanningModeField.style.cssText = "display:flex;flex-direction:column;gap:6px;font-size:12px;font-weight:900;color:#cbd5e1;";
+  shortFilmPlanningModeField.textContent = "Short Film Authoring Mode";
+  shortFilmPlanningModeField.append(shortFilmPlanningModeSelect);
+  const shortFilmPlanningModeInfo = document.createElement("div");
+  shortFilmPlanningModeInfo.style.cssText = "color:#bae6fd;line-height:1.45;min-width:0;overflow-wrap:anywhere;";
+  shortFilmPlanningModeWrap.append(shortFilmPlanningModeField, shortFilmPlanningModeInfo);
   const overallStoryIdeaInput = makeTextarea(
     state.storyLayer.overall_story_idea || "",
     "Optional short premise, e.g. A woman navigates a surreal dream world.",
@@ -2514,12 +3572,12 @@ function openStoryboardBuilder(payload = {}) {
   overallStoryIdeaInput.title = "Optional. Sets the overall premise, world, or theme that Gemma develops through the real lyric sections.";
   const userStoryArcInput = makeTextarea(
     state.storyLayer.user_story_arc || "",
-    isIdLoraMode ? "Short film premise, conflict, tone, character goal..." : "Optional user story arc, e.g. Verse 1: she feels trapped. Chorus: she breaks free...",
+    usesFilmPlanningProfile ? "Short film premise, conflict, tone, character goal, or pasted script..." : "Optional user story arc, e.g. Verse 1: she feels trapped. Chorus: she breaks free...",
     5,
   );
   const songStoryBriefInput = makeTextarea(
     state.storyLayer.song_story_brief || "",
-    isIdLoraMode ? "Gemma-created short film story brief..." : "Gemma-created song story brief...",
+    usesFilmPlanningProfile ? "LLM-created short film story brief..." : "Gemma-created song story brief...",
     5,
   );
   const lyricStoryStrengthInput = makeInput(String(normalizeStoryLayer(state.storyLayer).lyric_story_strength));
@@ -2560,11 +3618,11 @@ function openStoryboardBuilder(payload = {}) {
   const lyricStoryStrengthRow = document.createElement("div");
   lyricStoryStrengthRow.style.cssText = "grid-column:1/-1;display:grid;grid-template-columns:minmax(0,1fr) auto auto;gap:8px;align-items:end;";
   lyricStoryStrengthRow.append(storyField("Lyric Story Strength", lyricStoryStrengthInput), lyricStoryStrengthValue, lyricStoryStrengthHintButton);
-  lyricStoryStrengthRow.style.display = isIdLoraMode ? "none" : "grid";
+  lyricStoryStrengthRow.style.display = usesFilmPlanningProfile ? "none" : "grid";
   const idLoraDialoguePlanner = document.createElement("div");
   idLoraDialoguePlanner.style.cssText = "grid-column:1/-1;display:none;border:1px solid #155e75;border-radius:8px;background:#082f49;padding:12px;gap:10px;align-items:center;grid-template-columns:minmax(0,1fr) auto;";
   const idLoraDialoguePlannerText = document.createElement("div");
-  idLoraDialoguePlannerText.innerHTML = `<div style="font-weight:900;color:#cffafe;">Plan Dialogue Scenes</div><div style="color:#bae6fd;line-height:1.35;margin-top:3px;">Enter a story idea, outline, or pasted script above. If left blank, Gemma invents a short-film dialogue scene plan from your ID-LoRA characters and locations.</div>`;
+  idLoraDialoguePlannerText.innerHTML = `<div style="font-weight:900;color:#cffafe;">Plan Dialogue Scenes</div><div style="color:#bae6fd;line-height:1.35;margin-top:3px;">Enter a story idea, outline, or pasted script above. If left blank, the selected LLM invents a short-film dialogue scene plan from your ${isIdLoraMode ? "ID-LoRA" : "MiniMax H3"} characters and locations.</div>`;
   const idLoraDialogueControls = document.createElement("div");
   idLoraDialogueControls.style.cssText = "display:flex;gap:8px;align-items:end;flex-wrap:wrap;justify-content:flex-end;";
   const idLoraDialogueSceneCount = makeInput("6");
@@ -2573,27 +3631,50 @@ function openStoryboardBuilder(payload = {}) {
   idLoraDialogueSceneCount.max = "24";
   idLoraDialogueSceneCount.step = "1";
   idLoraDialogueSceneCount.style.width = "76px";
-  const planDialogueScenesButton = makeButton("Plan Dialogue Scenes", "primary");
-  planDialogueScenesButton.title = "ID-LoRA only. Create a preview scene plan from the premise/script and ID-LoRA Ref Builder characters.";
-  const applyDialoguePlanButton = makeButton("Apply Dialogue Plan", "primary");
-  applyDialoguePlanButton.title = "Apply the reviewed ID-LoRA dialogue scenes to Video Builder.";
+  const planDialogueScenesButton = makeButton("Plan Storyboard Scenes", "primary");
+  planDialogueScenesButton.title = `${isIdLoraMode ? "ID-LoRA" : "MiniMax H3 Guided Film"}. Develop editable scene cards inside Storyboard Builder. This does not create Video Builder timeline segments.`;
+  const applyDialoguePlanButton = makeButton("Create Timeline Segments", "primary");
+  applyDialoguePlanButton.title = "Create real Video Builder timeline segments from the reviewed storyboard scenes.";
   applyDialoguePlanButton.style.display = "none";
   idLoraDialogueControls.append(storyField("Scenes", idLoraDialogueSceneCount), planDialogueScenesButton, applyDialoguePlanButton);
   idLoraDialoguePlanner.append(idLoraDialoguePlannerText, idLoraDialogueControls);
+  const miniMaxGuidedWorkflowSteps = document.createElement("div");
+  miniMaxGuidedWorkflowSteps.style.cssText = "grid-column:1/-1;display:none;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:8px;border:1px solid #155e75;border-radius:8px;background:#041923;padding:10px;";
+  miniMaxGuidedWorkflowSteps.innerHTML = `
+    <div style="border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;"><strong style="color:#67e8f9;">STEP 1 — SCRIPT</strong><br><span style="color:#bae6fd;">Import or review the script, map speakers, then click <strong>Use This Script</strong>.</span></div>
+    <div style="border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;"><strong style="color:#67e8f9;">STEP 2 — DEVELOP</strong><br><span style="color:#bae6fd;">Create the editable storyboard scene cards. The timeline is still unchanged.</span></div>
+    <div style="border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;"><strong style="color:#67e8f9;">STEP 3 — REVIEW</strong><br><span style="color:#bae6fd;">Review and edit the scene cards, dialogue, references, shots, and continuity below.</span></div>
+    <div style="border:1px solid #0891b2;border-radius:7px;background:#083344;padding:10px;line-height:1.35;"><strong style="color:#67e8f9;">STEP 4 — TIMELINE</strong><br><span style="color:#bae6fd;">Create the real Video Builder timeline segments only after reviewing the cards.</span></div>
+  `;
+  const miniMaxScriptImporter = document.createElement("div");
+  miniMaxScriptImporter.style.cssText = "grid-column:1/-1;display:none;border:1px solid #0e7490;border-radius:8px;background:#06283d;padding:12px;gap:10px;align-items:center;grid-template-columns:minmax(0,1fr) auto;";
+  const miniMaxScriptImporterText = document.createElement("div");
+  miniMaxScriptImporterText.innerHTML = `<div style="font-weight:900;color:#cffafe;">Import Script / Script Mapper</div><div style="color:#bae6fd;line-height:1.4;margin-top:3px;">Paste a <strong>speaker: dialogue</strong> script or load a .txt/.json file. Validate exact cues, match speakers, and preview automatically timed MiniMax segments without changing the timeline.</div>`;
+  const openMiniMaxScriptMapperButton = makeButton("Import Script / Script Mapper", "primary");
+  openMiniMaxScriptMapperButton.title = "Import, map, time, and activate an exact dialogue script for MiniMax Guided Film Automation.";
+  miniMaxScriptImporter.append(miniMaxScriptImporterText, openMiniMaxScriptMapperButton);
   const storyActions = document.createElement("div");
   storyActions.style.cssText = "grid-column:1/-1;display:flex;gap:8px;align-items:center;flex-wrap:wrap;";
+  const storyActionsLabel = document.createElement("div");
+  storyActionsLabel.style.cssText = "flex:0 0 100%;font-size:12px;font-weight:900;color:#fcd34d;border-top:1px solid #334155;padding-top:10px;";
+  storyActionsLabel.textContent = usesFilmPlanningProfile
+    ? "OPTIONAL STORY PLANNING TOOLS — not required when using an imported authoritative script"
+    : "OPTIONAL STORY PLANNING TOOLS";
   const createStoryArcButton = makeButton("Create User Story Arc", "primary");
   const createStoryBriefButton = makeButton("Create Story Brief", "primary");
   const createMissingBeatsButton = makeButton("Create Missing Scene Beats", "purple");
   const replaceBeatsButton = makeButton("Replace All Scene Beats");
   const detectSectionsButton = makeButton("Detect Lyric Sections");
-  storyActions.append(createStoryArcButton, createStoryBriefButton, createMissingBeatsButton, replaceBeatsButton, detectSectionsButton);
+  storyActions.append(storyActionsLabel, createStoryArcButton, createStoryBriefButton, createMissingBeatsButton, replaceBeatsButton, detectSectionsButton);
   storyLayerBar.append(
     storyLayerHeader,
+    shortFilmPlanningModeWrap,
     lyricStoryStrengthRow,
     overallStoryIdeaField,
     storyField("User Story Arc", userStoryArcInput),
     storyField("Song Story Brief", songStoryBriefInput),
+    miniMaxGuidedWorkflowSteps,
+    miniMaxScriptImporter,
     idLoraDialoguePlanner,
     storyActions,
   );
@@ -2601,7 +3682,7 @@ function openStoryboardBuilder(payload = {}) {
   const sceneDefaultsPanel = makeCollapsiblePanel("Scene Defaults", "", cameraFlowBar, { open: false });
   sceneDefaultsPanel.classList.add("vrgdg-storyboard-panel");
   const hasStoryLayerContent = Boolean(String(state.storyLayer.overall_story_idea || "").trim() || String(state.storyLayer.user_story_arc || "").trim() || String(state.storyLayer.song_story_brief || "").trim());
-  const storyLayerPanel = makeCollapsiblePanel("Story Layer", "", storyLayerBar, { open: hasStoryLayerContent });
+  const storyLayerPanel = makeCollapsiblePanel("Story Layer", "", storyLayerBar, { open: hasStoryLayerContent || isMiniMaxShortFilmMode });
   storyLayerPanel.classList.add("vrgdg-storyboard-panel");
 
   const tableWrap = document.createElement("div");
@@ -2615,8 +3696,8 @@ function openStoryboardBuilder(payload = {}) {
   const footerActions = document.createElement("div");
   footerActions.style.cssText = "display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:flex-end;min-width:0;max-width:100%;";
   const save = makeButton("Save Storyboard");
-  const exportPrompts = makeButton("Export Prompt Files", "purple");
-  exportPrompts.title = "Export text prompt files plus clean JSON files keyed by scene number.";
+  const exportPrompts = makeButton("Export Prompt Files Only", "purple");
+  exportPrompts.title = "Write TXT and JSON prompt files only. This does not create or replace Video Builder timeline segments.";
   footerActions.append(save, exportPrompts);
   footer.append(stats, footerActions);
 
@@ -2628,6 +3709,9 @@ function openStoryboardBuilder(payload = {}) {
   const setMode = (mode) => {
     state.mode = mode;
     const isVideoPrepMode = mode === "image_to_video_prep";
+    const videoStyleEligible = (state.projectVideoEngine === "minimax_h3"
+      && ["text_to_video", "reference_to_video"].includes(state.miniMaxH3Mode))
+      || state.scenes.some((scene) => storyboardSceneSupportsMiniMaxVideoStyle(scene));
     stepPrompts.style.background = mode === "storyboard_prompts" ? "#0e7490" : "#2b2b30";
     stepPrompts.style.borderColor = mode === "storyboard_prompts" ? "#06b6d4" : "#3f3f46";
     stepPrep.style.background = mode === "image_to_video_prep" ? "#0e7490" : "#2b2b30";
@@ -2652,6 +3736,15 @@ function openStoryboardBuilder(payload = {}) {
     imageShotInfo.style.display = isVideoPrepMode ? "none" : "";
     imageAestheticControls.style.display = isVideoPrepMode ? "none" : "flex";
     imageAestheticInfo.style.display = isVideoPrepMode ? "none" : "";
+    videoStyleControls.style.display = isVideoPrepMode && videoStyleEligible ? "flex" : "none";
+    videoStyleCustomControls.style.display = isVideoPrepMode && videoStyleEligible && state.videoStyle === "custom" ? "flex" : "none";
+    videoStyleInfo.style.display = isVideoPrepMode && videoStyleEligible ? "" : "none";
+    const temporalEffectEligible = isVideoPrepMode && state.projectVideoEngine === "minimax_h3";
+    temporalEffectControls.style.display = temporalEffectEligible ? "flex" : "none";
+    temporalEffectCustomControls.style.display = temporalEffectEligible && state.temporalWorldEffect === "custom" ? "flex" : "none";
+    temporalEffectOptions.style.display = temporalEffectEligible && Boolean(state.temporalWorldEffect) ? "flex" : "none";
+    temporalProtectedCustomControls.style.display = temporalEffectEligible && Boolean(state.temporalWorldEffect) && state.temporalProtectedCharacters === "custom" ? "flex" : "none";
+    temporalEffectInfo.style.display = temporalEffectEligible ? "" : "none";
     imageWorldStyleControls.style.display = isVideoPrepMode ? "none" : "flex";
     imageWorldStyleInfo.style.display = isVideoPrepMode ? "none" : "";
     imageCustomStyleControls.style.display = isVideoPrepMode ? "none" : "flex";
@@ -2685,42 +3778,85 @@ function openStoryboardBuilder(payload = {}) {
     return !text;
   };
 
-  const shouldShowIdLoraDialoguePlanner = () => {
-    return isIdLoraMode
+  const isFullyCustomShortFilm = () => isMiniMaxShortFilmMode
+    && normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode) === "fully_custom";
+  const shouldShowFilmDialoguePlanner = () => {
+    return (isIdLoraMode || (isMiniMaxShortFilmMode && !isFullyCustomShortFilm()))
       && state.scenes.length > 0
       && state.scenes.length <= 2
       && state.scenes.every(sceneLooksLikeStarterPlaceholder);
   };
-  const hasIdLoraDialoguePlan = () => {
-    return isIdLoraMode
+  const hasFilmDialoguePlan = () => {
+    return (isIdLoraMode || isMiniMaxShortFilmMode)
       && state.scenes.some((scene) => String(scene.lyrics || scene.story_beat || scene.image_prompt || "").trim())
-      && state.scenes.some((scene) => String(scene.video_prompt_type || "") === "id_lora");
+      && (isIdLoraMode
+        ? state.scenes.some((scene) => String(scene.video_prompt_type || "") === "id_lora")
+        : state.scenes.some((scene) => normalizeStoryboardProjectVideoEngine(scene.project_video_engine || state.projectVideoEngine) === "minimax_h3"));
   };
 
   const refreshSetupPanelSummaries = () => {
     const cameraPreset = STORYBOARD_CAMERA_FLOW_PRESETS[state.cameraFlow] || STORYBOARD_CAMERA_FLOW_PRESETS.balanced;
     const imageShotPreset = imageShotFlowPresetForMode(state.imageShotFlow);
     const imageAestheticPreset = imageAestheticPresetForMode(state.imageAesthetic);
+    const videoStylePreset = storyboardMiniMaxVideoStylePreset(state.videoStyle);
+    const temporalEffectPreset = storyboardTemporalWorldEffectPreset(state.temporalWorldEffect);
     const performancePreset = performancePresetForMode(state.performanceStyle);
     const facialPreset = facialPresetForMode(state.facialPerformance);
     sceneDefaultsPanel.setSummary(state.mode === "image_to_video_prep"
-      ? `${cameraPreset.label || "Camera flow"} · camera ${storyboardSpeedValue(state.cameraMotionSpeed, 4)}/10 · character ${storyboardSpeedValue(state.characterMotionSpeed, 4)}/10 · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`
+      ? `${cameraPreset.label || "Camera flow"}${state.videoStyle ? ` · ${videoStylePreset.label}` : ""}${state.temporalWorldEffect ? ` · ${temporalEffectPreset.label}` : ""} · camera ${storyboardSpeedValue(state.cameraMotionSpeed, 4)}/10 · character ${storyboardSpeedValue(state.characterMotionSpeed, 4)}/10 · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`
       : `${imageShotPreset.label || "Still shot flow"} · ${imageAestheticPreset.label || "Image aesthetic"} · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`);
     const beatCount = state.scenes.filter((scene) => String(scene.story_beat || "").trim()).length;
     const sectionCount = state.scenes.filter((scene) => String(scene.lyric_section || "").trim()).length;
     const hasBrief = Boolean(String(state.storyLayer.song_story_brief || "").trim());
     const hasArc = Boolean(String(state.storyLayer.user_story_arc || "").trim());
     const lyricStrength = normalizeStoryLayer(state.storyLayer).lyric_story_strength;
-    const idLoraPlannerVisible = shouldShowIdLoraDialoguePlanner();
-    idLoraDialoguePlanner.style.display = (idLoraPlannerVisible || hasIdLoraDialoguePlan()) ? "grid" : "none";
-    applyDialoguePlanButton.style.display = hasIdLoraDialoguePlan() && state.onApplyIdLoraDialoguePlan ? "" : "none";
-    createStoryArcButton.textContent = isIdLoraMode ? "Create Story Premise" : "Create User Story Arc";
-    createStoryBriefButton.textContent = isIdLoraMode ? "Create Short Film Brief" : "Create Story Brief";
+    const filmPlannerVisible = shouldShowFilmDialoguePlanner();
+    const fullyCustom = isFullyCustomShortFilm();
+    const activeScriptImport = normalizeStoryboardScriptImportState(state.scriptImport);
+    shortFilmPlanningModeWrap.style.display = isMiniMaxShortFilmMode ? "grid" : "none";
+    miniMaxGuidedWorkflowSteps.style.display = isMiniMaxShortFilmMode && state.miniMaxH3AudioMode === "built_in_audio" && !fullyCustom ? "grid" : "none";
+    miniMaxScriptImporter.style.display = isMiniMaxShortFilmMode && state.miniMaxH3AudioMode === "built_in_audio" ? "grid" : "none";
+    miniMaxScriptImporterText.innerHTML = activeScriptImport.enabled
+      ? `<div style="font-weight:900;color:#cffafe;">Authoritative Script Active</div><div style="color:#bae6fd;line-height:1.4;margin-top:3px;"><strong>${activeScriptImport.cues.length}</strong> exact dialogue cues are mapped into <strong>${activeScriptImport.scene_plan.scene_count}</strong> planned MiniMax segments at a ${activeScriptImport.maximum_scene_seconds}-second maximum. Guided Film may develop the visual story but cannot rewrite the dialogue.</div>`
+      : `<div style="font-weight:900;color:#cffafe;">Import Script / Script Mapper</div><div style="color:#bae6fd;line-height:1.4;margin-top:3px;">Paste a <strong>speaker: dialogue</strong> script or load a .txt/.json file. Validate exact cues, match speakers, and preview automatically timed MiniMax segments without changing the timeline.</div>`;
+    openMiniMaxScriptMapperButton.textContent = activeScriptImport.enabled ? "Step 1 — Review / Replace Script" : "Step 1 — Import / Activate Script";
+    if (activeScriptImport.enabled) {
+      idLoraDialogueSceneCount.value = String(activeScriptImport.scene_plan.scene_count || 1);
+      idLoraDialogueSceneCount.disabled = true;
+      idLoraDialogueSceneCount.title = "The authoritative Script Mapper plan controls the required segment count.";
+      idLoraDialoguePlannerText.innerHTML = `<div style="font-weight:900;color:#cffafe;">Step 2 — Develop Imported Script Storyboard</div><div style="color:#bae6fd;line-height:1.35;margin-top:3px;">The LLM will create editable storyboard scene cards with visual story beats, actions, reactions, shots, camera direction, locations, ambience, and continuity for all ${activeScriptImport.scene_plan.scene_count} locked script sections. Exact dialogue, speakers, and order are enforced. The timeline remains unchanged. Afterward, complete <strong>Step 3</strong> by reviewing the cards below.</div>`;
+      planDialogueScenesButton.textContent = `Step 2 — Develop ${activeScriptImport.scene_plan.scene_count} Scenes`;
+      planDialogueScenesButton.title = `Develop ${activeScriptImport.scene_plan.scene_count} editable storyboard scene cards. After reviewing them, use Create ${activeScriptImport.scene_plan.scene_count} Timeline Segments.`;
+    } else {
+      idLoraDialogueSceneCount.disabled = false;
+      idLoraDialogueSceneCount.title = "Number of guided dialogue scenes to create.";
+      idLoraDialoguePlannerText.innerHTML = isMiniMaxShortFilmMode
+        ? `<div style="font-weight:900;color:#cffafe;">Step 2 — Plan Storyboard Scenes</div><div style="color:#bae6fd;line-height:1.35;margin-top:3px;">Enter a story idea, outline, or pasted script above. If left blank, the selected LLM invents editable short-film storyboard scenes from your MiniMax H3 characters and locations. The timeline remains unchanged until Step 4.</div>`
+        : `<div style="font-weight:900;color:#cffafe;">Plan Storyboard Scenes</div><div style="color:#bae6fd;line-height:1.35;margin-top:3px;">Enter a story idea, outline, or pasted script above. If left blank, the selected LLM invents editable short-film storyboard scenes from your ID-LoRA characters and locations. This does not alter the timeline until you choose Create Timeline Segments.</div>`;
+      planDialogueScenesButton.textContent = isMiniMaxShortFilmMode ? "Step 2 — Plan Storyboard Scenes" : "Plan Storyboard Scenes";
+      planDialogueScenesButton.title = "Develop editable storyboard scene cards. This does not create Video Builder timeline segments.";
+    }
+    shortFilmPlanningModeInfo.innerHTML = fullyCustom
+      ? `<strong style="color:#cffafe;">Manual scene cards are authoritative.</strong><br>Enter dialogue in Speaker Assignment and fill the scene beat, action, shot, camera, setting, references, audio direction, and continuity yourself. Prompt generation formats your entries but may not invent or rewrite them.`
+      : `<strong style="color:#cffafe;">The LLM can help plan the film.</strong><br>Use the premise/script, reference characters, film shot coverage, story beats, and dialogue planner to create scene cards. You can still edit every result manually before prompting.`;
+    idLoraDialoguePlanner.style.display = !fullyCustom && (activeScriptImport.enabled || filmPlannerVisible || hasFilmDialoguePlan()) ? "grid" : "none";
+    const hasApplyDialogueCallback = isIdLoraMode ? Boolean(state.onApplyIdLoraDialoguePlan) : Boolean(state.onApplyMiniMaxDialoguePlan);
+    applyDialoguePlanButton.style.display = hasFilmDialoguePlan() && hasApplyDialogueCallback ? "" : "none";
+    const plannedTimelineSceneCount = state.scenes.filter((scene) => String(scene.lyrics || scene.story_beat || scene.image_prompt || "").trim()).length;
+    applyDialoguePlanButton.textContent = plannedTimelineSceneCount
+      ? `${isMiniMaxShortFilmMode ? "Step 4 — " : ""}Create ${plannedTimelineSceneCount} Timeline Segment${plannedTimelineSceneCount === 1 ? "" : "s"}`
+      : `${isMiniMaxShortFilmMode ? "Step 4 — " : ""}Create Timeline Segments`;
+    applyDialoguePlanButton.title = plannedTimelineSceneCount
+      ? `Create ${plannedTimelineSceneCount} real Video Builder timeline segment${plannedTimelineSceneCount === 1 ? "" : "s"} from these storyboard scenes. This may replace existing base timeline scenes.`
+      : "Create real Video Builder timeline segments from the reviewed storyboard scenes.";
+    storyActions.style.display = fullyCustom ? "none" : "flex";
+    createStoryArcButton.textContent = usesFilmPlanningProfile ? "Create Story Premise" : "Create User Story Arc";
+    createStoryBriefButton.textContent = usesFilmPlanningProfile ? "Create Short Film Brief" : "Create Story Brief";
     createMissingBeatsButton.textContent = isIdLoraMode ? "Create Missing Scene Beats" : "Create Missing Scene Beats";
     replaceBeatsButton.textContent = isIdLoraMode ? "Replace All Scene Beats" : "Replace All Scene Beats";
-    detectSectionsButton.style.display = isIdLoraMode ? "none" : "";
-    storyLayerPanel.setSummary(isIdLoraMode
-      ? `${state.storyLayer.enabled === false ? "Off" : "On"} · ID-LoRA dialogue story · ${beatCount}/${state.scenes.length} beats${hasBrief ? " · brief" : ""}${hasArc ? " · premise" : ""}${idLoraPlannerVisible ? " · starter scenes" : ""}`
+    detectSectionsButton.style.display = usesFilmPlanningProfile ? "none" : "";
+    storyLayerPanel.setSummary(usesFilmPlanningProfile
+      ? `${state.storyLayer.enabled === false ? "Off" : "On"} · ${isIdLoraMode ? "ID-LoRA dialogue story" : (fullyCustom ? "MiniMax fully custom film" : "MiniMax guided film")} · ${beatCount}/${state.scenes.length} beats${hasBrief ? " · brief" : ""}${hasArc ? " · premise" : ""}${filmPlannerVisible ? " · starter scenes" : ""}`
       : `${state.storyLayer.enabled === false ? "Off" : "On"} · lyric ${lyricStrength}/10 · ${beatCount}/${state.scenes.length} beats · ${sectionCount}/${state.scenes.length} sections${hasBrief ? " · brief" : ""}${hasArc ? " · user arc" : ""}`);
   };
 
@@ -2817,6 +3953,7 @@ function openStoryboardBuilder(payload = {}) {
       state.onStoryLayerChanged({
         ...storyboardDefaultsPayload(),
         story_layer: normalizeStoryLayer(state.storyLayer),
+        script_import: normalizeStoryboardScriptImportState(state.scriptImport),
         facial_performance_default: state.facialPerformance || "",
         facial_performance_custom_default: state.facialPerformanceCustom || "",
         scenes: state.scenes.map((scene, index) => slimSceneForRequest(scene, index)),
@@ -2829,6 +3966,7 @@ function openStoryboardBuilder(payload = {}) {
     state.onStoryLayerChanged({
       ...storyboardDefaultsPayload(),
       story_layer: normalizeStoryLayer(state.storyLayer),
+      script_import: normalizeStoryboardScriptImportState(state.scriptImport),
       facial_performance_default: state.facialPerformance || "",
       facial_performance_custom_default: state.facialPerformanceCustom || "",
       scenes: state.scenes.map((scene, index) => slimSceneForRequest(scene, index)),
@@ -2853,6 +3991,42 @@ function openStoryboardBuilder(payload = {}) {
       .map(({ section, lyrics }) => `${section ? `[${section}]\n` : ""}${lyrics.join("\n")}`.trim())
       .filter(Boolean)
       .join("\n\n");
+  };
+
+  const refreshVideoStyleInfo = () => {
+    const preset = storyboardMiniMaxVideoStylePreset(state.videoStyle);
+    const exactVerbiage = storyboardMiniMaxVideoStyleVerbiage(state.videoStyle, state.videoStyleCustom);
+    videoStyleCustomControls.style.display = state.mode === "image_to_video_prep"
+      && ((state.projectVideoEngine === "minimax_h3"
+        && ["text_to_video", "reference_to_video"].includes(state.miniMaxH3Mode))
+        || state.scenes.some((scene) => storyboardSceneSupportsMiniMaxVideoStyle(scene)))
+      && state.videoStyle === "custom"
+      ? "flex"
+      : "none";
+    videoStyleInfo.textContent = exactVerbiage
+      ? `Required exact wording in every eligible prompt: ${exactVerbiage}`
+      : "Optional. Choose the governing visual aesthetic for MiniMax scenes that do not use a required start image.";
+    refreshSetupPanelSummaries();
+  };
+
+  const refreshTemporalEffectInfo = () => {
+    state.temporalBackgroundIntensity = storyboardTemporalIntensity(temporalIntensityInput.value);
+    temporalIntensityValue.textContent = `${state.temporalBackgroundIntensity}/10`;
+    temporalEffectCustomControls.style.display = state.mode === "image_to_video_prep"
+      && state.projectVideoEngine === "minimax_h3"
+      && state.temporalWorldEffect === "custom" ? "flex" : "none";
+    temporalEffectOptions.style.display = state.mode === "image_to_video_prep"
+      && state.projectVideoEngine === "minimax_h3"
+      && Boolean(state.temporalWorldEffect) ? "flex" : "none";
+    temporalProtectedCustomControls.style.display = state.mode === "image_to_video_prep"
+      && state.projectVideoEngine === "minimax_h3"
+      && Boolean(state.temporalWorldEffect)
+      && state.temporalProtectedCharacters === "custom" ? "flex" : "none";
+    const effect = storyboardTemporalWorldEffectForScene({}, state);
+    temporalEffectInfo.textContent = effect
+      ? `Hardcoded into every MiniMax video prompt unless a scene overrides it.\n${effect.exact_verbiage}`
+      : "Optional. Choose a global temporal/world effect. Existing projects and scenes remain natural-time while this is Off.";
+    refreshSetupPanelSummaries();
   };
 
   const sectionMapFromLyrics = () => {
@@ -2892,16 +4066,23 @@ function openStoryboardBuilder(payload = {}) {
 
   const createStoryBriefWithGemma = async () => {
     syncStoryLayerFromInputs();
+    const authoritativeScript = normalizeStoryboardScriptImportState(state.scriptImport);
     const progress = createStoryboardProgressWindow("Story Brief Gemma");
     try {
-      progress.set("Creating compact song story brief from lyrics, sections, and your story arc...", 18);
+      progress.set(authoritativeScript.enabled
+        ? "Creating a short-film production brief around the exact imported script..."
+        : "Creating compact song story brief from lyrics, sections, and your story arc...", 18);
       const data = await postJson("/vrgdg/storyboard/story_brief", {
         ...(state.gemmaSettings || {}),
         story_layer: normalizeStoryLayer(state.storyLayer),
+        script_import: normalizeStoryboardScriptImportState(state.scriptImport),
+        performance_mode: state.performanceMode,
+        reference_builder: state.referenceBuilder || {},
+        storyboard: slimStoryboardForRequest(state),
         lyrics: lyricsForStoryBrief(),
         scenes: state.scenes.map((scene, index) => slimSceneForRequest(scene, index)),
         unload_after: true,
-        max_new_tokens: 800,
+        max_new_tokens: authoritativeScript.enabled ? 1200 : 800,
       }, 240000);
       state.storyLayer.song_story_brief = String(data.story_brief || "").trim();
       songStoryBriefInput.value = state.storyLayer.song_story_brief;
@@ -2917,7 +4098,8 @@ function openStoryboardBuilder(payload = {}) {
 
   const createStoryArcWithGemma = async () => {
     syncStoryLayerFromInputs();
-    const progress = createStoryboardProgressWindow("Story Arc Gemma");
+    const authoritativeScript = normalizeStoryboardScriptImportState(state.scriptImport);
+    const progress = createStoryboardProgressWindow(authoritativeScript.enabled ? "Short Film Premise" : "Story Arc Gemma");
     const storyArcSeed = Math.floor(Math.random() * 2147483647);
     const existingStoryArcText = String(userStoryArcInput.value || "").trim();
     const overallStoryIdea = String(overallStoryIdeaInput.value || "").trim();
@@ -2927,13 +4109,17 @@ function openStoryboardBuilder(payload = {}) {
       user_story_arc: "",
     });
     try {
-      progress.set(`Creating a short song-structure story arc from lyrics, subjects, and locations...\nReroll seed: ${storyArcSeed}`, 18);
+      progress.set(authoritativeScript.enabled
+        ? `Creating a visual short-film premise around the exact imported dialogue...\nReroll seed: ${storyArcSeed}`
+        : `Creating a short song-structure story arc from lyrics, subjects, and locations...\nReroll seed: ${storyArcSeed}`, 18);
       const data = await postJson("/vrgdg/storyboard/story_arc", {
         ...(state.gemmaSettings || {}),
         n_ctx: Math.max(16384, Number(state.gemmaSettings?.n_ctx) || 0),
         seed: storyArcSeed,
         story_arc_seed: storyArcSeed,
         story_layer: storyLayerForRequest,
+        script_import: normalizeStoryboardScriptImportState(state.scriptImport),
+        performance_mode: state.performanceMode,
         storyboard: slimStoryboardForRequest(state),
         story_idea: overallStoryIdea,
         previous_story_arc: existingStoryArcText,
@@ -2955,9 +4141,9 @@ function openStoryboardBuilder(payload = {}) {
       state.storyLayer.user_story_arc = String(data.story_arc || "").trim();
       userStoryArcInput.value = state.storyLayer.user_story_arc;
       syncStoryLayerFromInputs({ notify: true });
-      progress.set(`Story arc saved into the Story Layer.\nSeed: ${storyArcSeed}`, 100);
+      progress.set(`${authoritativeScript.enabled ? "Short-film premise" : "Story arc"} saved into the Story Layer.\nSeed: ${storyArcSeed}`, 100);
       progress.close(1600);
-      createToast(`Story arc created. Seed: ${storyArcSeed}`);
+      createToast(`${authoritativeScript.enabled ? "Short-film premise" : "Story arc"} created. Seed: ${storyArcSeed}`);
     } catch (error) {
       progress.set(`Error:\n${String(error?.message || error)}`, 100);
       createToast(`Story arc failed:\n${String(error?.message || error)}`, true);
@@ -3076,23 +4262,397 @@ function openStoryboardBuilder(payload = {}) {
     }
   };
 
-  const planIdLoraDialogueScenesWithGemma = async () => {
-    if (!isIdLoraMode) return;
+  const openMiniMaxScriptMapper = () => {
+    if (!isMiniMaxShortFilmMode || state.miniMaxH3AudioMode !== "built_in_audio") {
+      createToast("Script Mapper is available for MiniMax Short Film with Built-in MiniMax Audio.", true);
+      return;
+    }
+    const mapperBackdrop = document.createElement("div");
+    mapperBackdrop.style.cssText = "position:fixed;inset:0;z-index:100070;background:rgba(0,0,0,.78);display:flex;align-items:stretch;justify-content:center;padding:18px;box-sizing:border-box;";
+    const mapperShell = document.createElement("div");
+    mapperShell.style.cssText = "width:min(1320px,calc(100vw - 36px));height:calc(100vh - 36px);min-height:520px;border:1px solid #0e7490;border-radius:11px;background:#07111f;color:#e5e7eb;box-shadow:0 24px 90px rgba(0,0,0,.72);overflow:hidden;display:grid;grid-template-rows:auto minmax(0,1fr) auto;";
+    const mapperHeader = document.createElement("div");
+    mapperHeader.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) auto;gap:14px;align-items:center;padding:15px 18px;background:#083344;border-bottom:1px solid #155e75;";
+    const mapperHeading = document.createElement("div");
+    mapperHeading.innerHTML = `<div style="font-size:20px;font-weight:900;color:#cffafe;">Import Script / Script Mapper</div><div style="font-size:12px;color:#bae6fd;line-height:1.4;margin-top:3px;">Import, map, and time exact dialogue, then activate it as the authoritative source for Guided Film Automation. Activation alone does not change the Video Builder timeline.</div>`;
+    const mapperCloseTop = makeButton("Close");
+    mapperHeader.append(mapperHeading, mapperCloseTop);
+
+    const mapperBody = document.createElement("div");
+    mapperBody.style.cssText = "min-height:0;overflow:auto;padding:16px 18px;display:grid;grid-template-columns:minmax(360px,.8fr) minmax(480px,1.2fr);gap:14px;align-items:stretch;";
+    const sourcePanel = document.createElement("div");
+    sourcePanel.style.cssText = "min-width:0;border:1px solid #334155;border-radius:9px;background:#0b1220;padding:12px;display:flex;flex-direction:column;gap:10px;";
+    const sourceTitle = document.createElement("div");
+    sourceTitle.innerHTML = `<div style="font-weight:900;color:#cffafe;">Script source</div><div style="font-size:12px;color:#94a3b8;line-height:1.4;margin-top:3px;">Plain text uses <strong style="color:#e2e8f0;">speaker: exact dialogue</strong>. JSON accepts cues with speaker/speaker_name and text/dialogue fields.</div>`;
+    const existingScriptImport = normalizeStoryboardScriptImportState(state.scriptImport);
+    const scriptInput = makeTextarea(existingScriptImport.raw_text, "woman: Have you tried the new MiniMax H3 model yet?\n\nman: I have, and honestly...", 22);
+    scriptInput.style.flex = "1 1 auto";
+    scriptInput.style.minHeight = "360px";
+    const sourceActions = document.createElement("div");
+    sourceActions.style.cssText = "display:flex;flex-wrap:wrap;gap:8px;align-items:center;";
+    const loadScriptButton = makeButton("Load .txt / .json", "primary");
+    const parseScriptButton = makeButton("Parse + Plan Preview", "purple");
+    const clearScriptButton = makeButton("Clear");
+    const scriptFileInput = document.createElement("input");
+    scriptFileInput.type = "file";
+    scriptFileInput.accept = ".txt,.json,text/plain,application/json";
+    scriptFileInput.style.display = "none";
+    sourceActions.append(loadScriptButton, parseScriptButton, clearScriptButton, scriptFileInput);
+    const sceneLengthSettings = document.createElement("div");
+    sceneLengthSettings.style.cssText = "border:1px solid #0e7490;border-radius:7px;background:#082f49;padding:10px;display:grid;grid-template-columns:minmax(150px,.8fr) minmax(180px,1.2fr);gap:9px;align-items:center;";
+    const sceneLengthLabel = document.createElement("div");
+    sceneLengthLabel.innerHTML = `<div style="font-weight:900;color:#cffafe;">Maximum scene length</div><div style="font-size:11px;color:#bae6fd;line-height:1.35;margin-top:3px;">Hard ceiling for every planned MiniMax clip. Shorter clips can reduce VRAM pressure and generation time.</div>`;
+    const sceneLengthControls = document.createElement("div");
+    sceneLengthControls.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) 96px;gap:8px;align-items:center;";
+    const maxSceneLengthSelect = makeSelect([
+      { value: "5", label: "5 seconds — low VRAM" },
+      { value: "8", label: "8 seconds — recommended" },
+      { value: "10", label: "10 seconds" },
+      { value: "12", label: "12 seconds" },
+      { value: "15", label: "15 seconds — maximum" },
+      { value: "custom", label: "Custom..." },
+    ], "8");
+    const customSceneLengthInput = makeInput("8", "3–15");
+    customSceneLengthInput.type = "number";
+    customSceneLengthInput.min = "3";
+    customSceneLengthInput.max = "15";
+    customSceneLengthInput.step = "0.5";
+    customSceneLengthInput.title = "Custom maximum scene length from 3 to 15 seconds";
+    customSceneLengthInput.style.display = "none";
+    const presetSceneLengths = new Set([5, 8, 10, 12, 15]);
+    if (existingScriptImport.enabled) {
+      if (presetSceneLengths.has(existingScriptImport.maximum_scene_seconds)) {
+        maxSceneLengthSelect.value = String(existingScriptImport.maximum_scene_seconds);
+      } else {
+        maxSceneLengthSelect.value = "custom";
+        customSceneLengthInput.value = String(existingScriptImport.maximum_scene_seconds);
+        customSceneLengthInput.style.display = "";
+      }
+    }
+    const currentMaximumSceneSeconds = () => Math.max(3, Math.min(15, Number(maxSceneLengthSelect.value === "custom" ? customSceneLengthInput.value : maxSceneLengthSelect.value) || 8));
+    sceneLengthControls.append(maxSceneLengthSelect, customSceneLengthInput);
+    sceneLengthSettings.append(sceneLengthLabel, sceneLengthControls);
+    const sourceStatus = document.createElement("div");
+    sourceStatus.style.cssText = "min-height:18px;font-size:12px;color:#94a3b8;line-height:1.4;";
+    sourcePanel.append(sourceTitle, scriptInput, sourceActions, sceneLengthSettings, sourceStatus);
+
+    const previewPanel = document.createElement("div");
+    previewPanel.style.cssText = "min-width:0;border:1px solid #155e75;border-radius:9px;background:#071827;padding:12px;overflow:auto;";
+    const renderEmptyPreview = () => {
+      previewPanel.innerHTML = `<div style="height:100%;min-height:360px;display:grid;place-items:center;border:1px dashed #334155;border-radius:8px;color:#94a3b8;text-align:center;padding:24px;box-sizing:border-box;"><div><strong style="display:block;color:#cffafe;font-size:15px;margin-bottom:6px;">No parsed script yet</strong>Paste dialogue or load a file, then click Parse Preview.</div></div>`;
+    };
+    let lastParsed = null;
+    const speakerMatches = new Map();
+    for (const match of existingScriptImport.speaker_matches || []) {
+      const aliasKey = storyboardScriptSpeakerMatchKey(match?.speaker_alias);
+      if (!aliasKey) continue;
+      speakerMatches.set(aliasKey, {
+        subject_id: String(match?.reference_subject_id || ""),
+        method: String(match?.match_method || (match?.reference_subject_id ? "manual" : "unmatched")),
+      });
+    }
+    const referenceCharacters = normalizeReferenceBuilderCatalog(state.referenceBuilder).subjects;
+    const copyParsedButton = makeButton("Copy Parsed JSON");
+    copyParsedButton.disabled = true;
+    const useGuidedScriptButton = makeButton("Use This Script in Guided Film", "primary");
+    useGuidedScriptButton.disabled = true;
+    const removeGuidedScriptButton = makeButton("Remove Active Script");
+    removeGuidedScriptButton.style.display = existingScriptImport.enabled ? "" : "none";
+    const renderParsedPreview = (parsed) => {
+      const characterById = new Map(referenceCharacters.map((character) => [String(character.id || ""), character]));
+      for (const speaker of Array.isArray(parsed?.speakers) ? parsed.speakers : []) {
+        const aliasKey = storyboardScriptSpeakerMatchKey(speaker?.name);
+        if (!aliasKey || speakerMatches.has(aliasKey)) continue;
+        const suggested = suggestStoryboardScriptSpeakerMatch(speaker.name, referenceCharacters);
+        speakerMatches.set(aliasKey, suggested
+          ? { subject_id: String(suggested.id || ""), method: "auto" }
+          : { subject_id: "", method: "unmatched" });
+      }
+      const mappedSpeakers = (Array.isArray(parsed?.speakers) ? parsed.speakers : []).map((speaker) => {
+        const aliasKey = storyboardScriptSpeakerMatchKey(speaker?.name);
+        const match = speakerMatches.get(aliasKey) || { subject_id: "", method: "unmatched" };
+        const character = characterById.get(String(match.subject_id || ""));
+        const method = character ? String(match.method || "manual") : "unmatched";
+        return {
+          ...speaker,
+          speaker_alias: String(speaker.name || ""),
+          reference_subject_id: character ? String(character.id || "") : "",
+          reference_subject_name: character ? String(character.name || "") : "",
+          match_method: method,
+        };
+      });
+      const mappedSpeakerByKey = new Map(mappedSpeakers.map((speaker) => [storyboardScriptSpeakerMatchKey(speaker.name), speaker]));
+      parsed.speakers = mappedSpeakers;
+      parsed.cues = (Array.isArray(parsed?.cues) ? parsed.cues : []).map((cue) => {
+        const mappedSpeaker = mappedSpeakerByKey.get(storyboardScriptSpeakerMatchKey(cue?.speaker));
+        return {
+          ...cue,
+          speaker_alias: String(cue?.speaker || ""),
+          speaker_id: String(mappedSpeaker?.reference_subject_id || ""),
+          speaker_name: String(mappedSpeaker?.reference_subject_name || cue?.speaker || ""),
+          reference_subject_id: String(mappedSpeaker?.reference_subject_id || ""),
+          reference_subject_name: String(mappedSpeaker?.reference_subject_name || ""),
+          speaker_match_method: String(mappedSpeaker?.match_method || "unmatched"),
+        };
+      });
+      parsed.speaker_matches = mappedSpeakers.map((speaker) => ({
+        speaker_alias: String(speaker.speaker_alias || speaker.name || ""),
+        reference_subject_id: String(speaker.reference_subject_id || ""),
+        reference_subject_name: String(speaker.reference_subject_name || ""),
+        match_method: String(speaker.match_method || "unmatched"),
+      }));
+      parsed.unmatched_speakers = mappedSpeakers.filter((speaker) => !speaker.reference_subject_id).map((speaker) => String(speaker.name || ""));
+      parsed.scene_plan = planStoryboardScriptScenes(parsed.cues, { max_scene_seconds: currentMaximumSceneSeconds() });
+      lastParsed = parsed;
+      copyParsedButton.disabled = !parsed?.cues?.length;
+      const cueCount = Array.isArray(parsed?.cues) ? parsed.cues.length : 0;
+      const speakerCount = Array.isArray(parsed?.speakers) ? parsed.speakers.length : 0;
+      const wordCount = Number(parsed?.word_count || 0);
+      const speechSeconds = Number(parsed?.estimated_spoken_seconds || 0);
+      const errorCount = Array.isArray(parsed?.errors) ? parsed.errors.length : 0;
+      const scenePlan = parsed.scene_plan || { scenes: [], warnings: [] };
+      const plannedSceneCount = Number(scenePlan.scene_count || 0);
+      const speakerHtml = speakerCount
+        ? parsed.speakers.map((speaker) => `<span style="display:inline-flex;gap:6px;align-items:center;border:1px solid #0e7490;border-radius:999px;background:#083344;color:#cffafe;padding:5px 9px;font-size:11px;font-weight:900;">${escapeHtml(speaker.name)} <span style="color:#67e8f9;">${Number(speaker.cue_count || 0)} cue${Number(speaker.cue_count || 0) === 1 ? "" : "s"}</span></span>`).join("")
+        : `<span style="color:#fca5a5;">No speakers detected.</span>`;
+      const matchedCount = parsed.speakers.filter((speaker) => speaker.reference_subject_id).length;
+      useGuidedScriptButton.disabled = !cueCount || errorCount > 0 || matchedCount !== speakerCount;
+      useGuidedScriptButton.title = errorCount
+        ? "Resolve every parse issue before activating the script."
+        : matchedCount !== speakerCount
+          ? "Match every script speaker to a Reference Builder character first."
+          : "Save this exact script and timed segment plan as the authoritative source for Guided Film Automation.";
+      const speakerMappingHtml = speakerCount
+        ? parsed.speakers.map((speaker, index) => {
+          const status = speaker.reference_subject_id
+            ? speaker.match_method === "auto" ? "Auto matched" : "Manually matched"
+            : "Needs a character";
+          const statusColor = speaker.reference_subject_id ? "#86efac" : "#fbbf24";
+          const options = [
+            `<option value="">Choose Reference Builder character...</option>`,
+            ...referenceCharacters.map((character) => `<option value="${escapeHtml(character.id)}"${String(character.id) === String(speaker.reference_subject_id) ? " selected" : ""}>${escapeHtml(character.name)}</option>`),
+          ].join("");
+          return `<div style="display:grid;grid-template-columns:minmax(130px,.65fr) minmax(210px,1.35fr) auto;gap:9px;align-items:center;border-top:${index ? "1px solid #1e3a5f" : "0"};padding:${index ? "9px 0 0" : "0"};margin-top:${index ? "9px" : "0"};"><div style="min-width:0;"><div style="font-size:10px;color:#94a3b8;text-transform:uppercase;font-weight:900;">Script speaker</div><div title="${escapeHtml(speaker.name)}" style="color:#cffafe;font-weight:900;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-top:3px;">${escapeHtml(speaker.name)}</div></div><select data-script-speaker-index="${index}" style="width:100%;box-sizing:border-box;border:1px solid #334155;border-radius:6px;background:#18181b;color:#f8fafc;padding:9px;"${referenceCharacters.length ? "" : " disabled"}>${options}</select><div style="color:${statusColor};font-size:11px;font-weight:900;white-space:nowrap;">${status}</div></div>`;
+        }).join("")
+        : `<div style="color:#fca5a5;">Parse at least one valid speaker before matching characters.</div>`;
+      const rows = cueCount
+        ? parsed.cues.map((cue) => `<tr style="border-top:1px solid #1e3a5f;"><td style="padding:8px;color:#67e8f9;font-weight:900;vertical-align:top;">${cue.index}</td><td style="padding:8px;color:#94a3b8;vertical-align:top;">${cue.line_number || "JSON"}</td><td style="padding:8px;color:#cffafe;font-weight:900;vertical-align:top;overflow-wrap:anywhere;">${escapeHtml(cue.speaker)}</td><td style="padding:8px;color:#e2e8f0;vertical-align:top;line-height:1.4;overflow-wrap:anywhere;">${escapeHtml(cue.text)}</td><td style="padding:8px;color:#a5f3fc;text-align:right;vertical-align:top;">${cue.word_count}</td></tr>`).join("")
+        : `<tr><td colspan="5" style="padding:18px;color:#fca5a5;text-align:center;">No valid dialogue cues were parsed.</td></tr>`;
+      const errorsHtml = errorCount
+        ? `<div style="margin-top:12px;border:1px solid #991b1b;border-radius:7px;background:#3f0808;padding:10px;"><div style="font-weight:900;color:#fecaca;">${errorCount} issue${errorCount === 1 ? "" : "s"} found</div>${parsed.errors.map((error) => `<div style="margin-top:6px;color:#fecaca;font-size:12px;line-height:1.4;"><strong>${error.line_number ? `Line ${error.line_number}: ` : ""}</strong>${escapeHtml(error.message)}${error.source ? `<div style="color:#fca5a5;font-family:monospace;overflow-wrap:anywhere;">${escapeHtml(error.source)}</div>` : ""}</div>`).join("")}</div>`
+        : `<div style="margin-top:12px;border:1px solid #166534;border-radius:7px;background:#052e16;color:#bbf7d0;padding:9px 10px;font-size:12px;font-weight:900;">All non-empty script lines parsed successfully. Exact dialogue was preserved.</div>`;
+      const scenePlanHtml = plannedSceneCount
+        ? scenePlan.scenes.map((scene) => {
+          const participantHtml = Array.isArray(scene.participants) && scene.participants.length
+            ? scene.participants.map((participant) => `<span style="display:inline-flex;border:1px solid #334155;border-radius:999px;background:#0f172a;color:#bae6fd;padding:3px 7px;font-size:10px;font-weight:900;">${escapeHtml(participant.name || participant.alias || "Unmatched speaker")}</span>`).join("")
+            : `<span style="color:#fbbf24;font-size:11px;">No matched participants</span>`;
+          const dialogueHtml = (Array.isArray(scene.speaker_assignments) ? scene.speaker_assignments : []).map((cue) => `<div style="display:grid;grid-template-columns:82px minmax(105px,.35fr) minmax(0,1fr);gap:8px;border-top:1px solid #1e3a5f;padding:7px 0;align-items:start;"><div style="color:#67e8f9;font:10px monospace;white-space:nowrap;">${Number(cue.planned_start_seconds || 0).toFixed(2)}–${Number(cue.planned_end_seconds || 0).toFixed(2)}s</div><div style="color:#cffafe;font-size:11px;font-weight:900;overflow-wrap:anywhere;">${escapeHtml(cue.speaker_name || cue.speaker_alias)}${Number(cue.part_count || 1) > 1 ? `<div style="color:#fbbf24;font-size:9px;margin-top:2px;">Split ${cue.part_index}/${cue.part_count}</div>` : ""}</div><div style="color:#e2e8f0;font-size:11px;line-height:1.4;overflow-wrap:anywhere;">${escapeHtml(cue.text)}</div></div>`).join("");
+          return `<div style="border:1px solid #334155;border-radius:7px;background:#07111f;padding:9px;margin-top:8px;"><div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;"><div><div style="font-weight:900;color:#cffafe;">Segment ${scene.index}${scene.continuation_of_previous ? ` <span style="color:#fbbf24;font-size:10px;">CONTINUATION</span>` : ""}</div><div style="color:#94a3b8;font:10px monospace;margin-top:3px;">Timeline ${Number(scene.timeline_start_seconds || 0).toFixed(1)}–${Number(scene.timeline_end_seconds || 0).toFixed(1)}s</div><div style="display:flex;flex-wrap:wrap;gap:5px;margin-top:5px;">${participantHtml}</div></div><div style="text-align:right;"><div style="font-weight:900;color:#67e8f9;">${Number(scene.duration_seconds || 0).toFixed(1)}s</div><div style="color:#94a3b8;font-size:10px;">max ${Number(scene.maximum_scene_seconds || 0).toFixed(1)}s</div></div></div><div style="margin-top:7px;">${dialogueHtml}</div></div>`;
+        }).join("")
+        : `<div style="color:#fca5a5;padding:10px;text-align:center;">No scenes could be planned from the parsed dialogue.</div>`;
+      const planWarningsHtml = Array.isArray(scenePlan.warnings) && scenePlan.warnings.length
+        ? `<div style="margin-top:8px;color:#fde68a;font-size:11px;line-height:1.4;">${scenePlan.warnings.map((warning) => escapeHtml(warning)).join("<br>")}</div>`
+        : "";
+      previewPanel.innerHTML = `
+        <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;">
+          <div style="border:1px solid #334155;border-radius:7px;background:#0f172a;padding:9px;"><div style="font-size:10px;color:#94a3b8;font-weight:900;text-transform:uppercase;">Format</div><div style="margin-top:3px;color:#cffafe;font-weight:900;">${escapeHtml(String(parsed.format || "text").toUpperCase())}</div></div>
+          <div style="border:1px solid #334155;border-radius:7px;background:#0f172a;padding:9px;"><div style="font-size:10px;color:#94a3b8;font-weight:900;text-transform:uppercase;">Speakers</div><div style="margin-top:3px;color:#cffafe;font-weight:900;">${speakerCount}</div></div>
+          <div style="border:1px solid #334155;border-radius:7px;background:#0f172a;padding:9px;"><div style="font-size:10px;color:#94a3b8;font-weight:900;text-transform:uppercase;">Dialogue cues</div><div style="margin-top:3px;color:#cffafe;font-weight:900;">${cueCount}</div></div>
+          <div style="border:1px solid #334155;border-radius:7px;background:#0f172a;padding:9px;"><div style="font-size:10px;color:#94a3b8;font-weight:900;text-transform:uppercase;">Words / raw speech</div><div style="margin-top:3px;color:#cffafe;font-weight:900;">${wordCount} / ${speechSeconds.toFixed(1)}s</div></div>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:7px;margin-top:11px;">${speakerHtml}</div>
+        <div style="margin-top:12px;border:1px solid ${matchedCount === speakerCount && speakerCount ? "#166534" : "#92400e"};border-radius:7px;background:${matchedCount === speakerCount && speakerCount ? "#052e16" : "#291804"};padding:10px;">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;margin-bottom:9px;"><div><div style="font-weight:900;color:${matchedCount === speakerCount && speakerCount ? "#bbf7d0" : "#fde68a"};">Speaker matching — ${matchedCount}/${speakerCount} matched</div><div style="font-size:11px;color:#cbd5e1;line-height:1.4;margin-top:3px;">Match each exact script name to the character that should speak it. Clear automatic matches can be changed manually.</div></div><div style="color:#94a3b8;font-size:11px;text-align:right;">${referenceCharacters.length} Reference Builder character${referenceCharacters.length === 1 ? "" : "s"}</div></div>
+          ${referenceCharacters.length ? speakerMappingHtml : `<div style="border:1px solid #991b1b;border-radius:6px;background:#3f0808;color:#fecaca;padding:9px;font-size:12px;">No Reference Builder characters are available. Add or save the film characters in Reference Builder, then reopen Script Mapper.</div>`}
+        </div>
+        <div style="margin-top:12px;border:1px solid #0e7490;border-radius:7px;background:#06283d;padding:10px;">
+          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;"><div><div style="font-weight:900;color:#cffafe;">Timed MiniMax scene plan</div><div style="font-size:11px;color:#bae6fd;line-height:1.4;margin-top:3px;">${plannedSceneCount} segment${plannedSceneCount === 1 ? "" : "s"}; ${Number(scenePlan.estimated_total_seconds || 0).toFixed(1)} estimated total seconds. Each clip stays at or below ${Number(scenePlan.maximum_scene_seconds || currentMaximumSceneSeconds()).toFixed(1)} seconds.</div></div><div style="color:#67e8f9;font-weight:900;white-space:nowrap;">${Number(scenePlan.split_cue_count || 0)} long cue${Number(scenePlan.split_cue_count || 0) === 1 ? "" : "s"} split</div></div>
+          ${planWarningsHtml}
+          <div style="margin-top:8px;max-height:620px;overflow:auto;padding-right:3px;">${scenePlanHtml}</div>
+        </div>
+        <div style="margin-top:12px;border:1px solid #334155;border-radius:7px;overflow:auto;max-height:520px;">
+          <table style="width:100%;border-collapse:collapse;table-layout:fixed;font-size:12px;">
+            <thead><tr style="background:#0f172a;color:#bae6fd;text-align:left;"><th style="width:42px;padding:8px;">#</th><th style="width:58px;padding:8px;">Line</th><th style="width:150px;padding:8px;">Speaker</th><th style="padding:8px;">Exact dialogue</th><th style="width:54px;padding:8px;text-align:right;">Words</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+        ${errorsHtml}`;
+      previewPanel.querySelectorAll("select[data-script-speaker-index]").forEach((select) => {
+        select.onchange = () => {
+          const speaker = parsed.speakers[Number(select.dataset.scriptSpeakerIndex || 0)];
+          if (!speaker) return;
+          const aliasKey = storyboardScriptSpeakerMatchKey(speaker.name);
+          speakerMatches.set(aliasKey, {
+            subject_id: String(select.value || ""),
+            method: select.value ? "manual" : "unmatched",
+          });
+          renderParsedPreview(parsed);
+        };
+      });
+      sourceStatus.textContent = cueCount
+        ? `Parsed ${cueCount} exact cue${cueCount === 1 ? "" : "s"} from ${speakerCount} speaker${speakerCount === 1 ? "" : "s"}; planned ${plannedSceneCount} MiniMax segment${plannedSceneCount === 1 ? "" : "s"} at a ${currentMaximumSceneSeconds()}s maximum. ${matchedCount}/${speakerCount} matched to Reference Builder.${errorCount ? ` Review ${errorCount} issue${errorCount === 1 ? "" : "s"}.` : ""}`
+        : "No valid dialogue cues were found.";
+      sourceStatus.style.color = cueCount && !errorCount && matchedCount === speakerCount ? "#67e8f9" : "#fbbf24";
+    };
+    renderEmptyPreview();
+    mapperBody.append(sourcePanel, previewPanel);
+
+    const mapperFooter = document.createElement("div");
+    mapperFooter.style.cssText = "display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:10px;padding:12px 18px;background:#0f172a;border-top:1px solid #334155;";
+    const footerNote = document.createElement("div");
+    footerNote.style.cssText = "color:#94a3b8;font-size:12px;line-height:1.4;";
+    footerNote.textContent = "Use This Script makes the exact dialogue authoritative for Guided Film Automation. It still does not change the Video Builder timeline.";
+    const footerActions = document.createElement("div");
+    footerActions.style.cssText = "display:flex;flex-wrap:wrap;gap:8px;";
+    const mapperDone = makeButton("Done", "primary");
+    footerActions.append(removeGuidedScriptButton, copyParsedButton, useGuidedScriptButton, mapperDone);
+    mapperFooter.append(footerNote, footerActions);
+    mapperShell.append(mapperHeader, mapperBody, mapperFooter);
+    mapperBackdrop.append(mapperShell);
+    document.body.append(mapperBackdrop);
+
+    const closeMapper = () => {
+      document.removeEventListener("keydown", onMapperKeyDown, true);
+      mapperBackdrop.remove();
+    };
+    const onMapperKeyDown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      closeMapper();
+    };
+    mapperCloseTop.onclick = closeMapper;
+    mapperDone.onclick = closeMapper;
+    mapperBackdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === mapperBackdrop) closeMapper();
+    });
+    document.addEventListener("keydown", onMapperKeyDown, true);
+    loadScriptButton.onclick = () => scriptFileInput.click();
+    maxSceneLengthSelect.onchange = () => {
+      customSceneLengthInput.style.display = maxSceneLengthSelect.value === "custom" ? "" : "none";
+      if (lastParsed?.cues?.length) renderParsedPreview(lastParsed);
+    };
+    customSceneLengthInput.onchange = () => {
+      customSceneLengthInput.value = String(currentMaximumSceneSeconds());
+      if (lastParsed?.cues?.length) renderParsedPreview(lastParsed);
+    };
+    scriptFileInput.onchange = async () => {
+      const file = scriptFileInput.files?.[0];
+      if (!file) return;
+      try {
+        scriptInput.value = await file.text();
+        sourceStatus.textContent = `Loaded ${file.name}. Parsing preview...`;
+        renderParsedPreview(parseStoryboardScriptImport(scriptInput.value));
+      } catch (error) {
+        sourceStatus.textContent = `Could not read ${file.name}: ${String(error?.message || error)}`;
+        sourceStatus.style.color = "#fca5a5";
+      } finally {
+        scriptFileInput.value = "";
+      }
+    };
+    parseScriptButton.onclick = () => renderParsedPreview(parseStoryboardScriptImport(scriptInput.value));
+    clearScriptButton.onclick = () => {
+      scriptInput.value = "";
+      lastParsed = null;
+      speakerMatches.clear();
+      copyParsedButton.disabled = true;
+      sourceStatus.textContent = "";
+      renderEmptyPreview();
+      scriptInput.focus();
+    };
+    copyParsedButton.onclick = async () => {
+      if (!lastParsed?.cues?.length) return;
+      await copyTextToClipboard(JSON.stringify(lastParsed, null, 2));
+      createToast("Parsed script JSON copied. No timeline changes were made.");
+    };
+    useGuidedScriptButton.onclick = async () => {
+      if (!lastParsed?.cues?.length || useGuidedScriptButton.disabled) return;
+      useGuidedScriptButton.disabled = true;
+      try {
+        state.scriptImport = normalizeStoryboardScriptImportState({
+          enabled: true,
+          authoritative: true,
+          format: lastParsed.format,
+          raw_text: scriptInput.value,
+          imported_at: new Date().toISOString(),
+          maximum_scene_seconds: currentMaximumSceneSeconds(),
+          cues: lastParsed.cues,
+        });
+        refreshSetupPanelSummaries();
+        notifyStoryboardDefaultsChanged();
+        if (state.projectFolder) {
+          await postJson("/vrgdg/storyboard/save", {
+            project_folder: state.projectFolder,
+            storyboard: slimStoryboardForRequest(state),
+          });
+        }
+        closeMapper();
+        createToast(`Authoritative script activated: ${state.scriptImport.cues.length} exact cue${state.scriptImport.cues.length === 1 ? "" : "s"} across ${state.scriptImport.scene_plan.scene_count} planned MiniMax segment${state.scriptImport.scene_plan.scene_count === 1 ? "" : "s"}.`);
+      } catch (error) {
+        sourceStatus.textContent = `Could not activate the script: ${String(error?.message || error)}`;
+        sourceStatus.style.color = "#fca5a5";
+        useGuidedScriptButton.disabled = false;
+      }
+    };
+    removeGuidedScriptButton.onclick = async () => {
+      if (!window.confirm("Remove the authoritative imported script from Guided Film Automation?\n\nThis does not delete existing Storyboard or Video Builder scenes.")) return;
+      removeGuidedScriptButton.disabled = true;
+      try {
+        state.scriptImport = normalizeStoryboardScriptImportState({});
+        refreshSetupPanelSummaries();
+        notifyStoryboardDefaultsChanged();
+        if (state.projectFolder) {
+          await postJson("/vrgdg/storyboard/save", {
+            project_folder: state.projectFolder,
+            storyboard: slimStoryboardForRequest(state),
+          });
+        }
+        closeMapper();
+        createToast("Authoritative script removed. Existing scenes were not changed.");
+      } catch (error) {
+        sourceStatus.textContent = `Could not remove the active script: ${String(error?.message || error)}`;
+        sourceStatus.style.color = "#fca5a5";
+        removeGuidedScriptButton.disabled = false;
+      }
+    };
+    if (existingScriptImport.enabled && scriptInput.value.trim()) {
+      renderParsedPreview(parseStoryboardScriptImport(scriptInput.value));
+    } else {
+      scriptInput.focus();
+    }
+  };
+
+  const planFilmDialogueScenesWithLlm = async () => {
+    if (!isIdLoraMode && !isMiniMaxShortFilmMode) return;
+    if (isFullyCustomShortFilm()) {
+      createToast("Fully Custom uses your manual scene cards. Switch to Guided Film Automation to ask the LLM to plan dialogue scenes.");
+      return;
+    }
     syncStoryLayerFromInputs();
-    const sceneCount = Math.max(1, Math.min(24, Number(idLoraDialogueSceneCount.value || 6)));
+    const authoritativeScript = normalizeStoryboardScriptImportState(state.scriptImport);
+    const sceneCount = authoritativeScript.enabled
+      ? Math.max(1, Math.min(80, Number(authoritativeScript.scene_plan.scene_count || 1)))
+      : Math.max(1, Math.min(24, Number(idLoraDialogueSceneCount.value || 6)));
     idLoraDialogueSceneCount.value = String(sceneCount);
-    const progress = createStoryboardProgressWindow("ID-LoRA Dialogue Scenes");
+    const plannerLabel = isIdLoraMode ? "ID-LoRA Dialogue Scenes" : "MiniMax Short Film Scenes";
+    const progress = createStoryboardProgressWindow(plannerLabel);
     try {
-      progress.set(`Planning ${sceneCount} ID-LoRA dialogue scene${sceneCount === 1 ? "" : "s"} with ${promptRunnerName()}...`, 8);
-      const data = await postJson("/vrgdg/storyboard/id_lora_dialogue_scenes", {
+      progress.set(`Planning ${sceneCount} ${isIdLoraMode ? "ID-LoRA" : "MiniMax"} dialogue scene${sceneCount === 1 ? "" : "s"} with ${promptRunnerName()}...`, 8);
+      const data = await postJson(isIdLoraMode ? "/vrgdg/storyboard/id_lora_dialogue_scenes" : "/vrgdg/storyboard/minimax_dialogue_scenes", {
         ...(state.gemmaSettings || {}),
-        story_source: [userStoryArcInput.value, songStoryBriefInput.value].map((item) => String(item || "").trim()).filter(Boolean).join("\n\n"),
+        story_source: authoritativeScript.enabled
+          ? authoritativeScript.raw_text
+          : [userStoryArcInput.value, songStoryBriefInput.value].map((item) => String(item || "").trim()).filter(Boolean).join("\n\n"),
+        script_import: authoritativeScript,
         story_layer: normalizeStoryLayer(state.storyLayer),
         reference_builder: state.referenceBuilder || {},
         scenes: state.scenes.map((scene, index) => slimSceneForRequest(scene, index)),
         storyboard: slimStoryboardForRequest(state),
         scene_count: sceneCount,
-        video_prompt_type: "id_lora",
+        project_video_engine: state.projectVideoEngine,
+        minimax_h3_mode: state.miniMaxH3Mode,
+        video_prompt_type: isIdLoraMode ? "id_lora" : state.videoPromptType,
+        short_film_planning_mode: "guided_film",
         performance_mode: "speaking",
         unload_after: true,
         max_new_tokens: Math.max(2200, sceneCount * 520),
@@ -3102,7 +4662,13 @@ function openStoryboardBuilder(payload = {}) {
       const generated = Array.isArray(data.scenes) ? data.scenes : [];
       if (!generated.length) throw new Error("Gemma returned no dialogue scenes.");
       state.scenes = generated.map((scene, index) => {
-        const normalized = normalizeScene({ ...scene, video_prompt_type: "id_lora", performance_mode: "speaking" }, index);
+        const normalized = normalizeScene({
+          ...scene,
+          video_prompt_type: isIdLoraMode ? "id_lora" : state.videoPromptType,
+          project_video_engine: isIdLoraMode ? "ltx" : "minimax_h3",
+          minimax_h3_mode: isIdLoraMode ? "" : state.miniMaxH3Mode,
+          performance_mode: "speaking",
+        }, index);
         normalized.id_lora_character_id = scene.id_lora_character_id || scene.character_id || scene.subject_id || "";
         normalized.id_lora_location_id = scene.id_lora_location_id || scene.location_id || "";
         return normalized;
@@ -3115,37 +4681,39 @@ function openStoryboardBuilder(payload = {}) {
       setMode("storyboard_prompts");
       renderTable();
       refreshSetupPanelSummaries();
-      progress.set(`Dialogue scene plan ready.\nCreated ${state.scenes.length} preview scene${state.scenes.length === 1 ? "" : "s"}.`, 96);
+      progress.set(`Storyboard scenes ready.\nCreated ${state.scenes.length} editable storyboard scene${state.scenes.length === 1 ? "" : "s"}. The Video Builder timeline has not been changed.`, 96);
       await saveStoryboard();
-      progress.set(`Dialogue scene plan saved for review.\nNext step will apply this plan to Video Builder.`, 100);
+      progress.set(`Storyboard saved for review.\nNext: click Create ${state.scenes.length} Timeline Segment${state.scenes.length === 1 ? "" : "s"} to build the Video Builder timeline.`, 100);
       progress.close(1800);
-      createToast(`ID-LoRA dialogue plan created with ${state.scenes.length} preview scene${state.scenes.length === 1 ? "" : "s"}.`);
+      createToast(`Created ${state.scenes.length} ${isIdLoraMode ? "ID-LoRA" : "MiniMax"} storyboard scene${state.scenes.length === 1 ? "" : "s"}. The timeline is unchanged until you click Create ${state.scenes.length} Timeline Segment${state.scenes.length === 1 ? "" : "s"}.`);
     } catch (error) {
-      progress.set(`ID-LoRA dialogue planning failed:\n${String(error?.message || error)}`, 100);
-      createToast(`ID-LoRA dialogue planning failed:\n${String(error?.message || error)}`, true);
+      progress.set(`${isIdLoraMode ? "ID-LoRA" : "MiniMax"} dialogue planning failed:\n${String(error?.message || error)}`, 100);
+      createToast(`${isIdLoraMode ? "ID-LoRA" : "MiniMax"} dialogue planning failed:\n${String(error?.message || error)}`, true);
     }
   };
 
-  const applyIdLoraDialoguePlanToVideoBuilder = async () => {
-    if (!isIdLoraMode || !state.onApplyIdLoraDialoguePlan) return;
+  const applyFilmDialoguePlanToVideoBuilder = async () => {
+    const applyCallback = isIdLoraMode ? state.onApplyIdLoraDialoguePlan : state.onApplyMiniMaxDialoguePlan;
+    if (!applyCallback) return;
     const scenes = state.scenes
       .map((scene, index) => slimSceneForRequest(scene, index))
       .filter((scene) => String(scene.lyrics || scene.story_beat || scene.image_prompt || "").trim());
     if (!scenes.length) {
-      createToast("No ID-LoRA dialogue plan scenes found.", true);
+      createToast(`No reviewed ${isIdLoraMode ? "ID-LoRA" : "MiniMax"} storyboard scenes were found to create timeline segments.`, true);
       return;
     }
-    const confirmed = window.confirm(`Apply ${scenes.length} ID-LoRA dialogue scene${scenes.length === 1 ? "" : "s"} to Video Builder?\n\nThis will replace the blank starter timeline scene when the project is still empty. If real scenes already exist, Video Builder will ask/guard before replacing.`);
+    const confirmed = window.confirm(`Create ${scenes.length} Video Builder timeline segment${scenes.length === 1 ? "" : "s"} from the reviewed ${isIdLoraMode ? "ID-LoRA" : "MiniMax"} storyboard scenes?\n\nThis is the step that creates the timeline. Export Prompt Files Only does not create timeline segments.\n\nThe blank starter scene will be replaced. If real scenes already exist, Video Builder will ask before replacing them.`);
     if (!confirmed) return;
     try {
       applyDialoguePlanButton.disabled = true;
-      const result = await state.onApplyIdLoraDialoguePlan({
+      const result = await applyCallback({
         story_layer: normalizeStoryLayer(state.storyLayer),
+        short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
         scenes,
       });
-      createToast(result?.message || `Applied ${scenes.length} ID-LoRA dialogue scene${scenes.length === 1 ? "" : "s"} to Video Builder.`);
+      createToast(result?.message || `Created ${scenes.length} Video Builder timeline segment${scenes.length === 1 ? "" : "s"} from the reviewed ${isIdLoraMode ? "ID-LoRA" : "MiniMax"} storyboard.`);
     } catch (error) {
-      createToast(`Apply Dialogue Plan failed:\n${String(error?.message || error)}`, true);
+      createToast(`Create Timeline Segments failed:\n${String(error?.message || error)}`, true);
     } finally {
       applyDialoguePlanButton.disabled = false;
     }
@@ -3389,6 +4957,9 @@ function openStoryboardBuilder(payload = {}) {
         location_id: String(scene.location_ref?.id || ""),
         trigger: String(scene.trigger_phrase || ""),
         trigger_position: String(scene.trigger_position || "start") === "end" ? "end" : "start",
+        speaker_assignments: normalizeStoryboardSpeakerAssignments(scene.speaker_assignments),
+        lyric_text: String(scene.lyrics || ""),
+        lyric_singers: Array.isArray(scene.lyric_singers) ? [...scene.lyric_singers] : [],
       })),
     });
   }
@@ -3630,6 +5201,36 @@ function openStoryboardBuilder(payload = {}) {
     return ref;
   };
 
+  const applyVideoStyle = ({ overwrite = false } = {}) => {
+    if (state.mode !== "image_to_video_prep") {
+      createToast("Video style is only available in Video Prep.");
+      return;
+    }
+    const value = String(state.videoStyle || "").trim();
+    if (!value) {
+      createToast("Choose a MiniMax video style first.");
+      return;
+    }
+    if (value === "custom" && !String(state.videoStyleCustom || "").trim()) {
+      createToast("Type the exact custom style wording first.");
+      return;
+    }
+    let changed = 0;
+    state.scenes.forEach((scene) => {
+      if (!storyboardSceneSupportsMiniMaxVideoStyle(scene)) return;
+      if (!overwrite && String(scene.video_style || "").trim()) return;
+      scene.video_style = value;
+      scene.video_style_custom = value === "custom" ? String(state.videoStyleCustom || "").trim() : "";
+      changed += 1;
+    });
+    renderTable();
+    if (overwrite) {
+      createToast(changed ? `Video style replaced ${changed} eligible scene${changed === 1 ? "" : "s"}.` : "No eligible MiniMax scene styles were changed.");
+    } else {
+      createToast(changed ? `Video style filled ${changed} eligible scene${changed === 1 ? "" : "s"}.` : "No blank eligible MiniMax scene styles needed filling.");
+    }
+  };
+
   const openStoryboardSubjectPicker = (scene) => {
     if (!scene) return;
     const backdrop = document.createElement("div");
@@ -3784,6 +5385,21 @@ function openStoryboardBuilder(payload = {}) {
     const characterMotionPreset = makeGroupedSelect(CHARACTER_MOTION_GROUPS, characterMotionValue);
     const customCharacterMotion = makeInput(scene.character_motion || "", "Custom character motion");
     const performanceStyle = makeSelect(performanceStylePresets, scene.performance_style || "");
+    const videoStyle = makeSelect(MINIMAX_VIDEO_STYLE_PRESETS, state.videoStyle || scene.video_style || "");
+    videoStyle.disabled = Boolean(state.videoStyle);
+    videoStyle.title = state.videoStyle ? "The global Video style is required for every eligible scene." : "Choose a style for this scene.";
+    const videoStyleCustom = makeTextarea(
+      state.videoStyle === "custom" ? state.videoStyleCustom : (scene.video_style_custom || state.videoStyleCustom || ""),
+      "Type the exact style wording that must appear unchanged in this scene's prompt...",
+      3,
+    );
+    videoStyleCustom.disabled = Boolean(state.videoStyle);
+    const temporalEffectOverride = makeSelect([
+      { value: "global", label: "Use global temporal effect" },
+      { value: "off", label: "Off for this scene" },
+      ...MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS.filter((item) => item.value).map((item) => ({ value: item.value, label: item.label })),
+    ], scene.temporal_world_effect_override || "global");
+    const temporalEffectCustom = makeTextarea(scene.temporal_world_effect_custom || "", "Exact custom temporal behavior for only this scene...", 3);
     const facialPerformance = makeSelect(facialPerformancePresets, scene.facial_performance || "");
     const facialPerformanceCustom = makeTextarea(scene.facial_performance_custom || "", "Optional custom facial expression/movement text for this scene...", 3);
     const includeMicLabel = document.createElement("label");
@@ -3903,6 +5519,8 @@ function openStoryboardBuilder(payload = {}) {
       { value: "end", label: "Add trigger to end" },
     ], scene.trigger_position || "start");
     const notes = makeTextarea(scene.notes, "Extra planning notes...", 3);
+    const audioDirection = makeTextarea(scene.audio_direction || "", "Exact ambience, sound effects, silence, breathing, or audio behavior for this scene...", 4);
+    const continuityDirection = makeTextarea(scene.continuity || "", "Exact identity, wardrobe, prop, location, screen-direction, and spatial continuity requirements...", 4);
     const selectedSubjectIds = scene.no_character_present ? [] : (Array.isArray(scene.subject_refs) ? scene.subject_refs : [])
       .map((ref) => String(ref?.id || ""))
       .filter(Boolean);
@@ -3976,13 +5594,17 @@ function openStoryboardBuilder(payload = {}) {
     const characterMotionField = field("Character motion preset", characterMotionPreset);
     const customCharacterMotionField = field("Custom character motion", customCharacterMotion);
     const performanceStyleField = field("Performance / song style", performanceStyle);
+    const videoStyleField = field(state.videoStyle ? "Video aesthetic — global and required" : "Video aesthetic", videoStyle);
+    const videoStyleCustomField = field("Custom style wording — copied exactly", videoStyleCustom);
+    const temporalEffectField = field("Temporal / world effect", temporalEffectOverride);
+    const temporalEffectCustomField = field("Custom temporal wording", temporalEffectCustom);
     const facialPerformanceField = field("Facial performance", facialPerformance);
     const facialPerformanceCustomField = field("Custom facial performance", facialPerformanceCustom);
     const imagePathField = field("Starting image", startingImageControl);
     const motionField = field(isImagePrepMode ? "Still photography notes" : "Motion Notes / LLM Direction", motion);
     const t2iPromptField = field("T2I prompt", imagePrompt);
     if (isVideoPrepMode) {
-      grid.append(field("Video prompt type", videoPromptType), field("Setting", setting), videoTypeHint, field("Subjects", subjects), performanceStyleField, facialPerformanceField, facialPerformanceCustomField, includeMicLabel, noCharacterLabel, shotPresetField, shotCustomField, cameraMotionField, characterMotionField, customCharacterMotionField, imagePathField, field("Scene trigger phrase", triggerPhrase), field("Trigger placement", triggerPosition));
+      grid.append(field("Video prompt type", videoPromptType), videoStyleField, videoStyleCustomField, field("Setting", setting), videoTypeHint, field("Subjects", subjects), performanceStyleField, facialPerformanceField, facialPerformanceCustomField, includeMicLabel, noCharacterLabel, shotPresetField, shotCustomField, cameraMotionField, characterMotionField, customCharacterMotionField, imagePathField, field("Scene trigger phrase", triggerPhrase), field("Trigger placement", triggerPosition));
     } else {
       grid.append(field("Setting", setting), field("Subjects", subjects), performanceStyleField, facialPerformanceField, facialPerformanceCustomField, includeMicLabel, noCharacterLabel, shotPresetField, shotCustomField, cameraMotionField, field("Scene trigger phrase", triggerPhrase), field("Trigger placement", triggerPosition));
     }
@@ -4003,6 +5625,10 @@ function openStoryboardBuilder(payload = {}) {
     const cancel = makeButton("Cancel");
     const apply = makeButton("Save Scene Card", "primary");
     actions.append(cancel, gemmaBeat, gemma, apply);
+    if (isFullyCustomShortFilm()) {
+      gemmaBeat.style.display = "none";
+      gemma.title = "Formats the manually entered scene card into a MiniMax H3 prompt without inventing or rewriting scene content.";
+    }
     const closeEditor = makeButton("×");
     closeEditor.style.cssText += "font-size:26px;line-height:1;width:44px;height:44px;padding:0;border-radius:8px;";
     const header = document.createElement("div");
@@ -4017,7 +5643,7 @@ function openStoryboardBuilder(payload = {}) {
     const basicsGrid = twoCol();
     basicsGrid.append(field("Scene label", label), field("Lyric section", lyricSection), field("Scene / lyrics", lyrics), field("Scene story beat", storyBeat));
     if (isVideoPrepMode) {
-      basicsGrid.append(field("Prompt mode", iconField("▣", videoPromptType)), field("Performance / song style", performanceStyle), field("Facial performance", facialPerformance), field("Custom facial performance", facialPerformanceCustom), includeMicLabel, noCharacterLabel, videoTypeHint);
+      basicsGrid.append(field("Prompt mode", iconField("▣", videoPromptType)), videoStyleField, videoStyleCustomField, temporalEffectField, temporalEffectCustomField, field("Performance / song style", performanceStyle), field("Facial performance", facialPerformance), field("Custom facial performance", facialPerformanceCustom), includeMicLabel, noCharacterLabel, videoTypeHint);
     } else {
       const imagePromptType = makeInput("Text to Image", "Text to Image");
       imagePromptType.readOnly = true;
@@ -4065,6 +5691,136 @@ function openStoryboardBuilder(payload = {}) {
     referencesGrid.append(subjectPick, locationPick, ...Array.from(referenceGrid.children));
     refreshReferenceChips();
 
+    const speakerAssignmentEnabled = isVideoPrepMode
+      && miniMaxProject
+      && normalizeStoryboardPerformanceMode(scene.performance_mode || state.performanceMode) === "speaking"
+      && normalizeStoryboardMiniMaxH3AudioMode(scene.minimax_h3_audio_mode || state.miniMaxH3AudioMode) === "built_in_audio";
+    let speakerAssignments = normalizeStoryboardSpeakerAssignments(scene.speaker_assignments);
+    const speakerAssignmentWrap = document.createElement("div");
+    speakerAssignmentWrap.style.cssText = "display:flex;flex-direction:column;gap:9px;";
+    const speakerAssignmentNote = document.createElement("div");
+    speakerAssignmentNote.style.cssText = "border:1px solid #155e75;border-radius:8px;background:#07111f;color:#cbd5e1;padding:9px 10px;font-size:12px;line-height:1.45;";
+    speakerAssignmentNote.textContent = "Drag cues into the exact speaking order. The same character can have multiple turns. Speaker choices come only from this scene’s mapped Reference Builder characters.";
+    const speakerAssignmentRows = document.createElement("div");
+    speakerAssignmentRows.style.cssText = "display:flex;flex-direction:column;gap:8px;";
+    const addSpeakerAssignment = makeButton("Add Dialogue Cue", "primary");
+    const mappedSpeakerOptions = () => {
+      const selectedIds = Array.from(subjectSelect.selectedOptions).map((option) => String(option.value || "")).filter(Boolean);
+      const selected = selectedIds
+        .map((id) => state.referenceBuilder.subjects.find((subject) => String(subject.id || "") === id))
+        .filter(Boolean);
+      const fallback = Array.isArray(scene.subject_refs) ? scene.subject_refs : [];
+      return (selected.length ? selected : fallback)
+        .filter((subject) => subject && typeof subject === "object")
+        .map((subject) => ({ id: String(subject.id || ""), name: String(subject.name || "Character").trim() || "Character" }));
+    };
+    const syncSpeakerAssignmentLegacy = () => {
+      speakerAssignments = normalizeStoryboardSpeakerAssignments(speakerAssignments);
+      scene.speaker_assignments = speakerAssignments;
+      const filled = speakerAssignments.filter((cue) => cue.text);
+      const combined = filled.map((cue) => cue.text).join("\n");
+      lyrics.value = combined;
+      scene.lyrics = combined;
+      scene.lyric_singers = Array.from(new Set(filled.map((cue) => cue.speaker_name).filter(Boolean)));
+    };
+    const ensureSpeakerAssignments = () => {
+      if (speakerAssignments.length) return;
+      const speakers = mappedSpeakerOptions();
+      const existingLine = String(scene.lyrics || lyrics.value || "").trim();
+      if (existingLine) {
+        const preferred = String((Array.isArray(scene.lyric_singers) ? scene.lyric_singers[0] : "") || "").trim();
+        const speaker = speakers.find((item) => item.name.toLowerCase() === preferred.toLowerCase()) || speakers[0] || { id: "", name: preferred };
+        speakerAssignments = normalizeStoryboardSpeakerAssignments([{ speaker_id: speaker.id, speaker_name: speaker.name, text: existingLine }]);
+      } else if (speakers.length) {
+        speakerAssignments = normalizeStoryboardSpeakerAssignments(speakers.map((speaker) => ({ speaker_id: speaker.id, speaker_name: speaker.name, text: "" })));
+      }
+      syncSpeakerAssignmentLegacy();
+    };
+    const renderSpeakerAssignments = () => {
+      speakerAssignmentRows.replaceChildren();
+      const speakers = mappedSpeakerOptions();
+      addSpeakerAssignment.disabled = !speakers.length || Boolean(noCharacterInput.checked);
+      ensureSpeakerAssignments();
+      if (!speakers.length || noCharacterInput.checked) {
+        const empty = document.createElement("div");
+        empty.textContent = noCharacterInput.checked
+          ? "This scene is marked No character present."
+          : "Map one or more Reference Builder characters to this scene first.";
+        empty.style.cssText = "border:1px dashed #334155;border-radius:8px;padding:12px;color:#94a3b8;text-align:center;font-size:12px;";
+        speakerAssignmentRows.append(empty);
+        return;
+      }
+      let draggedIndex = -1;
+      speakerAssignments.forEach((cue, index) => {
+        const row = document.createElement("div");
+        row.style.cssText = "display:grid;grid-template-columns:34px 34px minmax(160px,.65fr) minmax(300px,1.5fr) 76px;gap:8px;align-items:center;border:1px solid #334155;border-radius:8px;background:#0f172a;padding:8px;";
+        row.addEventListener("dragover", (event) => {
+          if (draggedIndex < 0 || draggedIndex === index) return;
+          event.preventDefault();
+          row.style.borderColor = "#22d3ee";
+        });
+        row.addEventListener("dragleave", () => { row.style.borderColor = "#334155"; });
+        row.addEventListener("drop", (event) => {
+          event.preventDefault();
+          row.style.borderColor = "#334155";
+          if (draggedIndex < 0 || draggedIndex === index) return;
+          const [moved] = speakerAssignments.splice(draggedIndex, 1);
+          speakerAssignments.splice(index, 0, moved);
+          syncSpeakerAssignmentLegacy();
+          renderSpeakerAssignments();
+        });
+        const handle = document.createElement("button");
+        handle.type = "button";
+        handle.textContent = "::";
+        handle.title = "Drag to change speaking order";
+        handle.draggable = true;
+        handle.style.cssText = "height:38px;border:1px solid #334155;border-radius:6px;background:#07111f;color:#67e8f9;font-weight:900;cursor:grab;";
+        handle.addEventListener("dragstart", () => { draggedIndex = index; row.style.opacity = ".55"; });
+        handle.addEventListener("dragend", () => { draggedIndex = -1; row.style.opacity = ""; });
+        const number = document.createElement("div");
+        number.textContent = String(index + 1);
+        number.style.cssText = "font-weight:900;color:#cffafe;text-align:center;";
+        const speakerSelect = makeSelect(speakers.map((speaker) => ({ value: speaker.id, label: speaker.name })), cue.speaker_id);
+        if (!speakers.some((speaker) => speaker.id === cue.speaker_id) && cue.speaker_name) {
+          speakerSelect.prepend(new Option(`${cue.speaker_name} (not currently mapped)`, cue.speaker_id));
+          speakerSelect.value = cue.speaker_id;
+        }
+        const line = makeInput(cue.text || "", "Exact words this character says...");
+        const remove = makeButton("Remove");
+        speakerSelect.addEventListener("change", () => {
+          const speaker = speakers.find((item) => item.id === speakerSelect.value) || { id: speakerSelect.value, name: speakerSelect.selectedOptions[0]?.textContent || "" };
+          cue.speaker_id = speaker.id;
+          cue.speaker_name = speaker.name;
+          syncSpeakerAssignmentLegacy();
+        });
+        line.addEventListener("input", () => {
+          cue.text = line.value;
+          syncSpeakerAssignmentLegacy();
+        });
+        remove.onclick = () => {
+          speakerAssignments.splice(index, 1);
+          syncSpeakerAssignmentLegacy();
+          renderSpeakerAssignments();
+        };
+        row.append(handle, number, speakerSelect, line, remove);
+        speakerAssignmentRows.append(row);
+      });
+    };
+    addSpeakerAssignment.onclick = () => {
+      const speaker = mappedSpeakerOptions()[0];
+      if (!speaker) return;
+      speakerAssignments.push(...normalizeStoryboardSpeakerAssignments([{ speaker_id: speaker.id, speaker_name: speaker.name, text: "" }]));
+      syncSpeakerAssignmentLegacy();
+      renderSpeakerAssignments();
+    };
+    speakerAssignmentWrap.append(speakerAssignmentNote, speakerAssignmentRows, addSpeakerAssignment);
+    if (speakerAssignmentEnabled) {
+      lyrics.readOnly = true;
+      lyrics.title = "This value is built automatically from the ordered Speaker Assignment cues below.";
+      lyrics.style.opacity = "0.78";
+      renderSpeakerAssignments();
+    }
+
     const motionGrid = isVideoPrepMode ? threeCol() : twoCol();
     if (isVideoPrepMode) {
       motionGrid.append(
@@ -4087,6 +5843,9 @@ function openStoryboardBuilder(payload = {}) {
     const advancedGrid = twoCol();
     if (isVideoPrepMode) {
       advancedGrid.append(field("Prompt summary", summary), motionField, field("Character details", subjectDetails), field("Location details", locationDetails), imagePathField, t2iPromptField, field("Video prompt", videoPrompt));
+      if (isMiniMaxShortFilmMode) {
+        advancedGrid.append(field("Manual audio / sound direction", audioDirection), field("Manual continuity requirements", continuityDirection));
+      }
     } else {
       advancedGrid.append(t2iPromptField, field("Character details", subjectDetails), field("Location details", locationDetails), field("Still photography notes", motion));
     }
@@ -4104,6 +5863,7 @@ function openStoryboardBuilder(payload = {}) {
       header,
       section(1, "Scene Basics", basicsGrid),
     ];
+    if (speakerAssignmentEnabled) editorSections.push(section("2", "Speaker Assignment", speakerAssignmentWrap));
     if (state.videoPromptType === "flf" || scene.video_prompt_type === "flf") editorSections.push(flfBeatSection);
     editorSections.push(
       section(3, "References", referencesGrid),
@@ -4123,6 +5883,7 @@ function openStoryboardBuilder(payload = {}) {
       const imageToVideoType = type === "i2v" || type === "image_to_video";
       const textToVideoType = type === "t2v" || type === "text_to_video";
       const referenceToVideoType = type === "rtv" || type === "reference_to_video";
+      const videoStyleType = miniMaxProject && (textToVideoType || referenceToVideoType);
       const options = isImagePrepMode ? IMAGE_SHOT_TYPES : (imageToVideoType ? VIDEO_SHOT_TYPES : Array.from(new Set([...IMAGE_SHOT_TYPES, ...VIDEO_SHOT_TYPES])));
       const current = shot.value || scene.shot_type || "";
       shotPreset.replaceChildren();
@@ -4149,6 +5910,10 @@ function openStoryboardBuilder(payload = {}) {
             : "Motion Notes / LLM Direction";
       t2iPromptField.style.display = isImagePrepMode || (!textToVideoType && !referenceToVideoType) ? "flex" : "none";
       imagePathField.style.display = isVideoPrepMode && !textToVideoType && !referenceToVideoType ? "flex" : "none";
+      videoStyleField.style.display = isVideoPrepMode && videoStyleType ? "flex" : "none";
+      videoStyleCustomField.style.display = isVideoPrepMode && videoStyleType && videoStyle.value === "custom" ? "flex" : "none";
+      temporalEffectField.style.display = isVideoPrepMode && miniMaxProject ? "flex" : "none";
+      temporalEffectCustomField.style.display = isVideoPrepMode && miniMaxProject && temporalEffectOverride.value === "custom" ? "flex" : "none";
       videoPrompt.style.display = isVideoPrepMode ? "" : "none";
       videoPrompt.placeholder = textToVideoType
         ? "Full text-to-video prompt..."
@@ -4160,6 +5925,8 @@ function openStoryboardBuilder(payload = {}) {
     };
     refreshShotPresetForVideoType();
     videoPromptType.addEventListener("change", refreshShotPresetForVideoType);
+    videoStyle.addEventListener("change", refreshShotPresetForVideoType);
+    temporalEffectOverride.addEventListener("change", refreshShotPresetForVideoType);
     const refreshSubjectDetailsFromSelection = () => {
       const selectedIds = Array.from(subjectSelect.selectedOptions).map((option) => option.value).filter(Boolean);
       const selectedSubjects = selectedIds
@@ -4173,6 +5940,10 @@ function openStoryboardBuilder(payload = {}) {
     subjectSelect.addEventListener("change", refreshSubjectDetailsFromSelection);
     subjectSelect.addEventListener("change", refreshReferenceChips);
     noCharacterInput.addEventListener("change", refreshNoCharacterState);
+    if (speakerAssignmentEnabled) {
+      subjectSelect.addEventListener("change", renderSpeakerAssignments);
+      noCharacterInput.addEventListener("change", renderSpeakerAssignments);
+    }
     refreshNoCharacterState();
     shotPreset.addEventListener("change", () => {
       if (shotPreset.value && shotPreset.value !== "__custom__") shot.value = shotPreset.value;
@@ -4297,6 +6068,10 @@ function openStoryboardBuilder(payload = {}) {
       scene.camera_motion = customCameraMotion.value.trim() || cameraMotionPreset.value.trim();
       scene.character_motion = isVideoPrepMode ? (customCharacterMotion.value.trim() || characterMotionPreset.value.trim()) : "";
       scene.performance_style = performanceStyle.value || "";
+      scene.video_style = videoStyle.value || "";
+      scene.video_style_custom = videoStyle.value === "custom" ? videoStyleCustom.value.trim() : "";
+      scene.temporal_world_effect_override = temporalEffectOverride.value || "global";
+      scene.temporal_world_effect_custom = temporalEffectOverride.value === "custom" ? temporalEffectCustom.value.trim() : "";
       scene.facial_performance = facialPerformance.value || "";
       scene.facial_performance_custom = facialPerformanceCustom.value.trim();
       scene.include_microphone = Boolean(includeMic.checked);
@@ -4312,7 +6087,13 @@ function openStoryboardBuilder(payload = {}) {
         scene.image_data = sceneImageData;
         scene.image_name = sceneImageName;
       }
+      if (speakerAssignmentEnabled) {
+        scene.minimax_h3_audio_mode = "built_in_audio";
+        syncSpeakerAssignmentLegacy();
+      }
       scene.notes = notes.value.trim();
+      scene.audio_direction = audioDirection.value.trim();
+      scene.continuity = continuityDirection.value.trim();
     };
     cancel.onclick = () => editorBackdrop.remove();
     gemma.onclick = async () => {
@@ -4505,7 +6286,9 @@ function openStoryboardBuilder(payload = {}) {
       const incomingScenes = state.scenes.map((scene) => normalizeScene(scene));
       const data = await postJson("/vrgdg/storyboard/load", { project_folder: state.projectFolder });
       const saved = data.storyboard || {};
-      state.projectVideoEngine = normalizeStoryboardProjectVideoEngine(saved.project_video_engine || saved.projectVideoEngine || state.projectVideoEngine);
+      if (!hasIncomingProjectVideoEngine) {
+        state.projectVideoEngine = normalizeStoryboardProjectVideoEngine(saved.project_video_engine || saved.projectVideoEngine || state.projectVideoEngine);
+      }
       const savedReferences = normalizeReferenceBuilderCatalog(saved.reference_builder || saved.referenceBuilder || {});
       const currentHasSubjects = Array.isArray(state.referenceBuilder?.subjects) && state.referenceBuilder.subjects.length > 0;
       const currentHasLocations = Array.isArray(state.referenceBuilder?.locations) && state.referenceBuilder.locations.length > 0;
@@ -4549,6 +6332,8 @@ function openStoryboardBuilder(payload = {}) {
             lyrics: fresh.lyrics || normalized.lyrics,
             lyric_section: fresh.lyric_section || normalized.lyric_section,
             story_beat: fresh.story_beat || normalized.story_beat,
+            audio_direction: fresh.audio_direction || normalized.audio_direction,
+            continuity: fresh.continuity || normalized.continuity,
             flf_start_state: fresh.flf_start_state || normalized.flf_start_state,
             flf_transformation: fresh.flf_transformation || normalized.flf_transformation,
             flf_end_state: fresh.flf_end_state || normalized.flf_end_state,
@@ -4556,6 +6341,8 @@ function openStoryboardBuilder(payload = {}) {
             performance_mode: fresh.performance_mode || normalized.performance_mode || state.performanceMode,
             prompt_summary: state.mode === "image_to_video_prep" ? (fresh.prompt_summary || normalized.prompt_summary) : "",
             motion_summary: fresh.motion_summary || normalized.motion_summary,
+            temporal_world_effect_override: fresh.temporal_world_effect_override || normalized.temporal_world_effect_override || "global",
+            temporal_world_effect_custom: fresh.temporal_world_effect_custom || normalized.temporal_world_effect_custom || "",
             image_path: fresh.image_path || normalized.image_path,
             no_character_present: Boolean(fresh.no_character_present || normalized.no_character_present),
             subjects,
@@ -4572,8 +6359,12 @@ function openStoryboardBuilder(payload = {}) {
         }
         absorbSceneReferencesIntoCatalog(state.scenes);
       }
-      state.mode = saved.mode || state.mode;
+      // The current video mode decides the opening workspace every time. Do not
+      // restore a stale Image Prep/Video Prep tab from an earlier visit.
+      state.mode = openingMode;
       state.performanceMode = normalizeStoryboardPerformanceMode(saved.performance_mode || saved.performanceMode || state.performanceMode);
+      state.shortFilmPlanningMode = normalizeStoryboardShortFilmPlanningMode(saved.short_film_planning_mode || saved.shortFilmPlanningMode || state.shortFilmPlanningMode);
+      shortFilmPlanningModeSelect.value = state.shortFilmPlanningMode;
       if (saved.camera_flow && STORYBOARD_CAMERA_FLOW_PRESETS[saved.camera_flow]) {
         state.cameraFlow = saved.camera_flow;
         cameraFlowSelect.value = state.cameraFlow;
@@ -4585,6 +6376,26 @@ function openStoryboardBuilder(payload = {}) {
       state.imageAesthetic = String(saved.image_aesthetic || saved.imageAesthetic || state.imageAesthetic || "");
       if (!imageAestheticPresets.some((preset) => preset.value === state.imageAesthetic)) state.imageAesthetic = imageAestheticPresets[0]?.value || "";
       imageAestheticSelect.value = state.imageAesthetic;
+      state.videoStyle = String(saved.video_style || saved.videoStyle || state.videoStyle || "");
+      if (!MINIMAX_VIDEO_STYLE_PRESETS.some((preset) => preset.value === state.videoStyle)) state.videoStyle = "";
+      videoStyleSelect.value = state.videoStyle;
+      state.videoStyleCustom = String(saved.video_style_custom || saved.videoStyleCustom || state.videoStyleCustom || "");
+      videoStyleCustomInput.value = state.videoStyleCustom;
+      state.temporalWorldEffect = String(saved.temporal_world_effect || saved.temporalWorldEffect || state.temporalWorldEffect || "");
+      if (!MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS.some((preset) => preset.value === state.temporalWorldEffect)) state.temporalWorldEffect = "";
+      temporalEffectSelect.value = state.temporalWorldEffect;
+      state.temporalWorldEffectCustom = String(saved.temporal_world_effect_custom || saved.temporalWorldEffectCustom || state.temporalWorldEffectCustom || "");
+      temporalEffectCustomInput.value = state.temporalWorldEffectCustom;
+      state.temporalAllowBackgroundExtras = (saved.temporal_allow_background_extras ?? saved.temporalAllowBackgroundExtras ?? state.temporalAllowBackgroundExtras) !== false;
+      temporalExtrasInput.checked = state.temporalAllowBackgroundExtras;
+      state.temporalBackgroundIntensity = storyboardTemporalIntensity(saved.temporal_background_intensity ?? saved.temporalBackgroundIntensity ?? state.temporalBackgroundIntensity);
+      temporalIntensityInput.value = String(state.temporalBackgroundIntensity);
+      state.temporalEnvironmentTimePassage = (saved.temporal_environment_time_passage ?? saved.temporalEnvironmentTimePassage ?? state.temporalEnvironmentTimePassage) !== false;
+      temporalEnvironmentInput.checked = state.temporalEnvironmentTimePassage;
+      state.temporalProtectedCharacters = storyboardTemporalProtectedMode(saved.temporal_protected_characters || saved.temporalProtectedCharacters || state.temporalProtectedCharacters);
+      temporalProtectedSelect.value = state.temporalProtectedCharacters;
+      state.temporalProtectedCustom = String(saved.temporal_protected_custom || saved.temporalProtectedCustom || state.temporalProtectedCustom || "");
+      temporalProtectedCustomInput.value = state.temporalProtectedCustom;
       state.globalConsistencyPhrase = String(saved.global_consistency_phrase || saved.globalConsistencyPhrase || state.globalConsistencyPhrase || "");
       consistencyInput.value = state.globalConsistencyPhrase;
       state.performanceStyle = String(saved.performance_style_default || saved.performance_style || state.performanceStyle || "");
@@ -4600,6 +6411,7 @@ function openStoryboardBuilder(payload = {}) {
       cameraSpeedInput.value = String(state.cameraMotionSpeed);
       characterSpeedInput.value = String(state.characterMotionSpeed);
       state.storyLayer = normalizeStoryLayer(saved.story_layer || saved.storyLayer || {});
+      state.scriptImport = normalizeStoryboardScriptImportState(saved.script_import || saved.scriptImport || state.scriptImport || {});
       storyLayerEnabledInput.checked = state.storyLayer.enabled !== false;
       overallStoryIdeaInput.value = state.storyLayer.overall_story_idea || "";
       userStoryArcInput.value = state.storyLayer.user_story_arc || "";
@@ -4609,6 +6421,8 @@ function openStoryboardBuilder(payload = {}) {
       refreshCameraFlowInfo();
       refreshImageShotInfo();
       refreshImageAestheticInfo();
+      refreshVideoStyleInfo();
+      refreshTemporalEffectInfo();
       refreshConsistencyInfo();
       refreshCameraSpeedInfo();
       refreshPerformanceInfo();
@@ -4674,7 +6488,7 @@ function openStoryboardBuilder(payload = {}) {
           scenes: state.scenes.map((scene, index) => slimSceneForRequest(scene, index)),
         });
       }
-      createToast(`Exported ${data.scene_count || 0} scene prompt rows:\nText:\n${data.t2i_prompts_path}\n${data.i2v_prompts_path}\nJSON:\n${data.t2i_prompts_json_path || ""}\n${data.video_prompts_json_path || ""}`);
+      createToast(`Exported ${data.scene_count || 0} scene prompt rows to files only. The Video Builder timeline was not created or replaced.\n\nText:\n${data.t2i_prompts_path}\n${data.i2v_prompts_path}\nJSON:\n${data.t2i_prompts_json_path || ""}\n${data.video_prompts_json_path || ""}`);
     } catch (error) {
       createToast(String(error?.message || error), true);
     } finally {
@@ -5160,6 +6974,63 @@ function openStoryboardBuilder(payload = {}) {
     refreshImageAestheticInfo();
     notifyStoryboardDefaultsChanged();
   };
+  videoStyleSelect.onchange = () => {
+    state.videoStyle = MINIMAX_VIDEO_STYLE_PRESETS.some((preset) => preset.value === videoStyleSelect.value) ? videoStyleSelect.value : "";
+    videoStyleSelect.value = state.videoStyle;
+    refreshVideoStyleInfo();
+    notifyStoryboardDefaultsChanged();
+  };
+  videoStyleCustomInput.addEventListener("input", () => {
+    state.videoStyleCustom = videoStyleCustomInput.value;
+    refreshVideoStyleInfo();
+  });
+  videoStyleCustomInput.addEventListener("change", notifyStoryboardDefaultsChanged);
+  temporalEffectSelect.onchange = () => {
+    const previous = state.temporalWorldEffect;
+    state.temporalWorldEffect = MINIMAX_TEMPORAL_WORLD_EFFECT_PRESETS.some((preset) => preset.value === temporalEffectSelect.value)
+      ? temporalEffectSelect.value
+      : "";
+    temporalEffectSelect.value = state.temporalWorldEffect;
+    if (!previous && state.temporalWorldEffect) {
+      state.temporalAllowBackgroundExtras = true;
+      state.temporalEnvironmentTimePassage = true;
+      temporalExtrasInput.checked = true;
+      temporalEnvironmentInput.checked = true;
+    }
+    refreshTemporalEffectInfo();
+    notifyStoryboardDefaultsChanged();
+  };
+  temporalEffectCustomInput.addEventListener("input", () => {
+    state.temporalWorldEffectCustom = temporalEffectCustomInput.value;
+    refreshTemporalEffectInfo();
+  });
+  temporalEffectCustomInput.addEventListener("change", notifyStoryboardDefaultsChanged);
+  temporalExtrasInput.onchange = () => {
+    state.temporalAllowBackgroundExtras = temporalExtrasInput.checked;
+    refreshTemporalEffectInfo();
+    notifyStoryboardDefaultsChanged();
+  };
+  temporalEnvironmentInput.onchange = () => {
+    state.temporalEnvironmentTimePassage = temporalEnvironmentInput.checked;
+    refreshTemporalEffectInfo();
+    notifyStoryboardDefaultsChanged();
+  };
+  temporalIntensityInput.addEventListener("input", () => {
+    state.temporalBackgroundIntensity = storyboardTemporalIntensity(temporalIntensityInput.value);
+    refreshTemporalEffectInfo();
+  });
+  temporalIntensityInput.addEventListener("change", notifyStoryboardDefaultsChanged);
+  temporalProtectedSelect.onchange = () => {
+    state.temporalProtectedCharacters = storyboardTemporalProtectedMode(temporalProtectedSelect.value);
+    temporalProtectedSelect.value = state.temporalProtectedCharacters;
+    refreshTemporalEffectInfo();
+    notifyStoryboardDefaultsChanged();
+  };
+  temporalProtectedCustomInput.addEventListener("input", () => {
+    state.temporalProtectedCustom = temporalProtectedCustomInput.value;
+    refreshTemporalEffectInfo();
+  });
+  temporalProtectedCustomInput.addEventListener("change", notifyStoryboardDefaultsChanged);
   consistencyInput.addEventListener("input", () => {
     state.globalConsistencyPhrase = consistencyInput.value.trim();
     refreshConsistencyInfo();
@@ -5188,6 +7059,8 @@ function openStoryboardBuilder(payload = {}) {
   imageShotReplace.onclick = () => applyImageShotFlow({ overwrite: true });
   imageAestheticApply.onclick = () => applyImageAesthetic({ overwrite: false });
   imageAestheticReplace.onclick = () => applyImageAesthetic({ overwrite: true });
+  videoStyleApply.onclick = () => applyVideoStyle({ overwrite: false });
+  videoStyleReplace.onclick = () => applyVideoStyle({ overwrite: true });
   performanceSelect.onchange = () => {
     state.performanceStyle = String(performanceSelect.value || "");
     refreshPerformanceInfo();
@@ -5236,6 +7109,13 @@ function openStoryboardBuilder(payload = {}) {
   clearPromptsButton.onclick = clearAllStoryboardPrompts;
   clearStoryBeatsButton.onclick = clearAllStoryboardStoryBeats;
   storyLayerEnabledInput.addEventListener("change", () => syncStoryLayerFromInputs({ notify: true }));
+  shortFilmPlanningModeSelect.addEventListener("change", () => {
+    state.shortFilmPlanningMode = normalizeStoryboardShortFilmPlanningMode(shortFilmPlanningModeSelect.value);
+    shortFilmPlanningModeSelect.value = state.shortFilmPlanningMode;
+    refreshSetupPanelSummaries();
+    notifyStoryboardDefaultsChanged();
+    renderTable();
+  });
   imageWorldStyleSelect.addEventListener("change", () => {
     refreshImageWorldStyleInfo();
     syncStoryLayerFromInputs({ notify: true });
@@ -5272,8 +7152,9 @@ function openStoryboardBuilder(payload = {}) {
   createMissingBeatsButton.onclick = () => createAllSceneBeatsWithGemma({ overwrite: false });
   replaceBeatsButton.onclick = () => createAllSceneBeatsWithGemma({ overwrite: true });
   detectSectionsButton.onclick = detectLyricSections;
-  planDialogueScenesButton.onclick = planIdLoraDialogueScenesWithGemma;
-  applyDialoguePlanButton.onclick = applyIdLoraDialoguePlanToVideoBuilder;
+  openMiniMaxScriptMapperButton.onclick = openMiniMaxScriptMapper;
+  planDialogueScenesButton.onclick = planFilmDialogueScenesWithLlm;
+  applyDialoguePlanButton.onclick = applyFilmDialoguePlanToVideoBuilder;
   keepGemmaLoadedInput.onchange = () => {
     state.gemmaSettings = {
       ...(state.gemmaSettings || {}),
@@ -5289,6 +7170,8 @@ function openStoryboardBuilder(payload = {}) {
   refreshCameraFlowInfo();
   refreshImageShotInfo();
   refreshImageAestheticInfo();
+  refreshVideoStyleInfo();
+  refreshTemporalEffectInfo();
   refreshImageWorldStyleInfo();
   refreshConsistencyInfo();
   refreshCameraSpeedInfo();


### PR DESCRIPTION
## Summary

This updates the Video Builder with the MiniMax H3 work developed after the initial testing release while keeping LTX 2.3 as the default for existing and new projects.

### MiniMax H3

- adds Built-in MiniMax Audio with a dedicated hidden runtime workflow
- adds ordered per-scene speaker cues and Reference Builder voice presets/custom voice descriptions
- adds previous-scene spatial-reference and exact-start-frame continuity modes
- preserves native MiniMax scene audio through rendering and final stitching
- improves Input Audio versus Built-in Audio prompt contracts, vocal timing, exact dialogue handling, and character-sheet identity handling
- adds detailed MiniMax render progress showing the active prompt, lyric/dialogue, mode, and ordered references

### Short-film and Storyboard authoring

- adds Guided Film Automation and Fully Custom authoring
- adds a TXT/JSON Script Mapper with speaker matching, exact cue preservation, timing preview, scene-length limits, and reviewed timeline creation
- adds MiniMax video-aesthetic controls, motion guidance, intimate close-ups, and protected-character temporal/world effects
- preserves speaker order and keeps non-speaking visible characters silent

### Builder reliability

- enforces visual-only behavior for MiniMax B-roll/no-lip-sync scenes at prompt generation and again immediately before rendering
- preserves Cyrillic and other Unicode characters during lyric timestamp alignment
- increases the scene render wait limit from 40 minutes to two hours
- adds a safeguard against accidental bulk lyric clearing during stale session saves
- adds an optional custom projects root for newly created projects, with safe project-listing and deletion boundaries
- preserves the existing 24 FPS MiniMax stitched-audio synchronization fix from main

### Documentation

- refreshes the Video Builder-only guide for LTX 2.3 and MiniMax H3
- adds an August 5 in-app release entry linked to the implementation commit

## Why

The initial MiniMax H3 Builder release supported supplied audio and the four generation modes, but it did not yet support generated native audio or the full short-film workflow. It also left several edge cases around B-roll vocal directions, Unicode lyric matching, continuity frames, long render waits, and project storage.

The B-roll issue was caused by vocal instructions surviving inside timestamp blocks or older saved prompts even after a scene was marked visual-only. The final render path now reapplies the safety contract and removes conflicting singing, speaking, mouthing, and lip-sync directions.

The Cyrillic alignment issue was caused by ASCII-only lyric normalization. Matching now uses Unicode-aware word characters.

## Compatibility and impact

- LTX 2.3 remains the default engine.
- Existing projects are not moved.
- Custom project roots affect only newly created projects unless a full project path is supplied explicitly.
- MiniMax Input Audio remains the exact supplied soundtrack path.
- Built-in MiniMax Audio must be selected for generated voices, dialogue, ambience, or sound effects.
- Projects outside ComfyUI output cannot be deleted through the Builder UI.

## Validation

- 62 targeted regression tests passed; 3 optional tests skipped
- modified Python files passed AST parsing
- both modified JavaScript modules passed Node syntax checking
- runtime workflow JSON and update-notes JSON parsed successfully
- final diff and whitespace checks passed
- release scope contains exactly 10 approved runtime/documentation files
- no test files, SRT backups, generated media, logs, browser profiles, or local backup files are included
