### PR TITLE
User Adjustable Max Tokens Option for both Internal Gemma and LM Studio

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -8205,9 +8205,14 @@ def _gemma_choices():
     }
 
 
+_MODEL_DEFAULT_VALUES = {
+    "llm_max_tokens": 8192,
+}
+
+
 _MODEL_DEFAULT_KEYS = (
     "text_gemma_runner",
-    "gemma_context_limit",
+    "llm_max_tokens",
     "lm_studio_base_url",
     "lm_studio_model",
     "lm_studio_api_key",
@@ -8247,7 +8252,7 @@ def _scrub_model_defaults_project_sources(defaults):
 def _extract_model_defaults(session):
     if not isinstance(session, dict):
         return {}
-    defaults = {}
+    defaults = dict(_MODEL_DEFAULT_VALUES)
     for key in _MODEL_DEFAULT_KEYS:
         value = session.get(key)
         if value is not None:
@@ -8273,7 +8278,7 @@ def _save_model_defaults(session):
 def _load_model_defaults():
     target = _model_defaults_path()
     if not os.path.isfile(target):
-        return {"path": target, "defaults": {}, "saved_at": ""}
+        return {"path": target, "defaults": dict(_MODEL_DEFAULT_VALUES), "saved_at": ""}
     with open(target, "r", encoding="utf-8") as handle:
         payload = json.load(handle)
     if not isinstance(payload, dict):
@@ -8281,7 +8286,10 @@ def _load_model_defaults():
     defaults = payload.get("defaults")
     if not isinstance(defaults, dict):
         defaults = {}
-    defaults = _scrub_model_defaults_project_sources(defaults)
+    defaults = {
+        **_MODEL_DEFAULT_VALUES,
+        **_scrub_model_defaults_project_sources(defaults),
+    }
     return {
         "path": target,
         "defaults": defaults,

--- a/tests/test_local_llm_token_limit.py
+++ b/tests/test_local_llm_token_limit.py
@@ -1,0 +1,29 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+BACKEND_SOURCE = (ROOT / "VRGDG_MusicVideoBuilderNodes.py").read_text(encoding="utf-8")
+
+
+class LocalLlmTokenLimitTests(unittest.TestCase):
+    def test_local_token_limit_is_hidden_and_omitted_for_api_runner(self):
+        self.assertIn('localTokenPanel.style.display = runner.value === "llm_api" ? "none" : "flex";', UI_SOURCE)
+        self.assertIn('if (runner === "llm_api") return undefined;', UI_SOURCE)
+
+    def test_forced_builtin_gemma_still_receives_local_token_limit(self):
+        self.assertIn('getLlmRunnerMaxTokens({ runner: "builtin" })', UI_SOURCE)
+
+    def test_local_token_limit_drives_gemma_context_and_is_persisted(self):
+        self.assertIn("const DEFAULT_LLM_MAX_TOKENS = 8192;", UI_SOURCE)
+        self.assertIn("n_ctx: getLlmRunnerMaxTokens(),", UI_SOURCE)
+        self.assertNotIn("normalizeGemmaContextLimit", UI_SOURCE)
+        self.assertNotIn("state.gemmaContextLimit", UI_SOURCE)
+        self.assertIn('llm_max_tokens: normalizeLlmMaxTokens(state.llmMaxTokens),', UI_SOURCE)
+        self.assertIn('"llm_max_tokens",', BACKEND_SOURCE)
+        self.assertIn('"llm_max_tokens": 8192,', BACKEND_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45133,7 +45133,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           reference_type: "location",
           source_text: "small empty test room",
           style_theme: "",
-          max_new_tokens: 120,
+          max_new_tokens: 1024,
         }, 60000);
         progress.set(`LM Studio responded successfully:\n${data.prompt}`, 100);
         progress.close(4000);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2916,7 +2916,7 @@ function openBuilder(node) {
         clear_before_load: false,
         temperature: 0.15,
         top_p: 0.85,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
       }, 4 * 60 * 1000);
       const description = String(data.description || "").trim();
       if (!description) throw new Error("The selected LLM Runner returned an empty face description.");
@@ -5995,6 +5995,7 @@ function openBuilder(node) {
     llmApiProvider: "openai",
     llmApiModel: "",
     llmApiKey: "",
+    llmMaxTokens: 8192,
     llmApiChoices: null,
     customModelsRoot: "",
     notificationSettings: defaultNotificationSettings(),
@@ -8486,6 +8487,7 @@ function openBuilder(node) {
       text_runner: state.textGemmaRunner || "builtin",
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
       n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
+      max_new_tokens: getLlmRunnerMaxTokens(),
       lmstudio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
       lmstudio_model: state.lmStudioModel || "",
       lmstudio_api_key: state.lmStudioApiKey || "",
@@ -8568,7 +8570,7 @@ function openBuilder(node) {
       reference_type: referenceType === "subject" ? (target?.reference_type || "character") : referenceType,
       name: target?.name || "",
       ...referenceImagePayload(image),
-      max_new_tokens: 8000,
+      max_new_tokens: getLlmRunnerMaxTokens(),
       unload_after: options.unloadAfter !== false,
       clear_before_load: Boolean(options.clearBeforeLoad),
     }, 4 * 60 * 1000);
@@ -9945,6 +9947,9 @@ function openBuilder(node) {
     if (defaults.llm_api_model || defaults.llmApiModel) {
       state.llmApiModel = defaults.llm_api_model || defaults.llmApiModel || state.llmApiModel || "";
     }
+    if (Object.prototype.hasOwnProperty.call(defaults, "llm_max_tokens") || Object.prototype.hasOwnProperty.call(defaults, "llmMaxTokens")) {
+      state.llmMaxTokens = normalizeLlmMaxTokens(defaults.llm_max_tokens ?? defaults.llmMaxTokens ?? state.llmMaxTokens);
+    }
     state.imageModelMode = defaults.image_model_mode || defaults.imageModelMode || defaults.flux_klein_settings?.image_model_mode || defaults.fluxKleinSettings?.image_model_mode || state.imageModelMode || "zimage";
     state.videoType = normalizeVideoType(defaults.video_type || defaults.videoType || state.videoType);
     if (defaults.zimage_settings || defaults.zimageSettings) {
@@ -10156,6 +10161,7 @@ function openBuilder(node) {
       lmStudioApiKey: state.lmStudioApiKey,
       llmApiProvider: state.llmApiProvider,
       llmApiModel: state.llmApiModel,
+      llmMaxTokens: normalizeLlmMaxTokens(state.llmMaxTokens),
       notificationSettings: normalizeNotificationSettings(state.notificationSettings),
       automaticMemoryCleanup: Boolean(state.automaticMemoryCleanup),
       waveformMode: state.waveformMode,
@@ -11560,6 +11566,19 @@ function openBuilder(node) {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return 8000;
     return Math.max(512, Math.min(262144, Math.round(parsed)));
+  }
+
+  function normalizeLlmMaxTokens(value) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return 8192;
+    return Math.max(2048, Math.min(262144, Math.round(parsed)));
+  }
+
+  function getLlmRunnerMaxTokens(options = {}) {
+    if (Object.prototype.hasOwnProperty.call(options, "maxNewTokens") && Number.isFinite(Number(options.maxNewTokens))) {
+      return normalizeLlmMaxTokens(options.maxNewTokens);
+    }
+    return normalizeLlmMaxTokens(state.llmMaxTokens);
   }
 
   function removeQuietFromSingingPrompt(text) {
@@ -19472,7 +19491,7 @@ function openBuilder(node) {
           story_idea: storyIdea || idea,
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         const text = String(data.text || "").trim();
         if (!text) throw new Error("Gemma4 returned an empty draft.");
@@ -26370,7 +26389,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 8000,
+            max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -26597,7 +26616,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             previous_assignments: previousAssignments.slice(-24),
             unload_after: batchIndex === batches.length - 1,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 8000,
+            max_new_tokens: getLlmRunnerMaxTokens(),
           }, 10 * 60 * 1000);
           mergedData.locations = batchData.locations || mergedData.locations || [];
           Object.assign(mergedData.scene_map, batchData.scene_map || {});
@@ -28938,7 +28957,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 8000,
+            max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -29681,7 +29700,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 8000,
+            max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -29767,7 +29786,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
           })),
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         upsertTextMapLocations(data.locations || []);
         let mapped = 0;
@@ -30605,7 +30624,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes: batch.map(({ segment, index }) => conceptPromptScenePayload(segment, index, sourceMode)),
           temperature: options.temperature ?? 0.45,
           top_p: options.topP ?? 0.95,
-          max_new_tokens: options.maxNewTokens ?? 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 180000);
         const prompts = data.prompts || {};
         for (const { segment, index } of batch) {
@@ -30773,7 +30792,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes: batch.map(({ segment, index }) => motionNoteScenePayload(segment, index, sourceMode)),
           temperature: options.temperature ?? 0.45,
           top_p: options.topP ?? 0.95,
-          max_new_tokens: options.maxNewTokens ?? 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 180000);
         const notes = data.notes || {};
         for (const { segment, index } of batch) {
@@ -32262,6 +32281,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.textGemmaRunner = data.session.text_gemma_runner || state.textGemmaRunner || "builtin";
         state.gemmaContextLimit = normalizeGemmaContextLimit(data.session.gemma_context_limit ?? data.session.n_ctx ?? state.gemmaContextLimit);
         state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.session.gemma_gpu_layers ?? data.session.n_gpu_layers ?? state.gemmaGpuLayers);
+        state.llmMaxTokens = normalizeLlmMaxTokens(data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.llmMaxTokens);
         state.lmStudioBaseUrl = data.session.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
         state.lmStudioModel = data.session.lm_studio_model || state.lmStudioModel || "";
         state.lmStudioApiKey = data.session.lm_studio_api_key || state.lmStudioApiKey || "";
@@ -33112,7 +33132,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       seed: options.seed,
       temperature: options.temperature ?? 0.35,
       top_p: options.topP ?? 0.90,
-      max_new_tokens: options.maxNewTokens ?? 8000,
+      max_new_tokens: getLlmRunnerMaxTokens(),
     }, 240000);
     pushHistory();
     syncSegmentT2IPrompt(segment, applyMappedTriggerPhrases(applyImageTriggerToPrompt(data.prompt, segment, imageMode, { validateJunk: true }), segment));
@@ -33889,7 +33909,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       clear_before_load: options.clearBeforeLoad !== false,
       unload_after: options.unloadAfter !== false,
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-      max_new_tokens: 8000,
+      max_new_tokens: getLlmRunnerMaxTokens(),
       seed: options.seed,
       temperature: options.temperature,
       top_p: options.topP,
@@ -34171,7 +34191,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         scene_number: sceneSlotNumber(segment),
         user_notes: userNotes,
         unload_after: true,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
       }, 10 * 60 * 1000);
       pushHistory();
       segment.enhance_prompt = applyTriggerPhrase(data.prompt, state.imageTriggerPhrase);
@@ -34516,7 +34536,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       no_character_present: Boolean(segment?.no_character_present),
       unload_after: options.unloadAfter !== false,
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-      max_new_tokens: 8000,
+      max_new_tokens: getLlmRunnerMaxTokens(),
     }, GEMMA_VIDEO_ENHANCE_TIMEOUT_MS);
     return String(data.prompt || "").trim() || base;
   }
@@ -34898,7 +34918,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
         temperature: 0.25,
         top_p: 0.9,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
       }, 180000);
       const nextPrompt = String(data.prompt || "").trim();
       if (!nextPrompt) throw new Error("Gemma returned an empty edited image prompt.");
@@ -34985,7 +35005,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
         temperature: 0.25,
         top_p: 0.9,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
       }, GEMMA_VIDEO_ENHANCE_TIMEOUT_MS);
       const nextPrompt = String(data.prompt || "").trim();
       if (!nextPrompt) throw new Error("Gemma returned an empty edited prompt.");
@@ -35410,7 +35430,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         unload_after: true,
         temperature: 0.45,
         top_p: 0.92,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
       }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
       const prompt = applyMiniMaxH3NativeVoiceBlock(String(data.prompt || ""), segment);
       if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
@@ -36984,7 +37004,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           unload_after: options.unloadAfter !== false,
           temperature: 0.45,
           top_p: 0.92,
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
         const generatedPrompt = String(data.prompt || "").trim();
         if (!generatedPrompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
@@ -37578,7 +37598,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
       temperature: 0.25,
       top_p: 0.9,
-      max_new_tokens: 8000,
+      max_new_tokens: getLlmRunnerMaxTokens(),
     }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
     const prompt = String(data.prompt || "").trim();
     if (!prompt) throw new Error("Gemma returned an empty chained I2V prompt.");
@@ -41439,7 +41459,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         next_lyrics: String(next?.lyric_text || ""),
         flf_mode: true,
         unload_after: index === missingTargets.length - 1,
-        max_new_tokens: 8000,
+        max_new_tokens: getLlmRunnerMaxTokens(),
         temperature: 0.35,
         top_p: 0.9,
       }, 240000);
@@ -44593,7 +44613,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           agent_purpose: purpose.value || "scene_work",
           unload_after: true,
           n_ctx: scope.value === "project_brief" || scope.value === "full_scene_plan" ? 12000 : 8000,
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
           temperature: 0.55,
           top_p: 0.95,
         });
@@ -44775,7 +44795,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           user_notes: "These are performer, character, location, and aesthetic references for the whole project.",
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
           temperature: 0.25,
           top_p: 0.95,
         }, 10 * 60 * 1000);
@@ -44987,6 +45007,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const modelPickerRow = document.createElement("div");
     modelPickerRow.style.cssText = "display:grid;grid-template-columns:1fr auto;gap:8px;align-items:end;";
     const lmStudioApiKey = makeInput(state.lmStudioApiKey || "", "password");
+    const llmMaxTokens = makeInput(String(normalizeLlmMaxTokens(state.llmMaxTokens)), "number");
+    llmMaxTokens.min = "2048";
+    llmMaxTokens.max = "262144";
+    llmMaxTokens.step = "256";
+    llmMaxTokens.title = "Global max tokens for LM Studio and LLM API requests.";
+    const llmMaxTokensField = makeField("Global max tokens", llmMaxTokens, "Applies to LM Studio and LLM API prompt generation. Default: 8192.");
     const lmPanel = document.createElement("div");
     lmPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
     const note = document.createElement("div");
@@ -45149,7 +45175,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const cancel = makeButton("Cancel");
     const save = makeButton("Save Runner", "primary");
     actions.append(cancel, save);
-    box.append(header, makeField("Text LLM runner", runner), builtinPanel, lmPanel, apiPanel, actions);
+    box.append(header, makeField("Text LLM runner", runner), llmMaxTokensField, builtinPanel, lmPanel, apiPanel, actions);
     backdrop.append(box);
     document.body.append(backdrop);
     syncVisibility();
@@ -45159,6 +45185,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.textGemmaRunner = runner.value || "builtin";
       state.gemmaContextLimit = normalizeGemmaContextLimit(gemmaContextLimit.value);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(gemmaGpuLayers.value);
+      state.llmMaxTokens = normalizeLlmMaxTokens(llmMaxTokens.value);
       state.lmStudioBaseUrl = baseUrl.value || "http://127.0.0.1:1234/v1";
       state.lmStudioModel = model.value || "";
       state.lmStudioApiKey = lmStudioApiKey.value || "";
@@ -46155,7 +46182,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           max_locations: refs.max_generated_locations || 8,
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         const { added, updated } = upsertWizardLocations(refs, data.locations || []);
         refs.use_location_references = Boolean(refs.locations.length || Object.keys(refs.scene_map || {}).length);
@@ -46210,7 +46237,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           })),
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         upsertWizardLocations(refs, data.locations || []);
         refs.scene_map = refs.scene_map && typeof refs.scene_map === "object" ? refs.scene_map : {};
@@ -46502,7 +46529,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           lyrics: scenes.map((scene) => `${scene.lyric_section ? `[${scene.lyric_section}]\n` : ""}${scene.lyrics || ""}`).filter(Boolean).join("\n\n"),
           scenes,
           unload_after: true,
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 240000);
         state.builderStoryLayer = normalizeBuilderStoryLayer({
           ...layer,
@@ -46541,7 +46568,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes,
           reference_builder: storyboardReferenceBuilderWithIdLoraRefs(state.fluxReferenceBuilder),
           unload_after: true,
-          max_new_tokens: 8000,
+          max_new_tokens: getLlmRunnerMaxTokens(),
         }, 240000);
         state.builderStoryLayer = normalizeBuilderStoryLayer({
           ...layer,
@@ -46601,7 +46628,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             previous_beat: previousBeat,
             next_lyrics: nextLyrics,
             unload_after: index === targets.length - 1,
-            max_new_tokens: 8000,
+            max_new_tokens: getLlmRunnerMaxTokens(),
           }, 240000);
           const segment = segments.find((item) => item.id === scene.id);
           if (segment) segment.story_beat = String(data.story_beat || "").trim();
@@ -46671,7 +46698,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
               ...(storyboardState.gemmaSettings || {}),
               unload_after: index === scenes.length - 1,
               storyboard_payload: storyboardGptPayload(storyboardState, [scene]),
-              max_new_tokens: 8000,
+              max_new_tokens: getLlmRunnerMaxTokens(),
               temperature: 0.35,
               top_p: 0.90,
             }, 240000);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45,6 +45,7 @@ import {
 
 const NODE_NAME = "VRGDG_MusicVideoBuilderUI";
 const BUILDER_UI_VERSION = "welcome-startup-2026-05-20";
+const DEFAULT_LLM_MAX_TOKENS = 8192;
 const HIDDEN_WIDGETS = new Set(["audio_path", "project_folder", "session_path", "srt_path"]);
 let builderAutomaticMemoryCleanupEnabled = false;
 const EMBEDDED_MEMORY_CLEANUP_NODE_TYPES = new Set([
@@ -5987,7 +5988,6 @@ function openBuilder(node) {
     storyIdeaPath: "",
     subjectScenePath: "",
     textGemmaRunner: "builtin",
-    gemmaContextLimit: 8000,
     gemmaGpuLayers: 99,
     lmStudioBaseUrl: "http://127.0.0.1:1234/v1",
     lmStudioModel: "",
@@ -5995,7 +5995,7 @@ function openBuilder(node) {
     llmApiProvider: "openai",
     llmApiModel: "",
     llmApiKey: "",
-    llmMaxTokens: 8192,
+    llmMaxTokens: DEFAULT_LLM_MAX_TOKENS,
     llmApiChoices: null,
     customModelsRoot: "",
     notificationSettings: defaultNotificationSettings(),
@@ -8485,7 +8485,7 @@ function openBuilder(node) {
   function textGemmaRunnerPayload() {
     return {
       text_runner: state.textGemmaRunner || "builtin",
-      n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      n_ctx: getLlmRunnerMaxTokens(),
       n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       max_new_tokens: getLlmRunnerMaxTokens(),
       lmstudio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
@@ -9929,9 +9929,6 @@ function openBuilder(node) {
     if (Object.prototype.hasOwnProperty.call(defaults, "gemma_gpu_layers") || Object.prototype.hasOwnProperty.call(defaults, "gemmaGpuLayers") || Object.prototype.hasOwnProperty.call(defaults, "n_gpu_layers")) {
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(defaults.gemma_gpu_layers ?? defaults.gemmaGpuLayers ?? defaults.n_gpu_layers ?? state.gemmaGpuLayers);
     }
-    if (Object.prototype.hasOwnProperty.call(defaults, "gemma_context_limit") || Object.prototype.hasOwnProperty.call(defaults, "gemmaContextLimit") || Object.prototype.hasOwnProperty.call(defaults, "n_ctx")) {
-      state.gemmaContextLimit = normalizeGemmaContextLimit(defaults.gemma_context_limit ?? defaults.gemmaContextLimit ?? defaults.n_ctx ?? state.gemmaContextLimit);
-    }
     if (defaults.lm_studio_base_url || defaults.lmStudioBaseUrl) {
       state.lmStudioBaseUrl = defaults.lm_studio_base_url || defaults.lmStudioBaseUrl || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
     }
@@ -9947,8 +9944,21 @@ function openBuilder(node) {
     if (defaults.llm_api_model || defaults.llmApiModel) {
       state.llmApiModel = defaults.llm_api_model || defaults.llmApiModel || state.llmApiModel || "";
     }
-    if (Object.prototype.hasOwnProperty.call(defaults, "llm_max_tokens") || Object.prototype.hasOwnProperty.call(defaults, "llmMaxTokens")) {
-      state.llmMaxTokens = normalizeLlmMaxTokens(defaults.llm_max_tokens ?? defaults.llmMaxTokens ?? state.llmMaxTokens);
+    if (
+      Object.prototype.hasOwnProperty.call(defaults, "llm_max_tokens")
+      || Object.prototype.hasOwnProperty.call(defaults, "llmMaxTokens")
+      || Object.prototype.hasOwnProperty.call(defaults, "gemma_context_limit")
+      || Object.prototype.hasOwnProperty.call(defaults, "gemmaContextLimit")
+      || Object.prototype.hasOwnProperty.call(defaults, "n_ctx")
+    ) {
+      state.llmMaxTokens = normalizeLlmMaxTokens(
+        defaults.llm_max_tokens
+        ?? defaults.llmMaxTokens
+        ?? defaults.gemma_context_limit
+        ?? defaults.gemmaContextLimit
+        ?? defaults.n_ctx
+        ?? state.llmMaxTokens,
+      );
     }
     state.imageModelMode = defaults.image_model_mode || defaults.imageModelMode || defaults.flux_klein_settings?.image_model_mode || defaults.fluxKleinSettings?.image_model_mode || state.imageModelMode || "zimage";
     state.videoType = normalizeVideoType(defaults.video_type || defaults.videoType || state.videoType);
@@ -10154,7 +10164,6 @@ function openBuilder(node) {
       storyIdeaPath: state.storyIdeaPath,
       subjectScenePath: state.subjectScenePath,
       textGemmaRunner: state.textGemmaRunner,
-      gemmaContextLimit: normalizeGemmaContextLimit(state.gemmaContextLimit),
       gemmaGpuLayers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       lmStudioBaseUrl: state.lmStudioBaseUrl,
       lmStudioModel: state.lmStudioModel,
@@ -10237,13 +10246,20 @@ function openBuilder(node) {
     state.storyIdeaPath = data.storyIdeaPath || "";
     state.subjectScenePath = data.subjectScenePath || "";
     state.textGemmaRunner = data.textGemmaRunner || data.text_gemma_runner || state.textGemmaRunner || "builtin";
-    state.gemmaContextLimit = normalizeGemmaContextLimit(data.gemmaContextLimit ?? data.gemma_context_limit ?? data.n_ctx ?? state.gemmaContextLimit);
     state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.gemmaGpuLayers ?? data.gemma_gpu_layers ?? data.n_gpu_layers ?? state.gemmaGpuLayers);
     state.lmStudioBaseUrl = data.lmStudioBaseUrl || data.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
     state.lmStudioModel = data.lmStudioModel || data.lm_studio_model || state.lmStudioModel || "";
     state.lmStudioApiKey = data.lmStudioApiKey || data.lm_studio_api_key || state.lmStudioApiKey || "";
     state.llmApiProvider = data.llmApiProvider || data.llm_api_provider || state.llmApiProvider || "openai";
     state.llmApiModel = data.llmApiModel || data.llm_api_model || state.llmApiModel || "";
+    state.llmMaxTokens = normalizeLlmMaxTokens(
+      data.llmMaxTokens
+      ?? data.llm_max_tokens
+      ?? data.gemmaContextLimit
+      ?? data.gemma_context_limit
+      ?? data.n_ctx
+      ?? state.llmMaxTokens,
+    );
     state.notificationSettings = normalizeNotificationSettings(data.notificationSettings || data.notification_settings || state.notificationSettings);
     state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.automaticMemoryCleanup ?? data.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
     state.waveformMode = data.waveformMode || state.waveformMode || "medium";
@@ -11562,19 +11578,15 @@ function openBuilder(node) {
     return Math.max(0, Math.min(999, Math.round(parsed)));
   }
 
-  function normalizeGemmaContextLimit(value) {
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed)) return 8000;
-    return Math.max(512, Math.min(262144, Math.round(parsed)));
-  }
-
   function normalizeLlmMaxTokens(value) {
     const parsed = Number(value);
-    if (!Number.isFinite(parsed)) return 8192;
+    if (!Number.isFinite(parsed)) return DEFAULT_LLM_MAX_TOKENS;
     return Math.max(2048, Math.min(262144, Math.round(parsed)));
   }
 
   function getLlmRunnerMaxTokens(options = {}) {
+    const runner = String(options.runner || state.textGemmaRunner || "builtin").trim().toLowerCase();
+    if (runner === "llm_api") return undefined;
     if (Object.prototype.hasOwnProperty.call(options, "maxNewTokens") && Number.isFinite(Number(options.maxNewTokens))) {
       return normalizeLlmMaxTokens(options.maxNewTokens);
     }
@@ -19483,6 +19495,7 @@ function openBuilder(node) {
         const storyIdea = gemmaTarget === "builder_subjects_and_scenes"
           ? await loadContextTextQuiet(storyIdeaInput.value)
           : "";
+        const localLlmMaxTokens = getLlmRunnerMaxTokens({ runner: "builtin" });
         const data = await postJson("/vrgdg/gemma4/generate", {
           target: gemmaTarget,
           model_file: modelFile,
@@ -19490,8 +19503,8 @@ function openBuilder(node) {
           style_theme: styleTheme,
           story_idea: storyIdea || idea,
           unload_after: true,
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: getLlmRunnerMaxTokens(),
+          n_ctx: localLlmMaxTokens,
+          max_new_tokens: localLlmMaxTokens,
         }, 10 * 60 * 1000);
         const text = String(data.text || "").trim();
         if (!text) throw new Error("Gemma4 returned an empty draft.");
@@ -26388,7 +26401,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             subject_context: referenceSubjectContextForLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
@@ -26401,7 +26414,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             subject_context: referenceSubjectContextForLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000);
         progress.set("Adding extracted locations to the Reference Builder...", 78);
@@ -26615,7 +26628,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             used_location_counts: usedLocationCounts,
             previous_assignments: previousAssignments.slice(-24),
             unload_after: batchIndex === batches.length - 1,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             max_new_tokens: getLlmRunnerMaxTokens(),
           }, 10 * 60 * 1000);
           mergedData.locations = batchData.locations || mergedData.locations || [];
@@ -28956,7 +28969,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             subject_context: ingredientSubjectContextForLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
@@ -28969,7 +28982,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             subject_context: ingredientSubjectContextForLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000);
         const { added, updated } = upsertLocationText((data.locations || []).map((item) => ({ name: item.name, description: item.description })));
@@ -29699,7 +29712,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
             subject_context: subjectContextForTextMapLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             max_new_tokens: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000)
@@ -29712,7 +29725,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
             subject_context: subjectContextForTextMapLocations(),
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
-            n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+            n_ctx: getLlmRunnerMaxTokens(),
             unload_after: true,
           }, 10 * 60 * 1000);
         const { added, updated } = upsertTextMapLocations((data.locations || []).map((item) => ({ name: item.name, description: item.description })));
@@ -29785,7 +29798,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
             description: compactTextForTextMap(item.description, 650),
           })),
           unload_after: true,
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+          n_ctx: getLlmRunnerMaxTokens(),
           max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         upsertTextMapLocations(data.locations || []);
@@ -32018,7 +32031,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       story_idea_path: state.storyIdeaPath,
       subject_scene_path: state.subjectScenePath,
       text_gemma_runner: state.textGemmaRunner || "builtin",
-      gemma_context_limit: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      gemma_context_limit: normalizeLlmMaxTokens(state.llmMaxTokens),
+      llm_max_tokens: normalizeLlmMaxTokens(state.llmMaxTokens),
       gemma_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       lm_studio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
       lm_studio_model: state.lmStudioModel || "",
@@ -32279,9 +32293,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.renderLogs = normalizeRenderLogs(data.session.render_logs || state.renderLogs);
         state.activeRenderLogId = data.session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
         state.textGemmaRunner = data.session.text_gemma_runner || state.textGemmaRunner || "builtin";
-        state.gemmaContextLimit = normalizeGemmaContextLimit(data.session.gemma_context_limit ?? data.session.n_ctx ?? state.gemmaContextLimit);
         state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.session.gemma_gpu_layers ?? data.session.n_gpu_layers ?? state.gemmaGpuLayers);
-        state.llmMaxTokens = normalizeLlmMaxTokens(data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.llmMaxTokens);
+        state.llmMaxTokens = normalizeLlmMaxTokens(
+          data.session.llm_max_tokens
+          ?? data.session.llmMaxTokens
+          ?? data.session.gemma_context_limit
+          ?? data.session.n_ctx
+          ?? state.llmMaxTokens,
+        );
         state.lmStudioBaseUrl = data.session.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
         state.lmStudioModel = data.session.lm_studio_model || state.lmStudioModel || "";
         state.lmStudioApiKey = data.session.lm_studio_api_key || state.lmStudioApiKey || "";
@@ -32606,8 +32625,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.renderLogs = normalizeRenderLogs(session.render_logs);
       state.activeRenderLogId = session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
       state.textGemmaRunner = session.text_gemma_runner || state.textGemmaRunner || "builtin";
-      state.gemmaContextLimit = normalizeGemmaContextLimit(session.gemma_context_limit ?? session.n_ctx ?? state.gemmaContextLimit);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(session.gemma_gpu_layers ?? session.n_gpu_layers ?? state.gemmaGpuLayers);
+      state.llmMaxTokens = normalizeLlmMaxTokens(
+        session.llm_max_tokens
+        ?? session.llmMaxTokens
+        ?? session.gemma_context_limit
+        ?? session.n_ctx
+        ?? state.llmMaxTokens,
+      );
       state.lmStudioBaseUrl = session.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
       state.lmStudioModel = session.lm_studio_model || state.lmStudioModel || "";
       state.lmStudioApiKey = session.lm_studio_api_key || state.lmStudioApiKey || "";
@@ -33908,7 +33933,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       user_notes: userNotes,
       clear_before_load: options.clearBeforeLoad !== false,
       unload_after: options.unloadAfter !== false,
-      n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      n_ctx: getLlmRunnerMaxTokens(),
       max_new_tokens: getLlmRunnerMaxTokens(),
       seed: options.seed,
       temperature: options.temperature,
@@ -34535,7 +34560,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       no_vocal: noVocal,
       no_character_present: Boolean(segment?.no_character_present),
       unload_after: options.unloadAfter !== false,
-      n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      n_ctx: getLlmRunnerMaxTokens(),
       max_new_tokens: getLlmRunnerMaxTokens(),
     }, GEMMA_VIDEO_ENHANCE_TIMEOUT_MS);
     return String(data.prompt || "").trim() || base;
@@ -34915,7 +34940,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           no_character_present: Boolean(segment.no_character_present),
         } : {},
         unload_after: true,
-        n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+        n_ctx: getLlmRunnerMaxTokens(),
         temperature: 0.25,
         top_p: 0.9,
         max_new_tokens: getLlmRunnerMaxTokens(),
@@ -35002,7 +35027,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           no_character_present: Boolean(segment.no_character_present),
         } : {},
         unload_after: true,
-        n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+        n_ctx: getLlmRunnerMaxTokens(),
         temperature: 0.25,
         top_p: 0.9,
         max_new_tokens: getLlmRunnerMaxTokens(),
@@ -37335,7 +37360,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         model_file: i2vTextGemmaModelSelect.value || t2iTextGemmaModelSelect.value || "",
         vision_model_file: i2vGemmaModelSelect.value || gemmaModelSelect.value || "",
         mmproj_file: i2vMmprojSelect.value || mmprojSelect.value || "",
-        n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+        n_ctx: getLlmRunnerMaxTokens(),
         n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
         n_threads: 8,
         unload_after: true,
@@ -37595,7 +37620,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       performance_mode: effectiveVideoPerformanceModeForSegment(nextSegment),
       repair_model_file: i2vTextGemmaModelSelect.value,
       unload_after: true,
-      n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      n_ctx: getLlmRunnerMaxTokens(),
       temperature: 0.25,
       top_p: 0.9,
       max_new_tokens: getLlmRunnerMaxTokens(),
@@ -42807,7 +42832,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         append_subject_to_prompts: true,
         repair_lyric_segments: false,
         text_gemma_runner: state.textGemmaRunner || "builtin",
-        gemma_context_limit: normalizeGemmaContextLimit(state.gemmaContextLimit),
+        gemma_context_limit: normalizeLlmMaxTokens(state.llmMaxTokens),
+        llm_max_tokens: normalizeLlmMaxTokens(state.llmMaxTokens),
         gemma_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
         lm_studio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
         lm_studio_model: state.lmStudioModel || "",
@@ -44612,7 +44638,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           auto_apply: allowActions,
           agent_purpose: purpose.value || "scene_work",
           unload_after: true,
-          n_ctx: scope.value === "project_brief" || scope.value === "full_scene_plan" ? 12000 : 8000,
+          n_ctx: getLlmRunnerMaxTokens(),
           max_new_tokens: getLlmRunnerMaxTokens(),
           temperature: 0.55,
           top_p: 0.95,
@@ -44794,7 +44820,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           image_ingredients: refs,
           user_notes: "These are performer, character, location, and aesthetic references for the whole project.",
           unload_after: true,
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+          n_ctx: getLlmRunnerMaxTokens(),
           max_new_tokens: getLlmRunnerMaxTokens(),
           temperature: 0.25,
           top_p: 0.95,
@@ -44978,10 +45004,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     runner.options[0].textContent = "Gemma Local";
     runner.options[1].textContent = "LM Studio";
     runner.options[2].textContent = "LLM API";
-    const gemmaContextLimit = makeInput(String(normalizeGemmaContextLimit(state.gemmaContextLimit)), "number");
-    gemmaContextLimit.min = "512";
-    gemmaContextLimit.max = "262144";
-    gemmaContextLimit.step = "256";
     const gemmaGpuLayers = makeInput(String(normalizeGemmaGpuLayers(state.gemmaGpuLayers)), "number");
     gemmaGpuLayers.min = "0";
     gemmaGpuLayers.max = "999";
@@ -44990,13 +45012,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     builtinPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
     const builtinNote = document.createElement("div");
     builtinNote.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;";
-    builtinNote.textContent = "Advanced local GGUF settings. Context limit controls how much text Gemma Local can accept. Higher context can use much more RAM/VRAM and may slow down, hang, fail, or run out of memory.";
+    builtinNote.textContent = "Advanced local GGUF settings. Max tokens controls how much text Gemma Local can accept. Higher values can use much more RAM/VRAM and may slow down, hang, fail, or run out of memory.";
     const gpuNote = document.createElement("div");
     gpuNote.style.cssText = "font-size:12px;color:#94a3b8;line-height:1.4;";
     gpuNote.textContent = "Lower GPU layers if Gemma Local runs out of VRAM; try 12 for 10GB cards. Higher values use more VRAM and may run faster.";
     builtinPanel.append(
       builtinNote,
-      makeField("Context limit / n_ctx", gemmaContextLimit),
       gpuNote,
       makeField("GPU layers / n_gpu_layers", gemmaGpuLayers),
     );
@@ -45011,8 +45032,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     llmMaxTokens.min = "2048";
     llmMaxTokens.max = "262144";
     llmMaxTokens.step = "256";
-    llmMaxTokens.title = "Global max tokens for LM Studio and LLM API requests.";
-    const llmMaxTokensField = makeField("Global max tokens", llmMaxTokens, "Applies to LM Studio and LLM API prompt generation. Default: 8192.");
+    llmMaxTokens.title = "Shared token limit for Gemma Local and LM Studio.";
+    const localTokenPanel = document.createElement("div");
+    localTokenPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #0e7490;border-radius:7px;background:#083344;padding:12px;";
+    localTokenPanel.append(makeField(
+      "Local LLM max tokens",
+      llmMaxTokens,
+      `Shared by both local runners: Gemma Local uses it for n_ctx and generation, while LM Studio receives it as max_tokens. Default: ${DEFAULT_LLM_MAX_TOKENS}.`,
+    ));
     const lmPanel = document.createElement("div");
     lmPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
     const note = document.createElement("div");
@@ -45083,6 +45110,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     llmApiKey.oninput = () => {
       state.llmApiKey = llmApiKey.value || "";
     };
+    llmMaxTokens.oninput = () => {
+      state.llmMaxTokens = normalizeLlmMaxTokens(llmMaxTokens.value);
+    };
     modelSelect.onchange = () => {
       if (modelSelect.value) model.value = modelSelect.value;
     };
@@ -45138,8 +45168,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     );
     const syncVisibility = () => {
       state.textGemmaRunner = runner.value || "builtin";
-      state.gemmaContextLimit = normalizeGemmaContextLimit(gemmaContextLimit.value);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(gemmaGpuLayers.value);
+      state.llmMaxTokens = normalizeLlmMaxTokens(llmMaxTokens.value);
+      localTokenPanel.style.display = runner.value === "llm_api" ? "none" : "flex";
       builtinPanel.style.display = runner.value === "builtin" ? "flex" : "none";
       lmPanel.style.display = runner.value === "lm_studio" ? "flex" : "none";
       apiPanel.style.display = runner.value === "llm_api" ? "flex" : "none";
@@ -45175,7 +45206,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const cancel = makeButton("Cancel");
     const save = makeButton("Save Runner", "primary");
     actions.append(cancel, save);
-    box.append(header, makeField("Text LLM runner", runner), llmMaxTokensField, builtinPanel, lmPanel, apiPanel, actions);
+    box.append(header, makeField("Text LLM runner", runner), localTokenPanel, builtinPanel, lmPanel, apiPanel, actions);
     backdrop.append(box);
     document.body.append(backdrop);
     syncVisibility();
@@ -45183,7 +45214,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     close.onclick = cancel.onclick = () => backdrop.remove();
     save.onclick = async () => {
       state.textGemmaRunner = runner.value || "builtin";
-      state.gemmaContextLimit = normalizeGemmaContextLimit(gemmaContextLimit.value);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(gemmaGpuLayers.value);
       state.llmMaxTokens = normalizeLlmMaxTokens(llmMaxTokens.value);
       state.lmStudioBaseUrl = baseUrl.value || "http://127.0.0.1:1234/v1";
@@ -46181,7 +46211,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           })),
           max_locations: refs.max_generated_locations || 8,
           unload_after: true,
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+          n_ctx: getLlmRunnerMaxTokens(),
           max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         const { added, updated } = upsertWizardLocations(refs, data.locations || []);
@@ -46236,7 +46266,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             description: compactWizardText(item.description, 700),
           })),
           unload_after: true,
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+          n_ctx: getLlmRunnerMaxTokens(),
           max_new_tokens: getLlmRunnerMaxTokens(),
         }, 10 * 60 * 1000);
         upsertWizardLocations(refs, data.locations || []);
@@ -46668,7 +46698,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           model_file: i2vTextGemmaModelSelect.value || t2iTextGemmaModelSelect.value || "",
           vision_model_file: i2vGemmaModelSelect.value || gemmaModelSelect.value || "",
           mmproj_file: i2vMmprojSelect.value || mmprojSelect.value || "",
-          n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+          n_ctx: getLlmRunnerMaxTokens(),
           n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
           n_threads: 8,
           unload_after: true,

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2916,7 +2916,7 @@ function openBuilder(node) {
         clear_before_load: false,
         temperature: 0.15,
         top_p: 0.85,
-        max_new_tokens: 180,
+        max_new_tokens: 8000,
       }, 4 * 60 * 1000);
       const description = String(data.description || "").trim();
       if (!description) throw new Error("The selected LLM Runner returned an empty face description.");
@@ -26369,7 +26369,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 2200,
+            max_new_tokens: 8000,
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -26596,7 +26596,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             previous_assignments: previousAssignments.slice(-24),
             unload_after: batchIndex === batches.length - 1,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 1200,
+            max_new_tokens: 8000,
           }, 10 * 60 * 1000);
           mergedData.locations = batchData.locations || mergedData.locations || [];
           Object.assign(mergedData.scene_map, batchData.scene_map || {});
@@ -28937,7 +28937,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 2200,
+            max_new_tokens: 8000,
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -29680,7 +29680,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
             existing_locations: refs.locations.map((item) => ({ name: item.name || "", description: item.description || "" })),
             max_locations: refs.max_generated_locations || 8,
             n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-            max_new_tokens: 2200,
+            max_new_tokens: 8000,
             unload_after: true,
           }, 10 * 60 * 1000)
           : await postJson("/vrgdg/music_builder/flux_reference_extract_locations", {
@@ -29766,7 +29766,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
           })),
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 1600,
+          max_new_tokens: 8000,
         }, 10 * 60 * 1000);
         upsertTextMapLocations(data.locations || []);
         let mapped = 0;
@@ -30604,7 +30604,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes: batch.map(({ segment, index }) => conceptPromptScenePayload(segment, index, sourceMode)),
           temperature: options.temperature ?? 0.45,
           top_p: options.topP ?? 0.95,
-          max_new_tokens: options.maxNewTokens ?? 1200,
+          max_new_tokens: options.maxNewTokens ?? 8000,
         }, 180000);
         const prompts = data.prompts || {};
         for (const { segment, index } of batch) {
@@ -30772,7 +30772,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes: batch.map(({ segment, index }) => motionNoteScenePayload(segment, index, sourceMode)),
           temperature: options.temperature ?? 0.45,
           top_p: options.topP ?? 0.95,
-          max_new_tokens: options.maxNewTokens ?? 1200,
+          max_new_tokens: options.maxNewTokens ?? 8000,
         }, 180000);
         const notes = data.notes || {};
         for (const { segment, index } of batch) {
@@ -33111,7 +33111,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       seed: options.seed,
       temperature: options.temperature ?? 0.35,
       top_p: options.topP ?? 0.90,
-      max_new_tokens: options.maxNewTokens ?? 1200,
+      max_new_tokens: options.maxNewTokens ?? 8000,
     }, 240000);
     pushHistory();
     syncSegmentT2IPrompt(segment, applyMappedTriggerPhrases(applyImageTriggerToPrompt(data.prompt, segment, imageMode, { validateJunk: true }), segment));
@@ -33888,7 +33888,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       clear_before_load: options.clearBeforeLoad !== false,
       unload_after: options.unloadAfter !== false,
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-      max_new_tokens: 900,
+      max_new_tokens: 8000,
       seed: options.seed,
       temperature: options.temperature,
       top_p: options.topP,
@@ -34170,7 +34170,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         scene_number: sceneSlotNumber(segment),
         user_notes: userNotes,
         unload_after: true,
-        max_new_tokens: 1000,
+        max_new_tokens: 8000,
       }, 10 * 60 * 1000);
       pushHistory();
       segment.enhance_prompt = applyTriggerPhrase(data.prompt, state.imageTriggerPhrase);
@@ -34515,7 +34515,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       no_character_present: Boolean(segment?.no_character_present),
       unload_after: options.unloadAfter !== false,
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-      max_new_tokens: 1200,
+      max_new_tokens: 8000,
     }, GEMMA_VIDEO_ENHANCE_TIMEOUT_MS);
     return String(data.prompt || "").trim() || base;
   }
@@ -34897,7 +34897,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
         temperature: 0.25,
         top_p: 0.9,
-        max_new_tokens: 1200,
+        max_new_tokens: 8000,
       }, 180000);
       const nextPrompt = String(data.prompt || "").trim();
       if (!nextPrompt) throw new Error("Gemma returned an empty edited image prompt.");
@@ -34984,7 +34984,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
         temperature: 0.25,
         top_p: 0.9,
-        max_new_tokens: 1200,
+        max_new_tokens: 8000,
       }, GEMMA_VIDEO_ENHANCE_TIMEOUT_MS);
       const nextPrompt = String(data.prompt || "").trim();
       if (!nextPrompt) throw new Error("Gemma returned an empty edited prompt.");
@@ -35409,7 +35409,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         unload_after: true,
         temperature: 0.45,
         top_p: 0.92,
-        max_new_tokens: 4000,
+        max_new_tokens: 8000,
       }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
       const prompt = applyMiniMaxH3NativeVoiceBlock(String(data.prompt || ""), segment);
       if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
@@ -36983,7 +36983,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           unload_after: options.unloadAfter !== false,
           temperature: 0.45,
           top_p: 0.92,
-          max_new_tokens: 4000,
+          max_new_tokens: 8000,
         }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
         const generatedPrompt = String(data.prompt || "").trim();
         if (!generatedPrompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
@@ -37577,7 +37577,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
       temperature: 0.25,
       top_p: 0.9,
-      max_new_tokens: 1200,
+      max_new_tokens: 8000,
     }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
     const prompt = String(data.prompt || "").trim();
     if (!prompt) throw new Error("Gemma returned an empty chained I2V prompt.");
@@ -41438,7 +41438,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         next_lyrics: String(next?.lyric_text || ""),
         flf_mode: true,
         unload_after: index === missingTargets.length - 1,
-        max_new_tokens: 700,
+        max_new_tokens: 8000,
         temperature: 0.35,
         top_p: 0.9,
       }, 240000);
@@ -44592,7 +44592,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           agent_purpose: purpose.value || "scene_work",
           unload_after: true,
           n_ctx: scope.value === "project_brief" || scope.value === "full_scene_plan" ? 12000 : 8000,
-          max_new_tokens: purpose.value === "story_builder" && allowActions ? 1800 : allowActions ? 700 : 450,
+          max_new_tokens: 8000,
           temperature: 0.55,
           top_p: 0.95,
         });
@@ -44774,7 +44774,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           user_notes: "These are performer, character, location, and aesthetic references for the whole project.",
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 500,
+          max_new_tokens: 8000,
           temperature: 0.25,
           top_p: 0.95,
         }, 10 * 60 * 1000);
@@ -46154,7 +46154,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           max_locations: refs.max_generated_locations || 8,
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 2200,
+          max_new_tokens: 8000,
         }, 10 * 60 * 1000);
         const { added, updated } = upsertWizardLocations(refs, data.locations || []);
         refs.use_location_references = Boolean(refs.locations.length || Object.keys(refs.scene_map || {}).length);
@@ -46209,7 +46209,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           })),
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 1800,
+          max_new_tokens: 8000,
         }, 10 * 60 * 1000);
         upsertWizardLocations(refs, data.locations || []);
         refs.scene_map = refs.scene_map && typeof refs.scene_map === "object" ? refs.scene_map : {};
@@ -46501,7 +46501,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           lyrics: scenes.map((scene) => `${scene.lyric_section ? `[${scene.lyric_section}]\n` : ""}${scene.lyrics || ""}`).filter(Boolean).join("\n\n"),
           scenes,
           unload_after: true,
-          max_new_tokens: 800,
+          max_new_tokens: 8000,
         }, 240000);
         state.builderStoryLayer = normalizeBuilderStoryLayer({
           ...layer,
@@ -46540,7 +46540,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           scenes,
           reference_builder: storyboardReferenceBuilderWithIdLoraRefs(state.fluxReferenceBuilder),
           unload_after: true,
-          max_new_tokens: 900,
+          max_new_tokens: 8000,
         }, 240000);
         state.builderStoryLayer = normalizeBuilderStoryLayer({
           ...layer,
@@ -46600,7 +46600,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             previous_beat: previousBeat,
             next_lyrics: nextLyrics,
             unload_after: index === targets.length - 1,
-            max_new_tokens: 360,
+            max_new_tokens: 8000,
           }, 240000);
           const segment = segments.find((item) => item.id === scene.id);
           if (segment) segment.story_beat = String(data.story_beat || "").trim();
@@ -46670,7 +46670,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
               ...(storyboardState.gemmaSettings || {}),
               unload_after: index === scenes.length - 1,
               storyboard_payload: storyboardGptPayload(storyboardState, [scene]),
-              max_new_tokens: 1400,
+              max_new_tokens: 8000,
               temperature: 0.35,
               top_p: 0.90,
             }, 240000);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -8568,6 +8568,7 @@ function openBuilder(node) {
       reference_type: referenceType === "subject" ? (target?.reference_type || "character") : referenceType,
       name: target?.name || "",
       ...referenceImagePayload(image),
+      max_new_tokens: 8000,
       unload_after: options.unloadAfter !== false,
       clear_before_load: Boolean(options.clearBeforeLoad),
     }, 4 * 60 * 1000);
@@ -25282,7 +25283,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
 
     async function describeGeneratedReference(referenceType, target, prompt = "") {
       if (referenceType === "subject") {
-        setInlineProgress(`Vision Gemma describing the generated subject image...\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 91);
+        setInlineProgress(`Vision Gemma describing the generated subject image...\n${gemmaRunnerLine({ vision: true })}`, 91);
         const description = await describeReferenceImageWithGemma(target, "subject", {
           unloadAfter: true,
           clearBeforeLoad: false,
@@ -25750,7 +25751,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         for (let index = 0; index < jobs.length; index += 1) {
           const { target, label } = jobs[index];
           const isLast = index === jobs.length - 1;
-          progress.set(`Vision Gemma describing ${referenceType} image...\n${index + 1}/${jobs.length}: ${label || target.name || referenceType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing ${referenceType} image...\n${index + 1}/${jobs.length}: ${label || target.name || referenceType}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(target, referenceType, {
             unloadAfter: options.keepLoaded ? isLast : true,
             clearBeforeLoad: index === 0 && Boolean(options.clearBeforeLoad),
@@ -25778,7 +25779,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       const effectiveType = referenceType === "subject" ? (target?.reference_type || "character") : referenceType;
       const progress = createProgressWindow(referenceType === "location" ? "Describing location" : "Describing reference", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing ${effectiveType} image...\n${label || target?.name || effectiveType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing ${effectiveType} image...\n${label || target?.name || effectiveType}\n${gemmaRunnerLine({ vision: true })}`, 18);
         const description = await describeReferenceImageWithGemma(target, referenceType, { unloadAfter: true, clearBeforeLoad: false });
         applyReferenceDescription(referenceType, target, description);
         renderAll();
@@ -27833,7 +27834,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       const primarySubject = refs.subjects[0] || refs.subject;
       const progress = createProgressWindow("Describing character", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing character image...\n${subjectNameInput.value || refs.subjects[0]?.name || "Subject"}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing character image...\n${subjectNameInput.value || refs.subjects[0]?.name || "Subject"}\n${gemmaRunnerLine({ vision: true })}`, 18);
         const description = await describeReferenceImageWithGemma(primarySubject, "subject", { unloadAfter: true });
         applyReferenceDescription("subject", primarySubject, description);
         renderAll();
@@ -28315,7 +28316,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       if (!currentSheet) return;
       const progress = createProgressWindow("Describing Ingredients sheet", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing sheet image...\n${currentSheet.name || "Ingredients sheet"}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing sheet image...\n${currentSheet.name || "Ingredients sheet"}\n${gemmaRunnerLine({ vision: true })}`, 18);
         await describeReferenceImageWithGemma(currentSheet, "subject", { unloadAfter: true });
         renderSheets();
         await autoSaveSessionQuiet("Gemma described ingredients sheet");
@@ -28339,7 +28340,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       try {
         for (let index = 0; index < jobs.length; index += 1) {
           const sheet = jobs[index];
-          progress.set(`Vision Gemma describing sheet image...\n${index + 1}/${jobs.length}: ${sheet.name || `Ingredients Sheet ${index + 1}`}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing sheet image...\n${index + 1}/${jobs.length}: ${sheet.name || `Ingredients Sheet ${index + 1}`}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(sheet, "subject", { unloadAfter: index === jobs.length - 1 });
           renderSheets();
           await autoSaveSessionQuiet(`Gemma described ingredients sheet ${index + 1}`);
@@ -29420,7 +29421,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
         for (let index = 0; index < jobs.length; index += 1) {
           const item = jobs[index];
           const effectiveType = referenceType === "subject" ? (item.reference_type || "character") : referenceType;
-          progress.set(`Vision Gemma describing ${effectiveType} image...\n${index + 1}/${jobs.length}: ${item.name || effectiveType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing ${effectiveType} image...\n${index + 1}/${jobs.length}: ${item.name || effectiveType}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(item, referenceType, { unloadAfter: index === jobs.length - 1 });
           renderAll();
           await autoSaveSessionQuiet(`Gemma described ${referenceType} text`);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45160,7 +45160,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           reference_type: "location",
           source_text: "small empty test room",
           style_theme: "",
-          max_new_tokens: 1024,
+          max_new_tokens: getLlmRunnerMaxTokens() || 1024,
         }, 60000);
         progress.set(`LM Studio responded successfully:\n${data.prompt}`, 100);
         progress.close(4000);


### PR DESCRIPTION
The previous PR https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/pull/113 just fixed the LM Studio connection test.  This one solves the problem of various LM Studio / Gemma tasks hitting a hardcoded token cap wall and failing.  

There is a new field that sets the max tokens for both LM Studio and Gemma (ignored on commercial API connections).  I could have reused the Gemma field, but that wouldn't make sense for folks running non-gemma LLMs in LM Studio and would be confusing later.  It's essentially your Gemma `n_ctx` field generalized and then more uniformly called in the UI.



Codex did the heavy lifting.  It seems to have done a good job.  I confirmed LM Studio is receiving the user specified token cap correctly, and that Internal Gemma still works (though I'm not sure how to see the value getting passed).  I'm now getting no failures against LM Studio everywhere I've tested.

I set the default to 8192.  That's the lowest I've ever seen a local LLM server default to, and it should be just enough for most if not all tasks currently using LLMs.  



# LM Studio

<img width="1702" height="1616" alt="Screenshot (25)" src="https://github.com/user-attachments/assets/a284656f-c089-4972-a85e-7501a2aa85b3" />


# Gemma Local

<img width="1458" height="998" alt="Screenshot (22)" src="https://github.com/user-attachments/assets/3a00c5aa-b71d-4ef1-9d2a-feeb6357232c" />


# API Runner
* No changes

<img width="1471" height="1114" alt="Screenshot (28)" src="https://github.com/user-attachments/assets/28bb63c6-f2f9-4dd4-ac2c-f5280db80942" />



## Also: Fixed some prompts saying Runner: Gemma when they were actually going to LM Studio

<img width="1830" height="383" alt="Screenshot (21)" src="https://github.com/user-attachments/assets/e3687ef2-7fd7-4a32-b198-66e0163ad64b" />



