### PR TITLE
Improve AI Video Builder timeline editing and MiniMax workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A growing collection of custom ComfyUI nodes for **AI video creation, music videos, storyboarding, image generation, video enhancement, face repair, editing, LoRA training, and workflow automation**.
 
-The flagship tool is the **MiniMax H3 and LTX 2.3 Video Builder**: a scene-by-scene production workspace that brings planning, prompting, media generation, timing, review, and final assembly together inside ComfyUI.
+The flagship tool is the **AI Video Builder**: a scene-by-scene production workspace for LTX 2.3, MiniMax H3, and future video engines that brings planning, prompting, media generation, timing, review, and final assembly together inside ComfyUI.
 
 ---
 
 ## 🎬 AI Video Builder
 
-Add the node named **`VRGDG Music Video Builder UI`** to open the Builder.
+Add the node named **`VRGDG AI Video Builder UI`** to open the Builder.
 
 Use it to:
 
@@ -23,7 +23,7 @@ Use it to:
 - 💾 Save, branch, export, import, and continue portable Builder projects.
 - 🤖 Use built-in LLM, local LM Studio, API, and Browser AI options where supported.
 
-📖 **New here? Start with the full [MiniMax H3 and LTX 2.3 Video Builder Guide](Workflows/LTX-2_Workflows/Video_Builder/readme.md).**
+📖 **New here? Start with the full [AI Video Builder Guide](Workflows/LTX-2_Workflows/Video_Builder/readme.md).**
 
 ✨ **Or chat with a GPT and ask any question about the video builder. [HERE](https://chatgpt.com/g/g-6a6b4799d0e48191acf5a97fb2132ba9-ltx-2-3-music-video-builder-guide)** 
 
@@ -68,7 +68,7 @@ These are some of the most useful tools included in the pack. Many can be used o
 
 1. Install the node pack and restart ComfyUI.
 2. Hard refresh the ComfyUI browser page so the latest JavaScript UI files load.
-3. Add **`VRGDG Music Video Builder UI`**.
+3. Add **`VRGDG AI Video Builder UI`**.
 4. Create a project and add audio, SRT timing, or scenes.
 5. Use the Wizard or Storyboard Builder to plan the project.
 6. Generate and approve scene images, render scene videos, then stitch the final video.

--- a/VRGDG_MusicVideoPromptCreatorNodes.py
+++ b/VRGDG_MusicVideoPromptCreatorNodes.py
@@ -1332,7 +1332,7 @@ def _save_prompt_creator_outputs(payload):
     if concept_prompts:
         concept_prompts = _canonical_prompt_mapping(concept_prompts)
         if _is_scene_label_only_prompt_mapping(concept_prompts):
-            raise ValueError("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to Video Creator.")
+            raise ValueError("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to AI Video Builder.")
         if _payload_bool(payload.get("append_subject_to_prompts", True), True):
             concept_prompts = _prepend_subject_to_prompts(
                 concept_prompts,

--- a/VRGDG_UpdateRoutes.py
+++ b/VRGDG_UpdateRoutes.py
@@ -76,7 +76,7 @@ def _load_release_notes(ref=""):
     if not raw:
         notes_path = os.path.join(_NODE_DIR, _RELEASE_NOTES_FILE)
         if not os.path.isfile(notes_path):
-            return {"schema_version": 1, "product": "LTX 2.3 Video Builder", "releases": []}, "none"
+            return {"schema_version": 1, "product": "AI Video Builder", "releases": []}, "none"
         with open(notes_path, "r", encoding="utf-8") as handle:
             raw = handle.read()
 

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -1,4 +1,4 @@
-# Video Builder Guide — LTX 2.3 and MiniMax H3
+# AI Video Builder Guide
 
 This guide is for someone opening the Video Builder for the first time. It explains what each main area does, the usual workflow, and where to look when something is missing.
 
@@ -209,7 +209,7 @@ After every completed update, fully stop and restart ComfyUI, then hard refresh 
 
 ## Opening the Builder
 
-Add the node named `VRGDG Music Video Builder UI` in ComfyUI.
+Add the node named `VRGDG AI Video Builder UI` in ComfyUI.
 
 When the builder opens, it may show a welcome window where you can create a new project or open an existing project.
 
@@ -2496,8 +2496,8 @@ Prompt Creator buttons:
 | `Run: Skip Whisper/SRT` | Uses existing SRT/segment data and runs the later prompt steps |
 | `Save Project Draft` | Saves the Prompt Creator draft |
 | `Load Project Draft` | Opens a saved Prompt Creator draft |
-| `Send To Video Creator` | Sends saved Prompt Creator output into Video Builder |
-| `Back To Video Creator` | Returns to Video Builder without necessarily importing new data |
+| `Send To AI Video Builder` | Sends saved Prompt Creator output into Video Builder |
+| `Back To AI Video Builder` | Returns to Video Builder without necessarily importing new data |
 
 ### Concept Lyric Match
 
@@ -2525,7 +2525,7 @@ Use presets or restore defaults if a custom instruction causes problems.
 After running or editing Prompt Creator:
 
 1. Click `Save Project Draft`.
-2. Click `Send To Video Creator`.
+2. Click `Send To AI Video Builder`.
 3. In Video Builder, confirm scenes, notes, prompt paths, audio, and SRT timing came over.
 4. Use `Import Data From Prompt Creator` or Prompt Options reload buttons if needed.
 
@@ -2539,9 +2539,9 @@ Useful buttons:
 | --- | --- |
 | `Prompt Creator (Legacy)` | Shows the legacy-workflow warning before opening Prompt Creator |
 | `Import Data From Prompt Creator` | Copies Prompt Creator outputs into the current builder project |
-| `Send To Video Creator` | From Prompt Creator, saves/imports the current prompt creator project into Video Builder |
+| `Send To AI Video Builder` | From Prompt Creator, saves/imports the current prompt creator project into Video Builder |
 | `Send To Prompt Creator` | From Video Builder, sends audio/SRT/lyrics back to Prompt Creator so you can create concept prompts |
-| `Back To Video Creator` | Returns to Video Builder; it is navigation, not the same as importing |
+| `Back To AI Video Builder` | Returns to Video Builder; it is navigation, not the same as importing |
 | `Prompt Options` | Opens prompt-related settings/options |
 | `LLM Runner` | Opens text-only LLM/Gemma runner tools |
 | `Agent` | Opens the builder assistant/agent |
@@ -2822,7 +2822,7 @@ These copies are optimized for web viewing and download. The original full-resol
 
 Use this if you are new and just want the first successful video.
 
-1. Add/open `VRGDG Music Video Builder UI`.
+1. Add/open `VRGDG AI Video Builder UI`.
 2. Click `New Project`.
 3. Add global audio in the `Audio` tab.
 4. Import SRT or create scenes with `+ Segment` / `Bulk Segments`.
@@ -2864,7 +2864,7 @@ Use this only for an older Prompt Creator project or when you specifically need 
 2. Add audio and full lyrics.
 3. Run the prompt creator pipeline.
 4. Review/edit concept prompts and motion notes.
-5. Click `Send To Video Creator`.
+5. Click `Send To AI Video Builder`.
 6. In Video Builder, verify scenes, notes, prompts, audio, and SRT timing.
 7. Generate images and videos.
 
@@ -2958,7 +2958,7 @@ Use this for new projects.
 | Story Arc reports a changed lyric structure | Update and rerun. Trailing invented headings are removed automatically; a remaining error means Gemma actually missed, renamed, reordered, or inserted a heading inside the required structure |
 | Render All progress disappeared | Reopen the persistent render log and inspect the saved JSON/text report in the project for completed phases, failures, and stitch timing |
 | A scene render reports the wait limit | The Builder now waits up to two hours. Check whether the ComfyUI queue is still running; if it finished, use scene-video recovery/history, and inspect the terminal plus temporary output before retrying |
-| Prompt Creator data does not populate notes | Use `Send To Video Creator` or `Import Data From Prompt Creator`, then reload/import prompt files if needed |
+| Prompt Creator data does not populate notes | Use `Send To AI Video Builder` or `Import Data From Prompt Creator`, then reload/import prompt files if needed |
 | LM Studio is selected but not used | Vision Gemma still uses built-in GGUF; only text-only passes use LM Studio |
 | Browser AI cannot control the browser | Run Install/Check Browser Setup, sign in with `Open Selected Login`, or use the manual export/import path |
 | Face Fix finds no face | Choose a clearer description frame, lower minimum face pixels, adjust confidence/rotation assist, or pick a repair-distance preset that includes the face size |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-vrgamedevgirl"
-description = "VRGameDevGirl custom nodes for ComfyUI music-video, audio, image, video, workflow-runner, prompt-creator, and post-process workflows."
+description = "VRGameDevGirl custom nodes for the ComfyUI AI Video Builder, audio, image, video, workflow-runner, prompt-creator, and post-process workflows."
 version = "9.0.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/tests/test_builder_delete_all_videos.py
+++ b/tests/test_builder_delete_all_videos.py
@@ -1,0 +1,60 @@
+import unittest
+from pathlib import Path
+
+
+BUILDER_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+DELETE_ALL_START = BUILDER_SOURCE.index("async function deleteAllTimelineVideos()")
+DELETE_ALL_END = BUILDER_SOURCE.index(
+    "async function deleteAllTimelineImages()", DELETE_ALL_START
+)
+DELETE_ALL_SOURCE = BUILDER_SOURCE[DELETE_ALL_START:DELETE_ALL_END]
+
+
+class BuilderDeleteAllVideosTests(unittest.TestCase):
+    def test_delete_all_videos_button_is_wired(self):
+        self.assertIn('makeButton("Delete ALL Videos")', BUILDER_SOURCE)
+        self.assertIn(
+            "deleteAllTimelineVideosButton.onclick = deleteAllTimelineVideos",
+            BUILDER_SOURCE,
+        )
+
+    def test_action_clears_timeline_video_assignments_and_history(self):
+        self.assertIn("const segments = allEditableSegments()", DELETE_ALL_SOURCE)
+        for line in (
+            'segment.video_path = ""',
+            "segment.video_history = []",
+            "segment.video_thumbnail_history = []",
+            "segment.video_backup_paths = []",
+            "segment.video_history_index = -1",
+            "segment.video_output = null",
+            'segment.video_status = "none"',
+        ):
+            self.assertIn(line, DELETE_ALL_SOURCE)
+
+    def test_action_never_deletes_media_files(self):
+        self.assertNotIn("delete_project_media", DELETE_ALL_SOURCE)
+        self.assertNotIn("postJson(", DELETE_ALL_SOURCE)
+        self.assertIn("will NOT be deleted", DELETE_ALL_SOURCE)
+        self.assertIn("remain on disk as backups", DELETE_ALL_SOURCE)
+
+    def test_action_is_undoable_and_saved(self):
+        self.assertIn("pushHistory()", DELETE_ALL_SOURCE)
+        self.assertIn(
+            'autoSaveSessionQuiet("all timeline videos removed")',
+            DELETE_ALL_SOURCE,
+        )
+
+    def test_action_does_not_clear_images_or_prompts(self):
+        self.assertNotIn("segment.image_history = []", DELETE_ALL_SOURCE)
+        self.assertNotIn('segment.i2v_prompt = ""', DELETE_ALL_SOURCE)
+        self.assertNotIn('segment.minimax_h3_prompt = ""', DELETE_ALL_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_ltx_to_minimax_conversion.py
+++ b/tests/test_builder_ltx_to_minimax_conversion.py
@@ -1,0 +1,64 @@
+import unittest
+from pathlib import Path
+
+
+BUILDER_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+class BuilderLtxToMiniMaxConversionTests(unittest.TestCase):
+    def test_converter_is_a_single_tools_panel_action(self):
+        self.assertIn(
+            'makeButton("Convert LTX Video Prompts to MiniMax H3", "primary")',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "convertLtxPromptsToMiniMaxButton.onclick = convertAllLtxVideoPromptsToMiniMaxH3",
+            BUILDER_SOURCE,
+        )
+
+    def test_converter_reads_ltx_prompts_and_writes_separate_minimax_prompts(self):
+        self.assertIn(
+            'ltxPrompt: String(segment?.i2v_prompt || "").trim()',
+            BUILDER_SOURCE,
+        )
+        self.assertIn("segment.minimax_h3_prompt = prompt", BUILDER_SOURCE)
+        self.assertNotIn("segment.i2v_prompt = prompt;\n        converted += 1", BUILDER_SOURCE)
+
+    def test_converter_keeps_global_audio_as_input_audio(self):
+        self.assertIn('audio_mode: "input_audio"', BUILDER_SOURCE)
+        self.assertIn(
+            "The existing global Audio 1 file remains the only audio source and must stay completely unchanged.",
+            BUILDER_SOURCE,
+        )
+
+    def test_converter_is_limited_to_music_video_projects(self):
+        self.assertIn(
+            'if (normalizeVideoType(state.videoType) === "speaking")',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "This converter is for music-video projects, not speaking / short-film projects.",
+            BUILDER_SOURCE,
+        )
+
+    def test_converter_creates_one_undo_checkpoint_before_first_write(self):
+        converter_start = BUILDER_SOURCE.index(
+            "async function convertAllLtxVideoPromptsToMiniMaxH3()"
+        )
+        converter_end = BUILDER_SOURCE.index(
+            "async function createI2VPromptWithGemma()", converter_start
+        )
+        converter = BUILDER_SOURCE[converter_start:converter_end]
+        self.assertEqual(converter.count("pushHistory();"), 1)
+        self.assertLess(
+            converter.index("pushHistory();"),
+            converter.index("segment.minimax_h3_prompt = prompt"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_builtin_audio_trim.py
+++ b/tests/test_builder_minimax_builtin_audio_trim.py
@@ -1,0 +1,67 @@
+import unittest
+from pathlib import Path
+
+
+BUILDER_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+def function_source(name, next_name):
+    start = BUILDER_SOURCE.index(f"function {name}")
+    end = BUILDER_SOURCE.index(f"function {next_name}", start)
+    return BUILDER_SOURCE[start:end]
+
+
+class BuilderMiniMaxBuiltInAudioTrimTests(unittest.TestCase):
+    def test_rendered_minimax_built_in_audio_is_a_timeline_playback_source(self):
+        source = function_source(
+            "segmentUsesRenderedTimelineAudio", "usingRenderedSceneAudioMode"
+        )
+        self.assertIn('normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3"', source)
+        self.assertIn('audio_mode === "built_in_audio"', source)
+        self.assertIn("selectedSegmentVideoPath(segment)", source)
+
+    def test_rendered_scene_media_starts_at_local_zero(self):
+        source = function_source(
+            "timelineAudioSourceStartForSegment", "timelineAudioDurationForSegment"
+        )
+        self.assertIn("segmentUsesRenderedTimelineAudio(segment)", source)
+        self.assertIn("return 0;", source)
+
+    def test_scrubbing_without_global_audio_uses_scene_timeline_time(self):
+        source = function_source("setGlobalPlaybackTime", "playSceneAudioFrom")
+        self.assertIn("if (usingSceneAudioPlaybackMode())", source)
+        self.assertIn("state.sceneSelectionUsesGlobalAudio = false", source)
+        self.assertIn("state.sceneAudioGlobalTime = time", source)
+
+    def test_right_clicking_scissors_offers_before_or_after_trim(self):
+        self.assertIn("splitSceneButton.oncontextmenu", BUILDER_SOURCE)
+        source = function_source(
+            "chooseRenderedSceneTrimAtPlayhead", "trimBaseSceneVideoAtPlayhead"
+        )
+        self.assertIn('value: "before"', source)
+        self.assertIn('label: "Remove before playhead"', source)
+        self.assertIn('value: "after"', source)
+        self.assertIn('label: "Remove after playhead"', source)
+        self.assertIn(
+            'choice === "before" ? "left" : "right"',
+            source,
+        )
+
+    def test_left_clicking_scissors_routes_rendered_minimax_to_trim(self):
+        start = BUILDER_SOURCE.index("async function splitActiveSceneAtPlayhead()")
+        end = BUILDER_SOURCE.index("function setTimelineRangePoint", start)
+        source = BUILDER_SOURCE[start:end]
+        self.assertIn("if (baseSceneVideoTrimKind(segment))", source)
+        self.assertIn("await chooseRenderedSceneTrimAtPlayhead()", source)
+        self.assertLess(
+            source.index("await chooseRenderedSceneTrimAtPlayhead()"),
+            source.index("cannot be split"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_render_prompt_passthrough.py
+++ b/tests/test_builder_minimax_render_prompt_passthrough.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+RUNNER_SOURCE = (ROOT / "VRGDG_WorkflowRunnerNodes.py").read_text(encoding="utf-8")
+
+
+RENDER_START = BUILDER_SOURCE.index(
+    "async function renderMiniMaxSceneVideoWithProgress"
+)
+RENDER_END = BUILDER_SOURCE.index(
+    "async function createMiniMaxSceneVideo", RENDER_START
+)
+RENDER_SOURCE = BUILDER_SOURCE[RENDER_START:RENDER_END]
+
+
+class BuilderMiniMaxRenderPromptPassthroughTests(unittest.TestCase):
+    def test_render_uses_the_saved_prompt_without_rewriting_it(self):
+        self.assertIn(
+            "const prompt = String(\n      options.prompt\n      ?? (segment?.minimax_h3_prompt || segment?.i2v_prompt || \"\")\n    ).trim();",
+            RENDER_SOURCE,
+        )
+        self.assertNotIn("applyMiniMaxH3NativeVoiceBlock", RENDER_SOURCE)
+        self.assertNotIn("applyMiniMaxH3ContinuityPromptBlock", RENDER_SOURCE)
+
+    def test_same_prompt_is_shown_and_sent(self):
+        self.assertIn("progress?.setSceneDetails?.({", RENDER_SOURCE)
+        self.assertIn("prompt,", RENDER_SOURCE)
+        payload_start = RENDER_SOURCE.index("const payload = {")
+        payload_end = RENDER_SOURCE.index("};", payload_start)
+        self.assertIn("prompt,", RENDER_SOURCE[payload_start:payload_end])
+
+    def test_workflow_runner_writes_the_complete_payload_string_to_h3(self):
+        start = RUNNER_SOURCE.index("def _build_minimax_h3_api_prompt")
+        end = RUNNER_SOURCE.index("def _build_i2v_api_prompt", start)
+        source = RUNNER_SOURCE[start:end]
+        self.assertIn(
+            '_set_api_input(prompt, "138", "value", video_prompt)',
+            source,
+        )
+        self.assertNotIn("video_prompt[:", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_silent_timeline_playback.py
+++ b/tests/test_builder_silent_timeline_playback.py
@@ -1,0 +1,62 @@
+import unittest
+from pathlib import Path
+
+
+BUILDER_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "VRGDG_MusicVideoBuilderUI.js"
+).read_text(encoding="utf-8")
+
+
+def between(start_text, end_text):
+    start = BUILDER_SOURCE.index(start_text)
+    end = BUILDER_SOURCE.index(end_text, start)
+    return BUILDER_SOURCE[start:end]
+
+
+class BuilderSilentTimelinePlaybackTests(unittest.TestCase):
+    def test_silent_clock_advances_with_animation_frames(self):
+        source = between(
+            "function startSilentTimelinePlayback",
+            "function currentGlobalTime",
+        )
+        self.assertIn("performance.now()", source)
+        self.assertIn("window.requestAnimationFrame(tick)", source)
+        self.assertIn("state.sceneAudioGlobalTime = current", source)
+        self.assertIn("updateAudioScrubbers()", source)
+
+    def test_silent_clock_counts_as_timeline_playback(self):
+        source = between("function isTimelinePlaying", "function updatePlayPauseButton")
+        self.assertIn("silentTimelinePlaying", source)
+
+    def test_no_audio_play_falls_back_to_silent_clock(self):
+        source = between(
+            "playButton.onclick = () => {",
+            "multiSelectButton.onclick",
+        )
+        self.assertIn("if (!ensureGlobalTimelineAudioSource(startTime))", source)
+        self.assertIn("startSilentTimelinePlayback(startTime)", source)
+        self.assertNotIn("Load audio first, or add custom audio to scenes.", source)
+
+    def test_unplayable_audio_also_falls_back_to_silent_clock(self):
+        self.assertIn(
+            "audio.play().then(updatePlayPauseButton).catch(() => startSilentTimelinePlayback(startTime))",
+            BUILDER_SOURCE,
+        )
+        scene_source = between("function playSceneAudioFrom", "function beginGlobalTimelineScrub")
+        self.assertIn("sceneAudio.play().catch(() =>", scene_source)
+        self.assertIn("startSilentTimelinePlayback(state.sceneAudioGlobalTime)", scene_source)
+
+    def test_no_audio_scrubbing_uses_virtual_timeline_time(self):
+        source = between("function currentGlobalTime", "function currentProjectAudioPath")
+        self.assertIn("if (!currentProjectAudioPath())", source)
+        self.assertIn("state.sceneAudioGlobalTime", source)
+
+    def test_pause_stops_the_silent_clock(self):
+        source = between("function pauseAllAudio", "function selectSegmentGlobalAudioStart")
+        self.assertIn("stopSilentTimelinePlayback()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+UPDATE_NOTES = json.loads((ROOT / "update_notes.json").read_text(encoding="utf-8"))
+
+
+class BuilderUpdateBannerNotesTests(unittest.TestCase):
+    def test_latest_release_documents_the_workspace_updates(self):
+        release = UPDATE_NOTES["releases"][0]
+        self.assertEqual(
+            release["id"],
+            "2026-08-06-timeline-editing-minimax-prompt-reliability",
+        )
+        items = "\n".join(
+            item
+            for section in release["sections"]
+            for item in section.get("items", [])
+        )
+        for expected in (
+            "LTX video prompt",
+            "silent timeline playback",
+            "playhead trimming",
+            "Delete ALL Videos",
+            "complete saved right-panel prompt",
+        ):
+            self.assertIn(expected, items)
+
+    def test_banner_uses_the_ai_video_builder_name(self):
+        self.assertIn(
+            'heading.textContent = "What\'s New in AI Video Builder"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            '"Dismiss AI Video Builder version status"',
+            BUILDER_SOURCE,
+        )
+
+    def test_uncommitted_local_release_is_visible_in_current_view(self):
+        self.assertIn(
+            '!String(release.commit || "").trim()',
+            BUILDER_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_notes.json
+++ b/update_notes.json
@@ -7,7 +7,7 @@
       "version": "2026.08.06-builder-workflow-updates",
       "date": "2026-08-06",
       "title": "Timeline editing and MiniMax prompt workflow improvements",
-      "commit": "",
+      "commit": "2f678b0ce9e15e4350745fd365f9af438d942462",
       "restart_required": true,
       "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
       "sections": [

--- a/update_notes.json
+++ b/update_notes.json
@@ -1,7 +1,51 @@
 {
   "schema_version": 1,
-  "product": "LTX 2.3 Video Builder",
+  "product": "AI Video Builder",
   "releases": [
+    {
+      "id": "2026-08-06-timeline-editing-minimax-prompt-reliability",
+      "version": "2026.08.06-builder-workflow-updates",
+      "date": "2026-08-06",
+      "title": "Timeline editing and MiniMax prompt workflow improvements",
+      "commit": "",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added a one-button Tools-panel converter that sends every populated LTX video prompt through the selected LLM Runner and saves a separate, more detailed MiniMax H3 prompt without changing the original LTX prompt, global audio, scene timing, or other project data.",
+            "Added silent timeline playback so the playhead, scene selection, seeking, and scrubbing continue to work in short-film projects and other timelines that do not have global audio.",
+            "Added playhead trimming for rendered MiniMax built-in-audio and ID-LoRA scenes. Click or right-click the scissors button and choose whether to remove everything before or after the playhead.",
+            "Added Delete ALL Videos to clear every selected video, video history entry, thumbnail assignment, trim state, and rendered-video continuity assignment from the timeline while preserving the actual files in the project folder as backups."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Rendered MiniMax H3 built-in-audio clips can now supply scene audio during timeline playback and begin from the rendered clip's local start when no global audio is present.",
+            "Renamed user-facing Music Video Builder and Video Creator labels to AI Video Builder across the main README, Builder guide, Prompt Creator, Storyboard Builder, Wizard, release notes, and package metadata.",
+            "Closing the Builder now stops global audio, scene audio, silent timeline playback, and active video-preview playback."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "MiniMax Render All now displays and sends the complete saved right-panel prompt exactly as written instead of rewriting voice, B-roll, or continuity text during rendering.",
+            "Replaced an unbounded MiniMax managed-block cleanup pattern that could remove every timestamped shot, Audio section, and Continuity section after a visual-only B-roll block.",
+            "Timeline Play no longer stops with a Load audio first error when the project has no global audio; it automatically uses the silent timeline clock instead.",
+            "MiniMax built-in-audio timeline scrubbing now uses scene timeline time and the correct local media offset."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "The LTX-to-MiniMax converter is for music-video projects and continues using the same unchanged global Audio 1 file; it does not enable MiniMax built-in audio.",
+            "Delete ALL Videos changes timeline assignments only. Existing rendered video and thumbnail files remain in the project folder and can still be used as backups."
+          ]
+        }
+      ]
+    },
     {
       "id": "2026-08-05-minimax-h3-model-downloads",
       "version": "2026.08.05-minimax-h3-model-downloads",
@@ -314,7 +358,7 @@
         {
           "title": "New",
           "items": [
-            "Added Review Guide to the Builder menu for direct access to the public LTX 2.3 Video Builder guide.",
+            "Added Review Guide to the Builder menu for direct access to the public AI Video Builder guide.",
             "Added a clear legacy notice before opening the older Prompt Creator workflow.",
             "Added an optional What's New window so users can review release details from the status banner or Builder menu."
           ]

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2390,7 +2390,7 @@ function openBuilder(node) {
   updateStatusClose.type = "button";
   updateStatusClose.textContent = "×";
   updateStatusClose.title = "Dismiss this version status";
-  updateStatusClose.setAttribute("aria-label", "Dismiss LTX 2.3 Video Builder version status");
+  updateStatusClose.setAttribute("aria-label", "Dismiss AI Video Builder version status");
   updateStatusClose.style.cssText = "width:24px;height:24px;flex:0 0 24px;display:flex;align-items:center;justify-content:center;padding:0;border:1px solid rgba(255,255,255,.32);border-radius:5px;background:rgba(0,0,0,.18);color:inherit;font:700 18px/1 sans-serif;cursor:pointer;";
   updateStatusBanner.append(updateStatusDot, updateStatusText, updateWhatsNewAction, updateStatusAction, updateStatusClose);
 
@@ -2436,7 +2436,10 @@ function openBuilder(node) {
     if (mode === "available" && availableIds.size) {
       releases = allReleases.filter((release) => availableIds.has(String(release.id || "")));
     } else if (mode === "current" && currentReleaseId) {
-      releases = allReleases.filter((release) => String(release.id || "") === currentReleaseId);
+      releases = allReleases.filter((release) => (
+        !String(release.commit || "").trim()
+        || String(release.id || "") === currentReleaseId
+      ));
     }
     if (!releases.length) releases = allReleases.slice(0, mode === "history" ? 8 : 3);
 
@@ -2451,7 +2454,7 @@ function openBuilder(node) {
     const headingWrap = document.createElement("div");
     headingWrap.style.cssText = "min-width:0;flex:1 1 auto;";
     const heading = document.createElement("div");
-    heading.textContent = "What's New in LTX 2.3 Video Builder";
+    heading.textContent = "What's New in AI Video Builder";
     heading.style.cssText = "font-size:19px;font-weight:950;color:#cffafe;";
     const summary = document.createElement("div");
     const installed = String(payload.installed_commit || "").slice(0, 7);
@@ -2627,6 +2630,8 @@ function openBuilder(node) {
   fullscreenButton.title = "Expand the Video Creator to fill the browser window without closing or resetting anything.";
   const closeButton = makeButton("Close");
   closeButton.onclick = () => {
+    pauseAllAudio();
+    if (!previewVideo.paused) previewVideo.pause();
     window.removeEventListener("vrgdg:builder-toast", toastNotificationHandler);
     if (builderKeydownHandler) document.removeEventListener("keydown", builderKeydownHandler, true);
     restoreBrowserAiDownloadsQuietly().catch(() => null);
@@ -2654,6 +2659,8 @@ function openBuilder(node) {
   const zImageAllButton = makeButton("Image All");
   const zEnhanceAllButton = makeButton("Enhance All");
   const zEnhanceAllToolButton = makeButton("Enhance All");
+  const convertLtxPromptsToMiniMaxButton = makeButton("Convert LTX Video Prompts to MiniMax H3", "primary");
+  convertLtxPromptsToMiniMaxButton.title = "Use the selected LLM Runner to convert every populated LTX video prompt into a MiniMax H3 prompt. Global audio and all other project data stay unchanged.";
   const importImageFolderButton = makeButton("Fill Timeline Images From Folder", "primary");
   const fullBuildButton = makeButton("Build Full Video");
   const fullFLFBuildButton = makeButton("Build Full FLF Video");
@@ -2803,6 +2810,7 @@ function openBuilder(node) {
     beatCalibrationToolRow,
     beatCalibrationWizard,
     makeToolRow(snapAllSceneStartsButton, "Snap Scene 3 onward to the nearest valid beat. The Scene 1-to-2 intro boundary stays fixed; connected previous scene ends move with later shared cuts."),
+    makeToolRow(convertLtxPromptsToMiniMaxButton, "Convert every populated LTX video prompt into a detailed MiniMax H3 prompt. The global audio file, scene timing, and original LTX prompts stay unchanged."),
     makeToolRow(zEnhanceAllToolButton, "Upscale/enhance every timeline scene that already has an image, using each scene's current T2I/image prompt."),
     makeToolRow(builderAgentButton, "Open Builder Agent for scene help, prompt edits, image references, and project guidance.")
   );
@@ -5389,7 +5397,7 @@ function openBuilder(node) {
   clearRangeButton.title = "Clear the selected timeline range.";
   closeTimelineGapsButton.title = "Shift later base scenes left to remove empty gaps in the timeline.";
   snapSceneEdgeButton.title = "Move the selected scene start or end to its closest beat marker. A connected neighboring scene follows only at that shared boundary. Shortcuts: Ctrl+S snaps the start; Ctrl+E snaps the end.";
-  splitSceneButton.title = "Split the selected base scene at the playhead. The left and right scene timings stay exactly where they are; later clips do not move and are only renumbered. Vocal text stays on the left half, while instrumental text is kept on both halves. Scenes with rendered video must be cleared before splitting.";
+  splitSceneButton.title = "Click: split an unrendered base scene, or trim a rendered ID-LoRA / MiniMax built-in-audio scene before or after the playhead. Right-click also opens the rendered-scene trim chooser.";
   idLoraTrimModeButton.title = "Quiet scrub mode for finding left/right video trim points without autoplay. Available for ID-LoRA and MiniMax built-in-audio scenes.";
   overlayTrackToggleButton.title = "Turn the advanced overlay timeline on or off.";
   overlayTrackHintButton.title = "How does the overlay timeline work?";
@@ -5495,13 +5503,19 @@ function openBuilder(node) {
   deleteSelectedMediaButton.style.padding = "6px 10px";
   deleteSelectedMediaButton.style.borderColor = "#7f1d1d";
   deleteSelectedMediaButton.style.color = "#fecaca";
+  const deleteAllTimelineVideosButton = makeButton("Delete ALL Videos");
+  deleteAllTimelineVideosButton.style.padding = "6px 10px";
+  deleteAllTimelineVideosButton.style.borderColor = "#dc2626";
+  deleteAllTimelineVideosButton.style.background = "#450a0a";
+  deleteAllTimelineVideosButton.style.color = "#fee2e2";
+  deleteAllTimelineVideosButton.title = "Remove every selected/generated video and video history entry from the timeline without deleting any video or thumbnail files from the project folder.";
   const deleteAllTimelineImagesButton = makeButton("Delete ALL Images");
   deleteAllTimelineImagesButton.style.padding = "6px 10px";
   deleteAllTimelineImagesButton.style.borderColor = "#dc2626";
   deleteAllTimelineImagesButton.style.background = "#450a0a";
   deleteAllTimelineImagesButton.style.color = "#fee2e2";
   deleteAllTimelineImagesButton.title = "Delete every timeline image from every scene, including FLF first frames, last frames, and extracted chained start frames, and remove those files from the project folder.";
-  selectedMediaTools.append(selectedMediaLabel, useFrameAsImageButton, deleteSelectedMediaButton, deleteAllTimelineImagesButton);
+  selectedMediaTools.append(selectedMediaLabel, useFrameAsImageButton, deleteSelectedMediaButton, deleteAllTimelineVideosButton, deleteAllTimelineImagesButton);
   const zoomWrap = document.createElement("div");
   zoomWrap.style.cssText = "display:flex;gap:4px;align-items:center;";
   zoomWrap.append(zoomOutButton, zoomInButton);
@@ -5538,6 +5552,10 @@ function openBuilder(node) {
   audio.preload = "metadata";
   const sceneAudio = document.createElement("audio");
   sceneAudio.preload = "metadata";
+  let silentTimelinePlaying = false;
+  let silentTimelineRaf = 0;
+  let silentTimelineStartedAt = 0;
+  let silentTimelineStartTime = 0;
   updateGlobalAudioMuteButton();
 
   const shellHeader = document.createElement("div");
@@ -8844,15 +8862,23 @@ function openBuilder(node) {
     return state.segments.some((segment) => String(segment.custom_audio_path || "").trim());
   }
 
+  function segmentUsesRenderedTimelineAudio(segment) {
+    if (!segment || !String(selectedSegmentVideoPath(segment) || "").trim()) return false;
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+      return miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio";
+    }
+    return currentVideoMode() === "id_lora";
+  }
+
   function usingRenderedSceneAudioMode() {
-    return currentVideoMode() === "id_lora" && !currentProjectAudioPath() && state.segments.some((segment) => String(selectedSegmentVideoPath(segment) || "").trim());
+    return !currentProjectAudioPath() && state.segments.some((segment) => segmentUsesRenderedTimelineAudio(segment));
   }
 
   function timelineAudioPathForSegment(segment) {
     if (!segment) return "";
     const customAudioPath = String(segment.custom_audio_path || "").trim();
     if (customAudioPath) return customAudioPath;
-    if (usingRenderedSceneAudioMode()) return String(selectedSegmentVideoPath(segment) || "").trim();
+    if (!currentProjectAudioPath() && segmentUsesRenderedTimelineAudio(segment)) return String(selectedSegmentVideoPath(segment) || "").trim();
     if (usingSceneAudioMode()) return currentProjectAudioPath();
     return "";
   }
@@ -8864,9 +8890,9 @@ function openBuilder(node) {
 
   function timelineAudioSourceStartForSegment(segment) {
     if (!segment) return 0;
-    return String(segment.custom_audio_path || "").trim()
-      ? audioSourceStart(segment)
-      : Math.max(0, Number(segment.start || 0));
+    if (String(segment.custom_audio_path || "").trim()) return audioSourceStart(segment);
+    if (!currentProjectAudioPath() && segmentUsesRenderedTimelineAudio(segment)) return 0;
+    return Math.max(0, Number(segment.start || 0));
   }
 
   function timelineAudioDurationForSegment(segment) {
@@ -9209,10 +9235,54 @@ function openBuilder(node) {
     };
   }
 
+  function stopSilentTimelinePlayback() {
+    silentTimelinePlaying = false;
+    if (silentTimelineRaf) window.cancelAnimationFrame(silentTimelineRaf);
+    silentTimelineRaf = 0;
+  }
+
+  function startSilentTimelinePlayback(startTime = currentGlobalTime()) {
+    const maxTime = playbackDuration();
+    if (!(maxTime > 0)) {
+      toast("Add a scene with a positive duration before playing the timeline.", true);
+      return false;
+    }
+    audio.pause();
+    sceneAudio.pause();
+    stopSilentTimelinePlayback();
+    silentTimelineStartTime = Math.max(0, Math.min(maxTime, Number(startTime || 0)));
+    silentTimelineStartedAt = performance.now();
+    state.sceneAudioGlobalTime = silentTimelineStartTime;
+    state.sceneSelectionUsesGlobalAudio = false;
+    silentTimelinePlaying = true;
+
+    const tick = (now) => {
+      if (!silentTimelinePlaying) return;
+      const elapsed = Math.max(0, (Number(now || 0) - silentTimelineStartedAt) / 1000);
+      const current = Math.min(maxTime, silentTimelineStartTime + elapsed);
+      state.sceneAudioGlobalTime = current;
+      updateAudioScrubbers();
+      if (current >= maxTime - 0.001) {
+        stopSilentTimelinePlayback();
+        if (!previewVideo.paused) previewVideo.pause();
+        updatePlayPauseButton();
+        updateAudioScrubbers();
+        return;
+      }
+      silentTimelineRaf = window.requestAnimationFrame(tick);
+    };
+    silentTimelineRaf = window.requestAnimationFrame(tick);
+    updatePlayPauseButton();
+    updateAudioScrubbers();
+    return true;
+  }
+
   function currentGlobalTime() {
+    if (silentTimelinePlaying) return Number(state.sceneAudioGlobalTime || 0);
     if (usingSceneAudioPlaybackMode() && (!state.sceneSelectionUsesGlobalAudio || (sceneAudio.src && !sceneAudio.paused))) {
       return Number(state.sceneAudioGlobalTime || 0);
     }
+    if (!currentProjectAudioPath()) return Number(state.sceneAudioGlobalTime || 0);
     return Number(audio.currentTime || 0);
   }
 
@@ -9280,7 +9350,7 @@ function openBuilder(node) {
   }
 
   function isTimelinePlaying() {
-    return (audio.src && !audio.paused) || (sceneAudio.src && !sceneAudio.paused);
+    return silentTimelinePlaying || (audio.src && !audio.paused) || (sceneAudio.src && !sceneAudio.paused);
   }
 
   function updatePlayPauseButton() {
@@ -9305,6 +9375,7 @@ function openBuilder(node) {
   }
 
   function pauseAllAudio() {
+    stopSilentTimelinePlayback();
     audio.pause();
     sceneAudio.pause();
     updatePlayPauseButton();
@@ -9320,9 +9391,18 @@ function openBuilder(node) {
     state.sceneSelectionUsesGlobalAudio = true;
     state.sceneAudioGlobalTime = start;
     if (!ensureGlobalTimelineAudioSource(start)) {
+      if (usingSceneAudioPlaybackMode()) {
+        state.sceneSelectionUsesGlobalAudio = false;
+        setGlobalPlaybackTime(start);
+        updatePlayPauseButton();
+        updateAudioScrubbers();
+        return true;
+      }
+      state.sceneSelectionUsesGlobalAudio = false;
+      state.sceneAudioGlobalTime = start;
       updatePlayPauseButton();
       updateAudioScrubbers();
-      return false;
+      return true;
     }
     seekAudioWhenReady(start);
     updatePlayPauseButton();
@@ -13191,6 +13271,12 @@ function openBuilder(node) {
     const media = selectedMediaForDelete();
     const segment = activeSegment();
     const hasVideoFrameSource = Boolean(selectedSegmentVideoPath(segment));
+    const hasTimelineVideos = allEditableSegments().some((item) => Boolean(
+      String(item?.video_path || "").trim()
+      || (Array.isArray(item?.video_history) && item.video_history.some((path) => String(path || "").trim()))
+      || (Array.isArray(item?.video_backup_paths) && item.video_backup_paths.some((path) => String(path || "").trim()))
+      || String(item?.video_original_path || "").trim()
+    ));
     const label = media.type ? `Selected media: ${media.type}` : "Selected media: none";
     selectedMediaLabel.textContent = media.path ? label : `${label} missing`;
     useFrameAsImageButton.disabled = !hasVideoFrameSource;
@@ -13198,6 +13284,8 @@ function openBuilder(node) {
     deleteSelectedMediaButton.textContent = media.type === "video" ? "Delete Video" : "Delete Image";
     deleteSelectedMediaButton.disabled = !media.path;
     deleteSelectedMediaButton.style.opacity = media.path ? "1" : ".55";
+    deleteAllTimelineVideosButton.disabled = !hasTimelineVideos;
+    deleteAllTimelineVideosButton.style.opacity = hasTimelineVideos ? "1" : ".55";
   }
 
   function syncPreview(segment) {
@@ -13528,7 +13616,7 @@ function openBuilder(node) {
   function updateAudioScrubbers() {
     const current = currentGlobalTime();
     const maxTime = playbackDuration();
-    const followPlayback = Boolean((audio.src && !audio.paused) || (sceneAudio.src && !sceneAudio.paused) || state.isScrubbing);
+    const followPlayback = Boolean(isTimelinePlaying() || state.isScrubbing);
     if (followPlayback) {
       const playbackSegment = playbackSegmentAtTime(current);
       if (playbackSegment && playbackSegment.id !== state.activeId) {
@@ -13561,7 +13649,12 @@ function openBuilder(node) {
     const maxTime = playbackDuration();
     const time = Math.max(0, Math.min(maxTime, Number(value || 0)));
     state.sceneAudioGlobalTime = time;
-    if (!state.sceneSelectionUsesGlobalAudio && usingSceneAudioPlaybackMode()) {
+    if (silentTimelinePlaying) {
+      silentTimelineStartTime = time;
+      silentTimelineStartedAt = performance.now();
+    }
+    if (usingSceneAudioPlaybackMode()) {
+      state.sceneSelectionUsesGlobalAudio = false;
       const segment = timelineAudioSegmentAtTime(time) || playbackSegmentAtTime(time) || state.segments[state.segments.length - 1] || null;
       if (segment) state.activeId = segment.id;
       const sourcePath = timelineAudioPathForSegment(segment);
@@ -13591,7 +13684,7 @@ function openBuilder(node) {
     state.sceneSelectionUsesGlobalAudio = false;
     const maxTime = timelineDuration();
     const segment = timelineAudioSegmentAtTime(time) || playbackSegmentAtTime(time) || state.segments.find((item) => timelineAudioEndForSegment(item) > time && timelineAudioPathForSegment(item)) || state.segments[0] || null;
-    if (!segment) return;
+    if (!segment) return false;
     state.activeId = segment.id;
     state.sceneAudioGlobalTime = Math.max(timelineAudioStartForSegment(segment), Math.min(maxTime, Number(time || 0)));
     syncInspector();
@@ -13603,11 +13696,10 @@ function openBuilder(node) {
       state.sceneAudioSegmentId = "";
       const next = state.segments.find((item) => timelineAudioStartForSegment(item) > timelineAudioStartForSegment(segment) && timelineAudioPathForSegment(item));
       if (next) {
-        playSceneAudioFrom(timelineAudioStartForSegment(next));
-        return;
+        return playSceneAudioFrom(timelineAudioStartForSegment(next));
       }
       updateAudioScrubbers();
-      return;
+      return false;
     }
     const local = Math.max(0, state.sceneAudioGlobalTime - timelineAudioStartForSegment(segment)) + timelineAudioSourceStartForSegment(segment);
     sceneAudio.src = audioUrl(sourcePath);
@@ -13619,10 +13711,14 @@ function openBuilder(node) {
       } catch {
         // Metadata not ready yet.
       }
-      sceneAudio.play().catch((error) => toast(String(error?.message || error), true));
+      sceneAudio.play().catch(() => {
+        sceneAudio.pause();
+        startSilentTimelinePlayback(state.sceneAudioGlobalTime);
+      });
     };
     if (Number.isFinite(sceneAudio.duration)) start();
     else sceneAudio.onloadedmetadata = start;
+    return true;
   }
 
   function beginGlobalTimelineScrub(event) {
@@ -17882,6 +17978,50 @@ function openBuilder(node) {
       return miniMaxH3SettingsForSegment(segment).audio_mode === "built_in_audio" ? "minimax_h3" : "";
     }
     return currentVideoMode() === "id_lora" ? "id_lora" : "";
+  }
+
+  async function chooseRenderedSceneTrimAtPlayhead() {
+    const segment = activeSegment();
+    if (!segment || segmentTrack(segment) === "overlay") {
+      toast("Select a rendered base scene before right-clicking ✂ to trim it.", true);
+      return;
+    }
+    if (!String(selectedSegmentVideoPath(segment) || "").trim()) {
+      toast("The selected scene does not have a rendered video to trim.", true);
+      return;
+    }
+    if (!baseSceneVideoTrimKind(segment)) {
+      toast("Right-click trimming is available for MiniMax built-in-audio and ID-LoRA rendered scenes.", true);
+      return;
+    }
+
+    const trimTime = Number(currentGlobalTime() || 0);
+    const sceneStart = Number(segment.start || 0);
+    const sceneEnd = Number(segment.end || sceneStart);
+    if (trimTime <= sceneStart + 0.15 || trimTime >= sceneEnd - 0.15) {
+      toast("Move the playhead inside the selected rendered scene, then right-click ✂ again.", true);
+      return;
+    }
+    pauseTimelineForEditing();
+    const choice = await chooseBatchModeAction({
+      title: "Trim Rendered Scene at Playhead",
+      intro: `${sceneDisplayName(segment, segmentIndexInfo(segment).index)} — playhead at ${formatTime(trimTime)}. Choose which portion to remove.`,
+      confirmLabel: "Trim Scene",
+      choices: [
+        {
+          value: "before",
+          label: "Remove before playhead",
+          description: "Discard the beginning of the rendered clip and keep everything from the playhead onward.",
+        },
+        {
+          value: "after",
+          label: "Remove after playhead",
+          description: "Keep the beginning of the rendered clip and discard everything after the playhead.",
+        },
+      ],
+    });
+    if (!choice) return;
+    await trimBaseSceneVideoAtPlayhead(segment, choice === "before" ? "left" : "right", trimTime);
   }
 
   async function trimBaseSceneVideoAtPlayhead(segment, side, trimTimeOverride = null) {
@@ -35092,6 +35232,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     ].join("\n");
   }
 
+  function stripMiniMaxH3ManagedPromptBlock(prompt, headingPattern) {
+    const nextSection = String.raw`(?=\n+(?:\[\s*\d+(?:\.\d+)?s?\s*[-–—]\s*\d+(?:\.\d+)?s?\s*\]|Audio(?:\s+1)?\s*:|Native\s+audio\s*:|Continuity\s*:|MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM:|REFERENCE SUBJECT COUNT — MANDATORY:|VISUAL-ONLY B-ROLL / NO-LIP-SYNC SAFETY — MANDATORY AND FINAL:|PREVIOUS-SCENE (?:SPATIAL|EXACT FRAME) CONTINUITY — MANDATORY:)|$)`;
+    return String(prompt || "").replace(
+      new RegExp(`\\n*${headingPattern}:[\\s\\S]*?${nextSection}`, "g"),
+      "",
+    ).trim();
+  }
+
   function stripMiniMaxH3VisualOnlyTimelineVocalDirections(prompt) {
     const positiveVocal = /\b(?:sing(?:s|ing)?|sang|sung|rap(?:s|ping)?|lip[ -]?sync(?:s|ing)?|speak(?:s|ing)?|say(?:s|ing)?|said|mouth(?:s|ed|ing)?|whisper(?:s|ing)?|perform(?:s|ing)?\s+(?:the\s+)?(?:saved\s+|exact\s+)?(?:lyric|dialogue|words?))\b/i;
     const negativeSafety = /\b(?:no|not|never|without|does\s+not|do\s+not|must\s+not|cannot|can['’]t|don['’]t)\b/i;
@@ -35155,19 +35303,27 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   function applyMiniMaxH3ContinuityPromptBlock(prompt, segment, continuityInput, imageNumber) {
-    const clean = String(prompt || "").trim()
-      .replace(/\n*PREVIOUS-SCENE (?:SPATIAL|EXACT FRAME) CONTINUITY — MANDATORY:[\s\S]*?(?=\n\n(?:MINIMAX NATIVE VOICE IDENTITY|REFERENCE SUBJECT COUNT|Audio:|Continuity:)|$)/g, "")
-      .trim();
+    const clean = stripMiniMaxH3ManagedPromptBlock(
+      prompt,
+      "PREVIOUS-SCENE (?:SPATIAL|EXACT FRAME) CONTINUITY — MANDATORY",
+    );
     const block = miniMaxH3ContinuityPromptBlock(segment, continuityInput, imageNumber);
     return block ? `${clean}\n\n${block}`.trim() : clean;
   }
 
   function applyMiniMaxH3NativeVoiceBlock(prompt, segment) {
-    const clean = String(prompt || "").trim()
-      .replace(/\n*MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM:[\s\S]*?(?=\n\n(?:Audio:|Continuity:)|$)/g, "")
-      .replace(/\n*REFERENCE SUBJECT COUNT — MANDATORY:[\s\S]*?(?=\n\n(?:MINIMAX NATIVE VOICE IDENTITY|Audio:|Continuity:)|$)/g, "")
-      .replace(/\n*VISUAL-ONLY B-ROLL \/ NO-LIP-SYNC SAFETY — MANDATORY AND FINAL:[\s\S]*$/g, "")
-      .trim();
+    let clean = stripMiniMaxH3ManagedPromptBlock(
+      prompt,
+      "MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM",
+    );
+    clean = stripMiniMaxH3ManagedPromptBlock(
+      clean,
+      "REFERENCE SUBJECT COUNT — MANDATORY",
+    );
+    clean = stripMiniMaxH3ManagedPromptBlock(
+      clean,
+      "VISUAL-ONLY B-ROLL / NO-LIP-SYNC SAFETY — MANDATORY AND FINAL",
+    );
     const visualOnlyBlock = miniMaxH3VisualOnlySafetyBlock(segment);
     const safePrompt = visualOnlyBlock ? stripMiniMaxH3VisualOnlyTimelineVocalDirections(clean) : clean;
     const block = visualOnlyBlock ? "" : miniMaxH3NativeVoiceBlock(segment);
@@ -35429,6 +35585,113 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     } finally {
       miniMaxCreatePromptButton.disabled = false;
       syncMiniMaxH3Panel();
+    }
+  }
+
+  async function convertAllLtxVideoPromptsToMiniMaxH3() {
+    updateActiveFromInputs();
+    if (normalizeVideoType(state.videoType) === "speaking") {
+      toast("This converter is for music-video projects, not speaking / short-film projects.", true);
+      return;
+    }
+    const targets = allEditableSegments()
+      .map((segment) => ({ segment, ltxPrompt: String(segment?.i2v_prompt || "").trim() }))
+      .filter((item) => item.ltxPrompt);
+    if (!targets.length) {
+      toast("No populated LTX video prompts were found to convert.", true);
+      return;
+    }
+
+    const projectFolder = activeProjectFolderForSave();
+    if (!projectFolder) {
+      toast("Create or load a Builder project before converting its LTX prompts.", true);
+      return;
+    }
+
+    let progress = null;
+    let converted = 0;
+    let historySaved = false;
+    try {
+      convertLtxPromptsToMiniMaxButton.disabled = true;
+      convertLtxPromptsToMiniMaxButton.textContent = "Converting...";
+      state.batchCancelled = false;
+      progress = createProgressWindow("Convert LTX Video Prompts to MiniMax H3");
+
+      for (let index = 0; index < targets.length; index += 1) {
+        assertBatchNotStopped();
+        const { segment, ltxPrompt } = targets[index];
+        const mode = miniMaxH3ModeForSegment(segment);
+        const modeLabel = miniMaxH3ModeLabel(mode);
+        const duration = Math.max(0, Number(segment.end || 0) - Number(segment.start || 0));
+        const lyricText = segmentUsesNoLipSyncPerformance(segment) || isInstrumentalLyricText(segment.lyric_text)
+          ? ""
+          : flattenLyricForPrompt(segment.lyric_text);
+        const singerNames = segmentUsesNoLipSyncPerformance(segment)
+          ? []
+          : (Array.isArray(segment.lyric_singers) ? segment.lyric_singers : String(segment.lyric_singers || "").split(/[,;\n]+/))
+            .map((value) => String(value || "").trim())
+            .filter(Boolean);
+        const label = `${sceneDisplayName(segment, segmentIndexInfo(segment).index)} (${index + 1}/${targets.length})`;
+        const percent = 5 + Math.round((index / Math.max(1, targets.length)) * 88);
+        progress.set(`${label}: converting the existing LTX prompt to detailed MiniMax H3 ${modeLabel} format...\n${gemmaRunnerLine()}`, percent);
+
+        const data = await postJson("/vrgdg/music_builder/generate_t2v", {
+          ...textGemmaRunnerPayload(),
+          project_folder: projectFolder,
+          scene_id: segment.id || "",
+          builder_instruction_key: miniMaxH3InstructionKey(mode),
+          model_file: miniMaxTextGemmaModelSelect.value || i2vTextGemmaModelSelect.value,
+          repair_model_file: miniMaxTextGemmaModelSelect.value || i2vTextGemmaModelSelect.value,
+          t2i_prompt: [
+            "EXISTING LTX VIDEO PROMPT TO CONVERT:",
+            ltxPrompt,
+            "",
+            `Target scene duration: ${duration.toFixed(3)} seconds.`,
+          ].join("\n"),
+          user_notes: [
+            "Rewrite the existing LTX video prompt as one substantially more detailed MiniMax H3 prompt for the selected mode.",
+            "Preserve the same scene, subjects, setting, wardrobe, action, camera intent, performance, and ending. Do not invent a different scene or change the creative intent.",
+            "The existing global Audio 1 file remains the only audio source and must stay completely unchanged. Do not generate, replace, remix, extend, or add audio.",
+          ].join("\n"),
+          performance_mode: effectiveVideoPerformanceModeForSegment(segment),
+          lyric_text: lyricText,
+          singers: singerNames,
+          audio_mode: "input_audio",
+          speaker_assignments: [],
+          no_character_present: Boolean(segment.no_character_present),
+          unload_after: index === targets.length - 1,
+          temperature: 0.4,
+          top_p: 0.92,
+          max_new_tokens: 4000,
+        }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
+
+        const prompt = String(data.prompt || "").trim();
+        if (!prompt) throw new Error(`${label}: the LLM returned an empty MiniMax H3 prompt.`);
+        if (!historySaved) {
+          pushHistory();
+          historySaved = true;
+        }
+        segment.minimax_h3_prompt = prompt;
+        segment.minimax_h3_prompt_origin = "gemma";
+        converted += 1;
+      }
+
+      if (activeSegment()) {
+        miniMaxPrompt.value = String(activeSegment().minimax_h3_prompt || "");
+      }
+      ensureAllSegmentRuntimeFields();
+      syncInspector();
+      render();
+      await autoSaveSessionQuiet("converted LTX video prompts to MiniMax H3");
+      progress.set(`Converted ${converted} LTX video prompt${converted === 1 ? "" : "s"} to MiniMax H3. Global audio and original LTX prompts were not changed.`, 100);
+      progress.close(1600);
+      toast(`Converted ${converted} LTX video prompt${converted === 1 ? "" : "s"} to MiniMax H3.`);
+    } catch (error) {
+      progress?.set(`Conversion stopped after ${converted}/${targets.length} prompts:\n${String(error?.message || error)}`, 100);
+      toast(`LTX to MiniMax H3 conversion stopped after ${converted}/${targets.length} prompts:\n${String(error?.message || error)}`, true);
+    } finally {
+      convertLtxPromptsToMiniMaxButton.disabled = false;
+      convertLtxPromptsToMiniMaxButton.textContent = "Convert LTX Video Prompts to MiniMax H3";
     }
   }
 
@@ -39022,10 +39285,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       )
       : options.continuityInput;
 
-    let prompt = applyMiniMaxH3NativeVoiceBlock(String(
+    const prompt = String(
       options.prompt
       ?? (segment?.minimax_h3_prompt || segment?.i2v_prompt || "")
-    ), segment);
+    ).trim();
     if (!prompt) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a MiniMax H3 prompt.`);
 
     const sourceAudioPath = String(
@@ -39088,10 +39351,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       }
       continuityImageNumber = imagePaths.findIndex((path) => mediaPathKey(path) === continuityKey) + 1;
       segment.minimax_h3_continuity_image_number = continuityImageNumber;
-      prompt = applyMiniMaxH3ContinuityPromptBlock(prompt, segment, continuityInput, continuityImageNumber);
     } else {
       segment.minimax_h3_continuity_image_number = 0;
-      prompt = applyMiniMaxH3ContinuityPromptBlock(prompt, segment, null, 0);
     }
     const rawVideoReferences = options.videoReferences
       ?? segment?.minimax_h3_video_references
@@ -41930,7 +42191,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       return;
     }
     if (String(selectedSegmentVideoPath(segment) || "").trim() || (Array.isArray(segment.video_history) && segment.video_history.length)) {
-      toast("This scene has rendered video versions. Clear its selected video/history before changing its timing.", true);
+      if (baseSceneVideoTrimKind(segment)) {
+        await chooseRenderedSceneTrimAtPlayhead();
+        return;
+      }
+      toast("This rendered scene cannot be split. MiniMax built-in-audio and ID-LoRA rendered scenes can be trimmed at the playhead instead.", true);
       return;
     }
     const index = state.segments.indexOf(segment);
@@ -45608,6 +45873,86 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
   }
 
+  async function deleteAllTimelineVideos() {
+    const segments = allEditableSegments();
+    const assignedSegments = segments.filter((segment) => Boolean(
+      String(segment.video_path || "").trim()
+      || (Array.isArray(segment.video_history) && segment.video_history.some((path) => String(path || "").trim()))
+      || (Array.isArray(segment.video_backup_paths) && segment.video_backup_paths.some((path) => String(path || "").trim()))
+      || String(segment.video_original_path || "").trim()
+    ));
+    const videoPaths = [...new Set(assignedSegments.flatMap((segment) => [
+      segment.video_path || "",
+      ...(Array.isArray(segment.video_history) ? segment.video_history : []),
+      ...(Array.isArray(segment.video_backup_paths) ? segment.video_backup_paths : []),
+      segment.video_original_path || "",
+    ]).map((path) => String(path || "").trim()).filter(Boolean))];
+    if (!assignedSegments.length) {
+      toast("There are no timeline videos to remove.");
+      return;
+    }
+    const ok = window.confirm(
+      `Remove ALL videos from the timeline?\n\nThis clears video assignments and video history from ${assignedSegments.length} scene${assignedSegments.length === 1 ? "" : "s"}.\n\nThe ${videoPaths.length} video file${videoPaths.length === 1 ? "" : "s"} and their thumbnails will NOT be deleted from the project folder. They remain on disk as backups.`
+    );
+    if (!ok) return;
+
+    try {
+      deleteAllTimelineVideosButton.disabled = true;
+      deleteAllTimelineVideosButton.textContent = "Removing ALL...";
+      pauseTimelineForEditing();
+      pushHistory();
+      for (const segment of segments) {
+        segment.video_path = "";
+        segment.video_source_path = "";
+        segment.video_thumbnail_path = "";
+        segment.video_history = [];
+        segment.video_thumbnail_history = [];
+        segment.video_backup_paths = [];
+        segment.video_backup_thumbnail_paths = [];
+        segment.video_history_index = -1;
+        segment.video_output = null;
+        segment.video_original_path = "";
+        segment.video_original_thumbnail_path = "";
+        segment.video_status = "none";
+        segment.video_cache_bust = Date.now();
+        segment.minimax_h3_trimmed_video = false;
+        segment.minimax_h3_trim_side = "";
+        segment.minimax_h3_trim_removed_seconds = 0;
+        segment.minimax_h3_trim_source_start_seconds = 0;
+        segment.minimax_h3_trimmed_duration_seconds = 0;
+        segment.minimax_h3_continuity_frame_path = "";
+        segment.minimax_h3_continuity_source_video_path = "";
+        segment.minimax_h3_continuity_source_scene_id = "";
+        segment.minimax_h3_continuity_image_number = 0;
+        segment.flf_rendered_source_video_path = "";
+        segment.preview_mode = "image";
+        ensureSegmentRuntimeFields(segment);
+      }
+      previewVideo.pause();
+      previewVideo.removeAttribute("src");
+      previewVideo.dataset.path = "";
+      previewVideo.dataset.cacheKey = "";
+      previewVideo.dataset.segmentId = "";
+      previewVideo.style.display = "none";
+      sceneAudio.pause();
+      sceneAudio.removeAttribute("src");
+      sceneAudio.load();
+      state.sceneAudioSegmentId = "";
+      syncInspector();
+      syncPreview(activeSegment());
+      renderList();
+      render();
+      await autoSaveSessionQuiet("all timeline videos removed");
+      updateSelectedMediaTools();
+      toast(`Removed all timeline videos from ${assignedSegments.length} scene${assignedSegments.length === 1 ? "" : "s"}. The files remain in the project folder as backups.`);
+    } catch (error) {
+      toast(String(error?.message || error), true);
+    } finally {
+      deleteAllTimelineVideosButton.disabled = false;
+      deleteAllTimelineVideosButton.textContent = "Delete ALL Videos";
+    }
+  }
+
   async function deleteAllTimelineImages() {
     const segments = allEditableSegments();
     const imagePaths = [...new Set(segments.flatMap((segment) => [
@@ -47776,6 +48121,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   overlayTrackToggleButton.onclick = toggleOverlayTrack;
   overlayTrackHintButton.onclick = showOverlayTrackHelp;
   splitSceneButton.onclick = splitActiveSceneAtPlayhead;
+  splitSceneButton.oncontextmenu = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    chooseRenderedSceneTrimAtPlayhead().catch((error) => toast(String(error?.message || error), true));
+  };
   loadSrtButton.onclick = loadSrt;
   loadSessionButton.onclick = loadSession;
   loadLastProjectButton.onclick = loadLastProject;
@@ -47807,6 +48157,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   zImageAllButton.onclick = confirmAndRunZImageAll;
   zEnhanceAllButton.onclick = confirmAndRunZEnhanceAll;
   zEnhanceAllToolButton.onclick = confirmAndRunZEnhanceAll;
+  convertLtxPromptsToMiniMaxButton.onclick = convertAllLtxVideoPromptsToMiniMaxH3;
   editI2VPromptButton.onclick = editCurrentVideoPromptWithGemma;
   fullBuildButton.onclick = confirmAndRunFullBuild;
   fullFLFBuildButton.onclick = confirmAndRunFullFLFBuild;
@@ -48240,6 +48591,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   deleteAllSegmentsButton.onclick = deleteAllSegments;
   useFrameAsImageButton.onclick = captureSelectedVideoFrameAsImage;
   deleteSelectedMediaButton.onclick = deleteSelectedMedia;
+  deleteAllTimelineVideosButton.onclick = deleteAllTimelineVideos;
   deleteAllTimelineImagesButton.onclick = deleteAllTimelineImages;
   globalAudioMuteButton.onclick = (event) => {
     event.preventDefault();
@@ -48258,8 +48610,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     if (!state.sceneSelectionUsesGlobalAudio && usingSceneAudioPlaybackMode()) {
       audio.pause();
-      playSceneAudioFrom(currentGlobalTime());
-      updatePlayPauseButton();
+      const started = playSceneAudioFrom(currentGlobalTime());
+      if (!started) startSilentTimelinePlayback(currentGlobalTime());
+      else updatePlayPauseButton();
       return;
     }
     let startTime = currentGlobalTime();
@@ -48267,11 +48620,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       startTime = Math.max(0, Number(activeSegment()?.start || 0));
     }
     if (!ensureGlobalTimelineAudioSource(startTime)) {
-      toast("Load audio first, or add custom audio to scenes.", true);
+      startSilentTimelinePlayback(startTime);
       return;
     }
     seekAudioWhenReady(startTime);
-    audio.play().then(updatePlayPauseButton).catch((error) => toast(String(error?.message || error), true));
+    audio.play().then(updatePlayPauseButton).catch(() => startSilentTimelinePlayback(startTime));
   };
   multiSelectButton.onclick = openMultiSelectChooser;
   multiSelectHintButton.onclick = showMultiSelectHint;
@@ -48421,7 +48774,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     updateAudioScrubbers();
   });
-  audio.addEventListener("play", updatePlayPauseButton);
+  audio.addEventListener("play", () => {
+    stopSilentTimelinePlayback();
+    updatePlayPauseButton();
+  });
   audio.addEventListener("pause", () => {
     updatePlayPauseButton();
     updateAudioScrubbers();
@@ -48431,7 +48787,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     updatePlayPauseButton();
     updateAudioScrubbers();
   });
-  sceneAudio.addEventListener("play", updatePlayPauseButton);
+  sceneAudio.addEventListener("play", () => {
+    stopSilentTimelinePlayback();
+    updatePlayPauseButton();
+  });
   sceneAudio.addEventListener("pause", updatePlayPauseButton);
   sceneAudio.addEventListener("timeupdate", () => {
     const segment = state.segments.find((item) => item.id === state.sceneAudioSegmentId) || activeSegment();

--- a/web/VRGDG_MusicVideoPromptCreatorUI.js
+++ b/web/VRGDG_MusicVideoPromptCreatorUI.js
@@ -705,9 +705,9 @@ function openPromptCreator(options = {}) {
   const title = document.createElement("div");
   title.textContent = "Prompt Creator (Legacy)";
   title.style.cssText = "font-size:16px;font-weight:900;color:#cffafe;margin-right:auto;";
-  const backButton = makeButton("Back To Video Creator");
+  const backButton = makeButton("Back To AI Video Builder");
   const loadDraftButton = makeButton("Load Project Draft");
-  const sendToVideoButton = makeButton("Send To Video Creator", "primary");
+  const sendToVideoButton = makeButton("Send To AI Video Builder", "primary");
   const gemmaRunnerButton = makeButton("Gemma Runner");
   const saveDraftButton = makeButton("Save Project Draft", "primary");
   const closeButton = makeButton("Close");
@@ -1798,7 +1798,7 @@ function openPromptCreator(options = {}) {
       throw new Error("ConceptPrompts editor does not contain any Prompt1/Prompt2 JSON values.");
     }
     if (isSceneLabelOnlyPromptMap(editedConceptPrompts)) {
-      throw new Error("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to Video Creator.");
+      throw new Error("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to AI Video Builder.");
     }
     state.conceptPrompts = Object.keys(editedConceptPrompts).length ? editedConceptPrompts : (state.conceptPrompts || {});
     state.i2vMotionNotes = Object.keys(editedI2VMotionNotes).length ? editedI2VMotionNotes : (state.i2vMotionNotes || {});
@@ -1810,7 +1810,7 @@ function openPromptCreator(options = {}) {
       ? state.conceptPrompts
       : parseJsonSafe(conceptOutput.value, {});
     if (isSceneLabelOnlyPromptMap(payload.prompts)) {
-      throw new Error("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to Video Creator.");
+      throw new Error("ConceptPrompts only contains scene labels like SCENE 1. Create or paste real concept prompts before sending to AI Video Builder.");
     }
     payload.i2v_motion_notes = state.i2vMotionNotes && Object.keys(state.i2vMotionNotes).length
       ? state.i2vMotionNotes
@@ -1836,15 +1836,15 @@ function openPromptCreator(options = {}) {
     try {
       sendToVideoButton.disabled = true;
       sendToVideoButton.textContent = "Sending...";
-      progress = createProgressWindow("Sending To Video Creator");
+      progress = createProgressWindow("Sending To AI Video Builder");
       const result = await saveOutputs(progress);
-      progress.set("Opening Video Creator and importing this Prompt Creator project...", 96);
+      progress.set("Opening AI Video Builder and importing this Prompt Creator project...", 96);
       if (typeof options.onSendToVideoCreator === "function") {
         await options.onSendToVideoCreator(result);
       } else {
         options.onSaved?.(result);
       }
-      progress.set("Sent to Video Creator.", 100);
+      progress.set("Sent to AI Video Builder.", 100);
       progress.close(900);
       overlay.remove();
     } catch (error) {
@@ -1853,7 +1853,7 @@ function openPromptCreator(options = {}) {
       progress?.set(`Error:\n${message}`, 100);
     } finally {
       sendToVideoButton.disabled = false;
-      sendToVideoButton.textContent = "Send To Video Creator";
+      sendToVideoButton.textContent = "Send To AI Video Builder";
     }
   }
 

--- a/web/VRGDG_MusicVideoWizardUI.js
+++ b/web/VRGDG_MusicVideoWizardUI.js
@@ -1015,7 +1015,7 @@ export function openMusicVideoWizard(api = {}) {
     const settingsCard = el("div", "vrgdg-wizard-settings-card span-6");
     settingsCard.append(
       el("div", "vrgdg-wizard-settings-title", "Current Builder State"),
-      el("div", "vrgdg-wizard-settings-subtitle", "The wizard uses the settings already selected in the Video Creator."),
+      el("div", "vrgdg-wizard-settings-subtitle", "The wizard uses the settings already selected in the AI Video Builder."),
     );
     const statusRow = el("div", "vrgdg-wizard-status-row");
     [

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -3149,7 +3149,7 @@ function openStoryboardBuilder(payload = {}) {
       <div style="width:52px;height:52px;border-radius:12px;background:#164e63;color:#67e8f9;display:grid;place-items:center;font-size:28px;">▣</div>
       <div style="min-width:0;">
         <div style="font-size:26px;font-weight:900;color:#cffafe;">Storyboard Builder <span id="vrgdg-storyboard-mode-pill" style="font-size:13px;border-radius:999px;background:#164e63;color:#a5f3fc;padding:5px 9px;vertical-align:middle;">Planning</span></div>
-        <div id="vrgdg-storyboard-subtitle" style="color:#cbd5e1;font-size:14px;margin-top:3px;">Write scene cards, image prompts, and video prompts before sending them to the Video Creator.</div>
+        <div id="vrgdg-storyboard-subtitle" style="color:#cbd5e1;font-size:14px;margin-top:3px;">Write scene cards, image prompts, and video prompts before sending them to the AI Video Builder.</div>
       </div>
     </div>
   `;
@@ -5182,7 +5182,7 @@ function openStoryboardBuilder(payload = {}) {
         createToast(`Could not save this reference image into the project folder. It will stay in this session only.\n${String(error?.message || error)}`, true);
       }
     } else {
-      createToast("Save the Video Creator project first if you want imported Storyboard references to persist.", true);
+      createToast("Save the AI Video Builder project first if you want imported Storyboard references to persist.", true);
     }
     const ref = upsertStoryboardReference(kind, reference);
     if (!ref || !scene) return ref;
@@ -6438,7 +6438,7 @@ function openStoryboardBuilder(payload = {}) {
 
   async function saveStoryboard() {
     if (!state.projectFolder) {
-      createToast("Save the Video Creator project first so Storyboard Builder knows where to write files.", true);
+      createToast("Save the AI Video Builder project first so Storyboard Builder knows where to write files.", true);
       return;
     }
     state.saving = true;
@@ -6466,7 +6466,7 @@ function openStoryboardBuilder(payload = {}) {
 
   async function exportPromptFiles() {
     if (!state.projectFolder) {
-      createToast("Save the Video Creator project first so Storyboard Builder knows where to export prompt files.", true);
+      createToast("Save the AI Video Builder project first so Storyboard Builder knows where to export prompt files.", true);
       return;
     }
     exportPrompts.disabled = true;


### PR DESCRIPTION
## Summary

- add a one-button Tools-panel converter that rewrites every populated LTX video prompt into a separate detailed MiniMax H3 prompt while preserving the original prompt, global audio, timing, and project data
- add silent timeline playback and scrubbing when no global audio is present
- expose before/after playhead trimming for rendered MiniMax built-in-audio and ID-LoRA scenes
- add Delete ALL Videos to clear timeline video assignments and history without deleting project-folder media backups
- pass the complete saved MiniMax scene prompt through Render All without render-time voice, B-roll, or continuity rewriting
- bound managed MiniMax prompt-block cleanup so it cannot remove later timestamped shots, Audio, or Continuity sections
- rename user-facing Music Video Builder and Video Creator labels to AI Video Builder
- add an August 6 What's New card and regression coverage for the new behavior

## Why

Several Builder workflows assumed a global audio file existed, which blocked short-film timeline playback and made trimming built-in-audio renders difficult. MiniMax render-time prompt post-processing also used an unbounded cleanup expression that could remove the normal scene description after a B-roll safety section. Reusing older LTX music-video projects for MiniMax required manually recreating every scene prompt, and clearing a reused project's rendered-video assignments required scene-by-scene cleanup.

## User impact

Users can now navigate and trim timelines without global audio, batch-convert LTX prompts without changing their soundtrack or original prompts, clear all timeline videos while retaining disk backups, and trust that the exact complete prompt shown in the right panel is the prompt sent to MiniMax H3.

## Validation

- JSON validation for update_notes.json
- JavaScript module syntax check for web/VRGDG_MusicVideoBuilderUI.js
- 37 targeted unit tests passed
- 3 environment-dependent tests skipped
- git diff checks passed