### PR TITLE
Increased LM Studio Test max tokens value to prevent empty "content" responses.

### DIFF
--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45133,7 +45133,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           reference_type: "location",
           source_text: "small empty test room",
           style_theme: "",
-          max_new_tokens: 120,
+          max_new_tokens: 1024,
         }, 60000);
         progress.set(`LM Studio responded successfully:\n${data.prompt}`, 100);
         progress.close(4000);


### PR DESCRIPTION
The previous 120 token cap is consumed if an LLM uses reasoning prior to responding.  I found gemma4 models typically were consuming 350-400 tokens to respond to the test prompt.

I increased the cap to 1024 so that it's plenty but also not so high there is no safety net.

I tested it a bunch of times and it's working fine.


Note: `max_new_tokens` is used all over the place occasionally with similar lower values.  I haven't investigated yet, but I suspect these are also the reason my LM Studio requests in various parts of the UI fail occasionally.  One thing at a time. ;)



<img width="2469" height="740" alt="lm_studio_test" src="https://github.com/user-attachments/assets/5c8de693-fcba-4022-8706-1cafd3be7fc7" />
