### PR TITLE
Add MiniMax H3 downloads and fix Story Arc lyric headers

### DIFF
--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -1645,20 +1645,65 @@ def _build_story_layer_brief(payload):
     }
 
 
-def _parse_story_arc_lyric_sections(lyrics):
-    """Return ordered (display label, body) pairs from exact bracketed lyric headers."""
+def _parse_story_arc_lyric_sections(lyrics, collapse_adjacent=True):
+    """Return ordered (display label, body) pairs from bracketed lyric headers."""
+    structural_pattern = re.compile(
+        r"^(?:intro|verse|pre[\s-]?chorus|chorus|post[\s-]?chorus|bridge|outro|"
+        r"refrain|hook|breakdown|drop|interlude|instrumental(?:\s+break)?|solo|break|"
+        r"spoken(?:\s+word)?|rap)(?:\s+(?:\d+|[ivxlcdm]+))?$",
+        re.IGNORECASE,
+    )
+    annotation_pattern = re.compile(
+        r"^(?:whispered|spoken|sung|dark atmosphere|building energy|high energy|"
+        r"emotional climax|explosive|quiet arrangement|falling tension|rising tension|"
+        r"silence|soft|loud|gentle|intense|energetic|calm|dramatic|atmospheric)$",
+        re.IGNORECASE,
+    )
+
+    def parse_header_line(raw_line):
+        """Return (section label, lyric remainder, terminal marker)."""
+        stripped = str(raw_line or "").strip()
+        if not stripped.startswith("["):
+            return "", raw_line, False
+        labels = []
+        position = 0
+        while position < len(stripped):
+            match = re.match(r"\s*\[([^\]\n]{1,80})\]", stripped[position:])
+            if not match:
+                break
+            labels.append(re.sub(r"\s+", " ", match.group(1)).strip())
+            position += match.end()
+        if not labels:
+            return "", raw_line, False
+        remainder = stripped[position:].strip()
+        terminal = any(label.casefold() in {"end", "end of song"} for label in labels)
+        structural = next((label for label in labels if structural_pattern.fullmatch(label)), "")
+        if not structural:
+            first = labels[0]
+            if not annotation_pattern.fullmatch(first) and first.casefold() not in {"end", "end of song"}:
+                # Preserve custom section names such as [Part A], while avoiding
+                # common performance/mood annotations used beside real headers.
+                structural = first
+        return structural, remainder, terminal and not structural
+
     sections = []
     current_label = ""
     current_lines = []
     for raw_line in str(lyrics or "").replace("\r\n", "\n").replace("\r", "\n").split("\n"):
-        header = re.match(r"^\s*\[([^\]\n]{1,80})\]\s*$", raw_line)
-        if header:
+        header_label, remainder, terminal = parse_header_line(raw_line)
+        if header_label:
             if current_label:
                 sections.append((current_label, "\n".join(current_lines).strip()))
-            current_label = re.sub(r"\s+", " ", header.group(1)).strip()
+            current_label = header_label
+            current_lines = [remainder] if remainder else []
+        elif terminal:
+            if current_label:
+                sections.append((current_label, "\n".join(current_lines).strip()))
+            current_label = ""
             current_lines = []
         elif current_label:
-            current_lines.append(raw_line)
+            # Lines containing annotation-only tags may still carry lyric text.
+            current_lines.append(remainder if remainder != raw_line else raw_line)
     if current_label:
         sections.append((current_label, "\n".join(current_lines).strip()))
     if not sections:
@@ -1669,7 +1714,7 @@ def _parse_story_arc_lyric_sections(lyrics):
     # later recurrences (for example, a chorus after Verse 2) as separate blocks.
     collapsed = []
     for label, body in sections:
-        if collapsed and collapsed[-1][0].casefold() == label.casefold():
+        if collapse_adjacent and collapsed and collapsed[-1][0].casefold() == label.casefold():
             previous_label, previous_body = collapsed[-1]
             merged_body = "\n".join(part for part in (previous_body, body) if part).strip()
             collapsed[-1] = (previous_label, merged_body)
@@ -1721,6 +1766,9 @@ def _normalize_story_arc_output(text, required_labels, maximum_words=100):
     blocks = []
     for index, match in enumerate(matches):
         label = re.sub(r"\s+", " ", match.group(1)).strip()
+        bracketed = re.fullmatch(r"\[([^\]\n]{1,80})\]", label)
+        if bracketed:
+            label = re.sub(r"\s+", " ", bracketed.group(1)).strip()
         end = matches[index + 1].start() if index + 1 < len(matches) else len(raw)
         blocks.append((label, raw[match.end():end].strip()))
     if required_labels:
@@ -1762,6 +1810,12 @@ def _normalize_story_arc_output(text, required_labels, maximum_words=100):
         blocks = folded_blocks
         returned = [label.casefold() for label, _body in blocks]
         required = [label.casefold() for label in required_labels]
+        # Some local Gemma models add "1" to the first occurrence of a
+        # heading even though only repeated occurrences are numbered.
+        returned = [
+            required[index] if index < len(required) and actual == f"{required[index]} 1" else actual
+            for index, actual in enumerate(returned)
+        ]
         if len(blocks) > len(required_labels) and returned[:len(required)] == required:
             # Gemma occasionally preserves every required lyric heading, then
             # appends invented sections such as an extra Instrumental or Outro.
@@ -1793,6 +1847,10 @@ def _normalize_story_arc_output(text, required_labels, maximum_words=100):
                 + " ".join(details)
                 + " Please rerun Story Arc."
             )
+        blocks = [
+            (required_labels[index], body)
+            for index, (_label, body) in enumerate(blocks)
+        ]
     return "\n\n".join(
         f"{label}:\n{_cap_story_arc_words(body, maximum_words)}"
         for label, body in blocks
@@ -1827,9 +1885,14 @@ def _build_story_layer_arc(payload):
                     prompt_creator_lyrics = _clean_scene_text(handle.read(), 40000)
             except OSError:
                 prompt_creator_lyrics = ""
-    lyrics = prompt_creator_lyrics or line_mapping_lyrics or timeline_lyrics
-    lyrics_source = "Prompt Creator reference lyrics" if prompt_creator_lyrics else ("Line Mapping reference lyrics" if line_mapping_lyrics else "timeline scene lyrics")
-    lyric_sections = _parse_story_arc_lyric_sections(lyrics)
+    # The lyrics currently open in Line Mapping are the live user input and must
+    # win over a potentially stale project_context/full_lyrics.txt file.
+    lyrics = line_mapping_lyrics or prompt_creator_lyrics or timeline_lyrics
+    lyrics_source = "Line Mapping reference lyrics" if line_mapping_lyrics else ("Prompt Creator reference lyrics" if prompt_creator_lyrics else "timeline scene lyrics")
+    lyric_sections = _parse_story_arc_lyric_sections(
+        lyrics,
+        collapse_adjacent=not bool(line_mapping_lyrics or prompt_creator_lyrics),
+    )
     required_section_labels = [item[0] for item in lyric_sections]
     section_word_limit = _story_arc_section_word_limit(len(required_section_labels))
     story_layer = _normalize_story_layer(payload.get("story_layer") or payload.get("storyLayer") or storyboard.get("story_layer") or {})
@@ -1968,6 +2031,7 @@ def _build_story_layer_arc(payload):
         "* Do not invent warehouses, loading docks, corridors, steel stairs, metal doors, concrete halls, or other industrial spaces unless those are explicitly present in the provided Location descriptions.\n"
         "* To create variety, change subject actions, camera energy, props, lighting, mood, blocking, and use of the mapped locations instead of inventing unrelated places.\n"
         "* Never force a standard pop-song template over explicit lyric section headers.\n"
+        "* When a lyric header line contains several bracketed tags, only the required section heading listed above is structural. Tags such as [Whispered], [High Energy], [Dark Atmosphere], and [Explosive] are performance or mood notes, not output headings. [End] is only an end marker.\n"
         "* Values such as [instrumental], [music only], or [no vocals] inside the Scene lyric map are timing/content markers, not additional song-section headings. Cover their visuals inside the nearest listed required section and never output those markers as separate headings.\n"
         "* If only lyrics are provided, build the arc from the lyrics.\n"
         "* If no lyrics are provided, build the arc from the theme or story idea.\n"

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -2701,7 +2701,7 @@ Quick missing-node checklist:
 
 ## Models and Downloads
 
-Use `Download Models` in the top bar if you need model links and folder locations.
+Use `Download Models` in the top bar if you need model links and folder locations. The window is organized into `LTX + Image Models`, `LLM Models`, and `MiniMax H3` tabs so each engine's required files stay together.
 
 The model download window includes groups for:
 
@@ -2713,6 +2713,7 @@ The model download window includes groups for:
 | `Flux/Klein 4B` | Smaller/lighter Flux/Klein generation |
 | `Ernie Image` | Ernie image generation |
 | `LTX 2.3` | Video generation |
+| `MiniMax H3` | MiniMax H3 diffusion model, Qwen3-VL text encoder, video VAE, and audio VAE |
 
 After placing models in the correct ComfyUI model folders, restart ComfyUI if dropdowns do not refresh.
 
@@ -2772,7 +2773,7 @@ ComfyUI/
     vae/minimax_h3_audio_vae_fp32.safetensors
 ```
 
-MiniMax H3 model names and folder locations are listed here because they are required by the Builder even when the current `Download Models` window does not provide an H3 download group. The MiniMax diffusion picker intentionally lists non-GGUF files only. If the H3 model or `MiniMaxH3ReferenceToVideo` node is missing after placing the files, update ComfyUI, restart it completely, and hard refresh the browser.
+The `MiniMax H3` tab in `Download Models` links each of these four required files and its `Folders` button shows the same directory structure. The MiniMax diffusion picker intentionally lists non-GGUF files only. If the H3 model or `MiniMaxH3ReferenceToVideo` node is missing after placing the files, update ComfyUI, restart it completely, and hard refresh the browser.
 
 ![Download Models Window](https://raw.githubusercontent.com/vrgamegirl19/comfyui-vrgamedevgirl/refs/heads/main/Workflows/LTX-2_Workflows/Video_Builder/images/2026-06-01%2016_02_27-.png)
 

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,24 @@
   "product": "LTX 2.3 Video Builder",
   "releases": [
     {
+      "id": "2026-08-05-minimax-h3-model-downloads",
+      "version": "2026.08.05-minimax-h3-model-downloads",
+      "date": "2026-08-05",
+      "title": "MiniMax H3 model downloads",
+      "commit": "b971be55a46f23f0e96f57098cd53a707196b092",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Reorganized Download Models into LTX + Image Models, LLM Models, and MiniMax H3 tabs while preserving every existing model link.",
+            "Added verified links and folder guidance for the MiniMax H3 diffusion model, Qwen3-VL text encoder, video VAE, and audio VAE."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-05-minimax-h3-short-film-builder",
       "version": "2026.08.05-minimax-h3",
       "date": "2026-08-05",

--- a/update_notes.json
+++ b/update_notes.json
@@ -6,8 +6,8 @@
       "id": "2026-08-05-minimax-h3-model-downloads",
       "version": "2026.08.05-minimax-h3-model-downloads",
       "date": "2026-08-05",
-      "title": "MiniMax H3 model downloads",
-      "commit": "b971be55a46f23f0e96f57098cd53a707196b092",
+      "title": "MiniMax H3 downloads and Story Arc reliability",
+      "commit": "2c0dfab471929c7536b1d29659e0e4821cc629fb",
       "restart_required": true,
       "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
       "sections": [
@@ -16,6 +16,12 @@
           "items": [
             "Reorganized Download Models into LTX + Image Models, LLM Models, and MiniMax H3 tabs while preserving every existing model link.",
             "Added verified links and folder guidance for the MiniMax H3 diffusion model, Qwen3-VL text encoder, video VAE, and audio VAE."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Create User Story Arc now recognizes compound lyric headers such as [Intro] [Whispered] [Dark Atmosphere], ignores adjacent performance and mood tags plus [End], preserves consecutive real sections, and accepts harmless bracketed or first-occurrence-numbered Gemma headings."
           ]
         }
       ]

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -360,6 +360,12 @@ const LTX_MODEL_DOWNLOADS = [
   { label: "Latent Upscaler", url: "https://huggingface.co/prince-canuma/LTX-2.3-distilled/resolve/main/ltx-2.3-spatial-upscaler-x2-1.1.safetensors" },
   { label: "Audio VAE", url: "https://huggingface.co/Kijai/LTX2.3_comfy/tree/main/vae" },
 ];
+const MINIMAX_H3_MODEL_DOWNLOADS = [
+  { label: "Diffusion model", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors" },
+  { label: "Qwen3-VL text encoder", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors" },
+  { label: "Video VAE", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/vae/minimax_h3_video_vae_fp16.safetensors" },
+  { label: "Audio VAE", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/vae/minimax_h3_audio_vae_fp32.safetensors" },
+];
 const ZIMAGE_MODEL_DOWNLOADS = [
   { label: "Z-Image Turbo", url: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors" },
   { label: "Qwen CLIP", url: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors" },
@@ -470,6 +476,15 @@ models/
     LTX2.3_audio_vae_bf16.safetensors
   latent_upscale_models/
     ltx-2.3-spatial-upscaler-x2-1.1.safetensors`,
+  "MiniMax H3": `ComfyUI/
+models/
+  diffusion_models/
+    minimax_h3_ref2va_pruned_int8_convrot.safetensors
+  text_encoders/
+    qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors
+  vae/
+    minimax_h3_video_vae_fp16.safetensors
+    minimax_h3_audio_vae_fp32.safetensors`,
 };
 
 const builderResponsiveStyle = document.createElement("style");
@@ -1135,14 +1150,33 @@ function showFinalVideoReadyModal(videoPath) {
 }
 
 function showModelDownloadModal() {
-  const groups = [
-    { title: "LLM / Vision", note: "Use SuperGemma for text prompting. Use Gemma Vision GGUF plus mmproj for image-reference prompting.", downloads: LLM_MODEL_DOWNLOADS },
-    { title: "ZImage", note: "Core ZImage Turbo diffusion model, Qwen text encoder, and VAE.", downloads: ZIMAGE_MODEL_DOWNLOADS },
-    { title: "Krea2", note: "Krea2 text-to-image model used by the Reference Builder Krea2 + ZImage enhancer option.", downloads: KREA2_MODEL_DOWNLOADS },
-    { title: "Flux/Klein 9B", note: "9B is higher quality. 4B is smaller and lighter.", downloads: FLUX_KLEIN_9B_MODEL_DOWNLOADS },
-    { title: "Flux/Klein 4B", note: "4B is smaller and lighter.", downloads: FLUX_KLEIN_4B_MODEL_DOWNLOADS },
-    { title: "Ernie Image", note: "Ernie diffusion model, Ministral text encoder, and VAE.", downloads: ERNIE_MODEL_DOWNLOADS },
-    { title: "LTX 2.3", note: "High-quality image and video generation model.", downloads: LTX_MODEL_DOWNLOADS },
+  const tabs = [
+    {
+      id: "ltx",
+      label: "LTX + Image Models",
+      groups: [
+        { title: "LTX 2.3", note: "High-quality image and video generation model.", downloads: LTX_MODEL_DOWNLOADS },
+        { title: "ZImage", note: "Core ZImage Turbo diffusion model, Qwen text encoder, and VAE.", downloads: ZIMAGE_MODEL_DOWNLOADS },
+        { title: "Krea2", note: "Krea2 text-to-image model used by the Reference Builder Krea2 + ZImage enhancer option.", downloads: KREA2_MODEL_DOWNLOADS },
+        { title: "Flux/Klein 9B", note: "9B is higher quality. 4B is smaller and lighter.", downloads: FLUX_KLEIN_9B_MODEL_DOWNLOADS },
+        { title: "Flux/Klein 4B", note: "4B is smaller and lighter.", downloads: FLUX_KLEIN_4B_MODEL_DOWNLOADS },
+        { title: "Ernie Image", note: "Ernie diffusion model, Ministral text encoder, and VAE.", downloads: ERNIE_MODEL_DOWNLOADS },
+      ],
+    },
+    {
+      id: "llm",
+      label: "LLM Models",
+      groups: [
+        { title: "LLM / Vision", note: "Use SuperGemma for text prompting. Use Gemma Vision GGUF plus mmproj for image-reference prompting.", downloads: LLM_MODEL_DOWNLOADS },
+      ],
+    },
+    {
+      id: "minimax",
+      label: "MiniMax H3",
+      groups: [
+        { title: "MiniMax H3", note: "Required diffusion model, Qwen3-VL text encoder, video VAE, and audio VAE for MiniMax H3 rendering.", downloads: MINIMAX_H3_MODEL_DOWNLOADS },
+      ],
+    },
   ];
   const backdrop = document.createElement("div");
   backdrop.style.cssText = "position:fixed;inset:0;z-index:100006;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:28px;box-sizing:border-box;";
@@ -1158,60 +1192,100 @@ function showModelDownloadModal() {
   close.style.fontSize = "18px";
   header.append(title, close);
   const body = document.createElement("div");
+  body.id = "vrgdg-model-downloads-panel";
+  body.setAttribute("role", "tabpanel");
   body.style.cssText = "display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:18px;padding:18px 20px 20px;";
-  for (const group of groups) {
-    const card = document.createElement("div");
-    card.style.cssText = "display:flex;flex-direction:column;gap:14px;border:1px solid #334155;border-radius:10px;background:#111827;padding:18px;";
-    const titleRow = document.createElement("div");
-    titleRow.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:10px;";
-    const groupTitle = document.createElement("div");
-    groupTitle.textContent = group.title;
-    groupTitle.style.cssText = "font-size:22px;font-weight:900;color:#f8fafc;";
-    const folderButton = makeMiniButton("Folders");
-    folderButton.style.fontSize = "13px";
-    folderButton.style.padding = "8px 10px";
-    folderButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const pre = document.createElement("pre");
-      pre.textContent = MODEL_FOLDER_HINTS[group.title] || "No folder location listed yet.";
-      pre.style.cssText = "white-space:pre-wrap;margin:0;padding:12px;border:1px solid #334155;border-radius:8px;background:#020617;color:#bae6fd;font-size:12px;line-height:1.45;overflow:auto;";
-      showInfoModal({
-        title: `${group.title} Folder Locations`,
-        lines: [
-          "Place the files here, then restart ComfyUI if the dropdowns do not refresh.",
-          pre,
-        ],
-      });
-    });
-    titleRow.append(groupTitle, folderButton);
-    const note = document.createElement("div");
-    note.textContent = group.note;
-    note.style.cssText = "font-size:17px;line-height:1.35;color:#c7d2fe;";
-    const buttons = document.createElement("div");
-    buttons.style.cssText = "display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;";
-    for (const item of group.downloads) {
-      const button = makeMiniButton(item.label);
-      button.style.borderColor = "#2563eb";
-      button.style.background = "#1d4ed8";
-      button.style.color = "#eff6ff";
-      button.style.fontWeight = "900";
-      button.style.fontSize = "16px";
-      button.style.padding = "12px 16px";
-      button.style.borderRadius = "7px";
-      button.addEventListener("click", (event) => {
+  const tabBar = document.createElement("div");
+  tabBar.setAttribute("role", "tablist");
+  tabBar.setAttribute("aria-label", "Model download categories");
+  tabBar.style.cssText = "position:sticky;top:78px;z-index:1;display:flex;flex-wrap:wrap;gap:10px;padding:14px 20px;border-bottom:1px solid #334155;background:#0b1220;";
+  const tabButtons = new Map();
+
+  const renderGroups = (groups) => {
+    body.replaceChildren();
+    for (const group of groups) {
+      const card = document.createElement("div");
+      card.style.cssText = "display:flex;flex-direction:column;gap:14px;border:1px solid #334155;border-radius:10px;background:#111827;padding:18px;";
+      const titleRow = document.createElement("div");
+      titleRow.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:10px;";
+      const groupTitle = document.createElement("div");
+      groupTitle.textContent = group.title;
+      groupTitle.style.cssText = "font-size:22px;font-weight:900;color:#f8fafc;";
+      const folderButton = makeMiniButton("Folders");
+      folderButton.style.fontSize = "13px";
+      folderButton.style.padding = "8px 10px";
+      folderButton.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
-        window.open(item.url, "_blank", "noopener,noreferrer");
+        const pre = document.createElement("pre");
+        pre.textContent = MODEL_FOLDER_HINTS[group.title] || "No folder location listed yet.";
+        pre.style.cssText = "white-space:pre-wrap;margin:0;padding:12px;border:1px solid #334155;border-radius:8px;background:#020617;color:#bae6fd;font-size:12px;line-height:1.45;overflow:auto;";
+        showInfoModal({
+          title: `${group.title} Folder Locations`,
+          lines: [
+            "Place the files here, then restart ComfyUI if the dropdowns do not refresh.",
+            pre,
+          ],
+        });
       });
-      buttons.append(button);
+      titleRow.append(groupTitle, folderButton);
+      const note = document.createElement("div");
+      note.textContent = group.note;
+      note.style.cssText = "font-size:17px;line-height:1.35;color:#c7d2fe;";
+      const buttons = document.createElement("div");
+      buttons.style.cssText = "display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;";
+      for (const item of group.downloads) {
+        const button = makeMiniButton(item.label);
+        button.style.borderColor = "#2563eb";
+        button.style.background = "#1d4ed8";
+        button.style.color = "#eff6ff";
+        button.style.fontWeight = "900";
+        button.style.fontSize = "16px";
+        button.style.padding = "12px 16px";
+        button.style.borderRadius = "7px";
+        button.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          window.open(item.url, "_blank", "noopener,noreferrer");
+        });
+        buttons.append(button);
+      }
+      card.append(titleRow, note, buttons);
+      body.append(card);
     }
-    card.append(titleRow, note, buttons);
-    body.append(card);
+  };
+
+  const activateTab = (tabId) => {
+    const selected = tabs.find((tab) => tab.id === tabId) || tabs[0];
+    for (const [id, button] of tabButtons) {
+      const active = id === selected.id;
+      button.setAttribute("aria-selected", active ? "true" : "false");
+      button.tabIndex = active ? 0 : -1;
+      button.style.background = active ? "#0e7490" : "#1e293b";
+      button.style.borderColor = active ? "#22d3ee" : "#475569";
+      button.style.color = active ? "#ecfeff" : "#cbd5e1";
+    }
+    renderGroups(selected.groups);
+  };
+
+  for (const tab of tabs) {
+    const button = makeMiniButton(tab.label);
+    button.setAttribute("role", "tab");
+    button.setAttribute("aria-controls", body.id);
+    button.style.cssText += ";font-size:15px;font-weight:900;padding:10px 16px;border-radius:7px;";
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      activateTab(tab.id);
+    });
+    tabButtons.set(tab.id, button);
+    tabBar.append(button);
   }
-  box.append(header, body);
+
+  box.append(header, tabBar, body);
   backdrop.append(box);
   document.body.append(backdrop);
+  activateTab("ltx");
   close.onclick = () => backdrop.remove();
   backdrop.addEventListener("click", (event) => {
     if (event.target === backdrop) backdrop.remove();

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -21304,9 +21304,23 @@ function openBuilder(node) {
     for (const rawLine of String(text || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")) {
       const line = rawLine.trim();
       if (!line) continue;
-      const header = line.match(/^\[([^\]]{2,80})\]$/);
-      if (header) {
-        currentSection = header[1].trim();
+      const tags = Array.from(line.matchAll(/\[([^\]]{1,80})\]/g));
+      const tagPrefix = tags.length && tags[0].index === 0
+        ? line.match(/^(?:\s*\[[^\]]{1,80}\])+\s*/)?.[0] || ""
+        : "";
+      const structural = tags
+        .map((match) => String(match[1] || "").replace(/\s+/g, " ").trim())
+        .find((label) => /^(?:intro|verse|pre[\s-]?chorus|chorus|post[\s-]?chorus|bridge|outro|refrain|hook|breakdown|drop|interlude|instrumental(?:\s+break)?|solo|break|spoken(?:\s+word)?|rap)(?:\s+(?:\d+|[ivxlcdm]+))?$/i.test(label));
+      const terminal = tags.some((match) => /^(?:end|end of song)$/i.test(String(match[1] || "").trim()));
+      if (structural && tagPrefix) {
+        currentSection = structural;
+        const lyricRemainder = line.slice(tagPrefix.length).trim();
+        const key = normalizeLyricSectionLookupText(lyricRemainder);
+        if (key && !map.has(key)) map.set(key, currentSection);
+        continue;
+      }
+      if (terminal && tagPrefix && !line.slice(tagPrefix.length).trim()) {
+        currentSection = "";
         continue;
       }
       const key = normalizeLyricSectionLookupText(line);


### PR DESCRIPTION
## What changed

- Reorganized the Video Builder Download Models window into LTX + Image Models, LLM Models, and MiniMax H3 tabs.
- Preserved every existing model link and added verified MiniMax H3 diffusion model, Qwen3-VL text encoder, video VAE, and audio VAE links with folder guidance.
- Fixed Create User Story Arc parsing for compound lyric headers such as [Intro] [Whispered] [Dark Atmosphere].
- Story Arc now ignores adjacent mood/performance tags and [End], preserves consecutive real sections, prioritizes live Line Mapping lyrics, and accepts harmless bracketed or first-occurrence-numbered Gemma headings.
- Updated the Video Builder guide and in-app New Updates entry.

## Why

MiniMax H3 users need its complete model setup discoverable from the Builder. Separately, lyrics containing multiple bracketed tags caused the Story Arc parser to miss real song sections and validate Gemma against incorrect instrumental scene headings.

## User impact

Users can find every MiniMax H3 model from Download Models. Songs using combined section, performance, and mood tags now retain their real Intro, Verse, Chorus, Bridge, and Outro structure when Create User Story Arc runs.

## Root cause

The lyric parser only recognized a section when the entire line contained exactly one bracket pair. It also preferred a saved project lyrics file over the live Line Mapping input, and the output validator rejected otherwise harmless bracketed headings.

## Validation

- All four Hugging Face model links returned HTTP 200.
- The reported lyric sample parses as Intro, Verse, Verse 2, Chorus, Bridge, and Outro.
- Existing Story Arc section tests pass.
- Python and JavaScript syntax checks pass.
- update_notes.json parses successfully.
- Git diff and whitespace checks pass.
- No test, backup, or temporary files are included.