### PR TITLE
Add MiniMax Turbo, reference controls, and LLM limits

### DIFF
--- a/VRGDG_MiniMaxH3PromptInstructions.py
+++ b/VRGDG_MiniMaxH3PromptInstructions.py
@@ -15,12 +15,14 @@ CORE WORKFLOW
 2. Begin exactly with: Generate a [duration]-second [aspect ratio] [visual style] video.
 3. Replace every bracketed placeholder with concrete values. Never leave placeholder text in the result.
 4. Use the exact sectioned layout described under OUTPUT FORMAT. Preserve every required blank line and line break.
-5. Follow the media assignments with a timestamped visual schedule covering the entire duration.
-6. Every timestamp must connect precisely, with no gaps or overlaps.
-7. Expand the idea into an exciting but physically readable sequence while preserving the user's subject, location, story intent, and requested ending.
-8. Make reasonable creative decisions from the supplied context without asking questions.
+5. Obey any supplied `EDITING / CUT PLAN — MANDATORY` contract before applying general timeline-density or shot-planning guidance.
+6. Follow the media assignments with a timestamped visual schedule covering the entire duration.
+7. Every timestamp must connect precisely, with no gaps or overlaps.
+8. Expand the idea into an exciting but physically readable sequence while preserving the user's subject, location, story intent, and requested ending.
+9. Make reasonable creative decisions from the supplied context without asking questions.
 
 TIMELINE DENSITY
+- These ranges are fallback guidance only when the scene context does not supply an `EDITING / CUT PLAN — MANDATORY` contract.
 - 4-5 seconds: 2-3 clear visual beats.
 - 6-8 seconds: 3-5 clear visual beats.
 - 9-12 seconds: 4-6 clear visual beats.
@@ -32,6 +34,14 @@ Format timestamps like:
 [2s-4.5s]
 [4.5s-8s]
 
+EDITING / CUT PLAN AUTHORITY
+- When the scene context supplies an `EDITING / CUT PLAN — MANDATORY` contract, treat its continuous-shot choice, cut count, shot count, and cut times as authoritative. It overrides TIMELINE DENSITY and any general preference for more or fewer visual beats, shots, cutaways, or transitions.
+- A continuous-shot plan means one uninterrupted take for the entire duration. Timestamp blocks may describe chronological phases of that same take, but they must not create a new shot, angle reset, cutaway, montage beat, dissolve, match cut, hard cut, scene change, or transition. Change framing only through explicitly continuous camera movement, and never write `CUT TO:`.
+- An active cut plan requires exactly the supplied number of hard cuts and exactly one more shot than cuts. Begin shot 1 at 0 seconds. Start every later shot at the supplied cut time, and begin its visual description with the literal words `CUT TO:` immediately after the timestamp header.
+- Do not omit, merge, add, or shift a scheduled cut. Do not add any transition at an unscheduled time. The final timestamp must still end at the exact scene duration with no gaps or overlaps.
+- Every post-cut shot must be meaningfully different coverage—such as a new wide, medium, close-up, extreme close-up, reaction, object detail, profile, low angle, or high angle—while remaining inside the same scene and ongoing action unless the user's scene material explicitly requests a location or time change.
+- Across cuts, preserve subject identity, face, hairstyle, body proportions, wardrobe, props, location, lighting, screen direction, spatial relationships, dialogue order, vocal timing, and action continuity. Never use a cut as permission to clone a subject, reset the scene, or invent unrelated action.
+
 VISUAL DIRECTION
 - Describe visible actions literally and chronologically.
 - Include the subject and relevant appearance, environment, physical action, camera framing and movement, lighting and atmosphere, important facial expression, object interaction, and physical consequences.
@@ -39,7 +49,7 @@ VISUAL DIRECTION
 - Give each timestamp one main readable event, especially in fast sequences.
 - Do not overload one moment with incompatible camera movements.
 - Use clear camera language such as wide establishing shot, extreme close-up, low-angle tracking shot, fast push-in, orbiting camera, handheld chase shot, rapid pullback, continuous unbroken shot, hard cut, or match cut.
-- In multi-shot sequences, make each shot meaningfully different and connect them with a hard cut, match cut, motivated transition, or continuous movement.
+- When no mandatory cut plan is supplied, multi-shot sequences may connect meaningfully different shots with a hard cut, match cut, motivated transition, or continuous movement. When a mandatory cut plan is supplied, follow only its permitted transition type, count, and timing.
 - Do not fill time with slow motion unless the user requests it.
 - Treat supplied camera-motion speed and character-motion speed as hard requirements, not suggestions. Concrete scene-card motion wording must agree with them.
 - At camera speed 7-8, use energetic, visibly active camera movement and do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera language. At camera speed 9-10, use two or more coordinated readable camera actions when practical.
@@ -134,14 +144,21 @@ _MINIMAX_H3_IMAGE_TO_VIDEO_MODE = """MODE: IMAGE TO VIDEO
 
 _MINIMAX_H3_REFERENCE_TO_VIDEO_MODE = """MODE: REFERENCE TO VIDEO
 - The input context will list the connected images in their exact workflow order and state the intended purpose of each one. Refer to them as Image 1 through Image 9 only when they are actually supplied.
-- Clearly assign every supplied picture its stated purpose in the finished prompt. Purposes may include character identity and clothing, location, visual style, prop, start frame, end frame, or storyboard guidance.
+- The context may separately identify an attached picture as `PROMPT-ONLY SCENE-IMAGE INSPIRATION`. That picture is visible only to the prompt-writing LLM and is never supplied to the MiniMax renderer. Never assign it an Image N label, never count it as a renderer reference, and never mention the picture, inspiration process, source imagery, or visual analysis in the finished prompt.
+- For environment-only inspiration, extract only location/environment, atmosphere/mood, lighting/weather, colors/materials/background details, and relevant objects or environmental activity. Explicitly ignore framing, shot distance, camera angle, lens, composition, and every character's identity, face, hair, body, clothing, accessories, pose, placement, and activity.
+- For environment-plus-framing inspiration, the same environmental properties are allowed and framing, shot distance, angle, lens, and composition may be optional inspiration that can be changed freely. Still ignore every character property, pose, placement, and activity.
+- Under either prompt-only inspiration mode, assigned character-reference images are the sole visual authority for the rendered character's complete identity and appearance. Convert permitted environmental observations into direct scene description, and use only the renderer Image N labels and mapping supplied by the context.
+- Clearly assign every renderer picture its stated purpose in the finished prompt. Purposes may include character identity and clothing, location, visual style, prop, start frame, end frame, or storyboard guidance. The separately identified prompt-only inspiration picture is excluded from this requirement and must never receive an Image N assignment.
 - Never assume a fixed purpose from slot number. The supplied ordered assignments are authoritative.
 - Preserve character and location identity from the pictures assigned to those purposes without copying an unwanted pose, crop, camera angle, panel layout, or collage.
 - When a picture is identified as a storyboard grid, interpret its panels as ordered visual beats and composition guidance. Do not generate the grid, borders, panels, labels, or a collage as the output video.
-- A character/person picture may be a multi-view character sheet, turnaround sheet, or contact sheet. All portraits and body views inside that one reference picture depict the same single person. Use the views only to learn that person's identity, face, hair, clothing, and proportions.
+- A character/person picture may be a multi-view character sheet, turnaround sheet, or contact sheet. All portraits and body views inside that one reference picture depict the same single person. Extract only the character properties granted by its ordered assignment and the supplied start-frame priority contract; never assume that clothing or body proportions are authoritative when the assignment grants only face and hair.
 - Render exactly one on-screen instance of each distinct named subject. Never interpret alternate views in a character sheet as additional people, and never duplicate, clone, twin, multiply, or add background copies of a referenced subject unless the user explicitly requests duplicates.
 - When start and end pictures are assigned, begin from the start picture and arrive coherently at the end picture. Follow the user's requested transition behavior, including surreal morph, cinematic non-morphing continuation, or longer action between the endpoints.
-- When Image 1 is assigned as the exact start frame and later images are character references, Image 1 controls only the opening composition, pose, camera angle, environment, and lighting. The character-reference images remain authoritative for face, hair, clothing, body proportions, and identity details that are hidden in Image 1. Use those identity details to keep the character correct when they turn around, change angle, become partially occluded, or move into a different framing.
+- When Image 1 is assigned as the exact start frame and later images are character references, obey the supplied `START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY` contract exactly.
+- Under `Face + hair only`, Image 1 remains authoritative for pose, body and body proportions, clothing, wardrobe styling, accessories, framing, composition, camera angle, environment, props, lighting, colors, and every other visible detail. Character-reference images are authoritative ONLY for face identity, facial features, and hair. The first generated frame must already show that face and hair in Image 1's otherwise unchanged visual setup. Describe the intended character as directly present from frame one; do not use temporal comparison language such as `now featuring`, `becomes`, `changes into`, or `replaced by`. Never describe or depict a face swap, replacement process, morph, transition, or transformation, and never import the character reference's clothing, body, pose, accessories, framing, lighting, or background.
+- Under `Full character identity`, Image 1 controls the opening composition, pose, camera angle, environment, and lighting, while character-reference images control face, hair, clothing, body proportions, and identity details that are hidden in Image 1.
+- If no start-frame character-influence contract is supplied, use `Full character identity` for backward compatibility.
 - Do not mention any image label that was not supplied.
 - Follow only the selected audio-mode and vocal contract.
 """
@@ -204,6 +221,7 @@ MINIMAX_H3_SHORT_FILM_GUIDED_CONTRACT = """SHORT FILM — GUIDED FILM AUTOMATION
 
 MINIMAX_H3_SHORT_FILM_CUSTOM_CONTRACT = """SHORT FILM — FULLY CUSTOM / MANUAL SOURCE CONTRACT
 - Every populated scene-card field is locked, authoritative source material: ordered dialogue and speakers, story beat, action, performance, facial direction, shot/framing, camera movement, setting, character and location references, audio direction, continuity, and notes.
+- A supplied `EDITING / CUT PLAN — MANDATORY` contract is also locked, authoritative source material. Applying its exact scheduled cuts and choosing the continuity-preserving coverage needed for those shots is required formatting, not an invented camera or story choice. A continuous-shot plan still prohibits every cut or transition.
 - Your only creative task is to format those exact instructions into the required MiniMax H3 prompt structure and timestamp them across the exact supplied duration.
 - Do not invent, rewrite, polish, paraphrase, reorder, merge, omit, replace, or contradict any supplied dialogue, speaker, action, story beat, camera choice, setting, sound, or continuity detail.
 - Never add dialogue, narration, lyrics, a new speaker, a new character, a new action, a new plot beat, a new location, or an unrequested camera move.

--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -3282,7 +3282,7 @@ def _validate_builder_gemma_prompt(text, label, payload=None):
 
 
 def _llm_runner_from_payload(payload):
-    runner = str(payload.get("text_runner") or payload.get("gemma_runner") or "builtin").strip().lower()
+    runner = str(payload.get("text_runner") or payload.get("text_gemma_runner") or payload.get("gemma_runner") or "builtin").strip().lower()
     if runner in {"lmstudio", "lm-studio", "lm_studio"}:
         runner = "lm_studio"
     if runner in {"llmapi", "llm-api", "llm_api", "api", "outside_api", "outside_llm_api"}:
@@ -3290,6 +3290,117 @@ def _llm_runner_from_payload(payload):
     if runner not in {"builtin", "lm_studio", "llm_api"}:
         runner = "builtin"
     return runner
+
+
+def _normalized_token_limit(value, default, minimum=64, maximum=262144):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = int(default)
+    return max(int(minimum), min(int(maximum), parsed))
+
+
+def _runner_output_token_limit(payload, requested=1200):
+    payload = payload if isinstance(payload, dict) else {}
+    runner = _llm_runner_from_payload(payload)
+    if runner == "lm_studio":
+        configured = payload.get("lmstudio_output_token_limit")
+        if configured in (None, ""):
+            configured = payload.get("lm_studio_output_token_limit")
+    elif runner == "builtin":
+        configured = payload.get("gemma_output_token_limit")
+    else:
+        configured = None
+    if runner in {"builtin", "lm_studio"} and configured in (None, ""):
+        configured = payload.get("llm_max_tokens")
+    if configured not in (None, ""):
+        return _normalized_token_limit(configured, requested)
+    return _normalized_token_limit(requested, 1200)
+
+
+def _lm_studio_context_limit(payload):
+    payload = payload if isinstance(payload, dict) else {}
+    configured = payload.get("lmstudio_context_limit")
+    if configured in (None, ""):
+        configured = payload.get("lm_studio_context_limit")
+    return _normalized_token_limit(configured, 32768, minimum=512)
+
+
+def _lm_studio_api_root(payload):
+    base_url = str(payload.get("lmstudio_base_url") or _LM_STUDIO_DEFAULT_BASE_URL).strip().rstrip("/")
+    if base_url.lower().endswith("/v1"):
+        return base_url[:-3].rstrip("/")
+    return base_url
+
+
+def _lm_studio_native_output_text(data):
+    output = data.get("output") if isinstance(data, dict) else None
+    if not isinstance(output, list):
+        return ""
+    parts = []
+    for item in output:
+        if not isinstance(item, dict) or str(item.get("type") or "").lower() != "message":
+            continue
+        content = item.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict):
+                    text = block.get("text") or block.get("content")
+                    if text:
+                        parts.append(str(text))
+    return "\n".join(part.strip() for part in parts if str(part or "").strip()).strip()
+
+
+def _run_lm_studio_native_chat(payload, input_value, temperature, top_p, max_new_tokens, timeout, label):
+    api_root = _lm_studio_api_root(payload)
+    model = str(payload.get("lmstudio_model") or payload.get("model_file") or "").strip()
+    api_key = str(payload.get("lmstudio_api_key") or "").strip()
+    if not api_root:
+        raise ValueError("LM Studio base URL is empty.")
+    if not model:
+        raise ValueError(f"Enter the LM Studio {label}model name shown in LM Studio.")
+    body = {
+        "model": model,
+        "input": input_value,
+        "temperature": float(temperature),
+        "top_p": float(top_p),
+        "context_length": _lm_studio_context_limit(payload),
+        "max_output_tokens": _runner_output_token_limit(payload, max_new_tokens),
+        "store": False,
+        "stream": False,
+    }
+    if payload.get("seed") is not None:
+        body["seed"] = int(payload.get("seed"))
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(
+        f"{api_root}/api/v1/chat",
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=float(timeout)) as response:
+            data = json.loads(response.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
+        if exc.code in {404, 405}:
+            raise RuntimeError(
+                "LM Studio's native /api/v1/chat endpoint is required to apply per-request context and output limits. "
+                "Update LM Studio and make sure its Local Server is running."
+            ) from exc
+        raise RuntimeError(f"LM Studio {label}request failed ({exc.code}): {details or exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Could not connect to LM Studio at {api_root}. Make sure LM Studio's local server is running.") from exc
+    text = _lm_studio_native_output_text(data)
+    if not text:
+        raise ValueError(f"LM Studio {label}returned empty text.")
+    return text
 
 
 def _resolve_mmproj_dropdown_path(llm, mmproj_file):
@@ -3314,50 +3425,15 @@ def _resolve_mmproj_dropdown_path(llm, mmproj_file):
 
 
 def _run_lm_studio_text(payload, instruction_text, temperature=0.6, top_p=0.95, max_new_tokens=1200):
-    base_url = str(payload.get("lmstudio_base_url") or _LM_STUDIO_DEFAULT_BASE_URL).strip().rstrip("/")
-    model = str(payload.get("lmstudio_model") or payload.get("model_file") or "").strip()
-    api_key = str(payload.get("lmstudio_api_key") or "").strip()
-    if not base_url:
-        raise ValueError("LM Studio base URL is empty.")
-    if not model:
-        raise ValueError("Enter the LM Studio model name shown in LM Studio.")
-    url = f"{base_url}/chat/completions"
-    body = {
-        "model": model,
-        "messages": [{"role": "user", "content": instruction_text}],
-        "temperature": float(temperature),
-        "top_p": float(top_p),
-        "max_tokens": int(max_new_tokens),
-        "stream": False,
-    }
-    if payload.get("seed") is not None:
-        body["seed"] = int(payload.get("seed"))
-    headers = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(body).encode("utf-8"),
-        headers=headers,
-        method="POST",
+    return _run_lm_studio_native_chat(
+        payload,
+        str(instruction_text or ""),
+        temperature,
+        top_p,
+        max_new_tokens,
+        payload.get("lmstudio_timeout") or 180,
+        "",
     )
-    try:
-        with urllib.request.urlopen(request, timeout=float(payload.get("lmstudio_timeout") or 180)) as response:
-            data = json.loads(response.read().decode("utf-8", errors="replace"))
-    except urllib.error.HTTPError as exc:
-        details = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
-        raise RuntimeError(f"LM Studio request failed ({exc.code}): {details or exc.reason}") from exc
-    except urllib.error.URLError as exc:
-        raise RuntimeError(f"Could not connect to LM Studio at {base_url}. Make sure LM Studio's local server is running.") from exc
-    choices = data.get("choices") if isinstance(data, dict) else None
-    if not choices:
-        raise ValueError("LM Studio returned no choices.")
-    message = choices[0].get("message") if isinstance(choices[0], dict) else {}
-    text = message.get("content") if isinstance(message, dict) else ""
-    text = str(text or "").strip()
-    if not text:
-        raise ValueError("LM Studio returned empty text.")
-    return text
 
 
 def _run_llm_api_text(payload, instruction_text):
@@ -3457,58 +3533,24 @@ def _pil_image_to_data_url(image, max_height=512, quality=88):
 
 
 def _run_lm_studio_vision(payload, instruction_text, pil_images, temperature=0.25, top_p=0.95, max_new_tokens=1200):
-    base_url = str(payload.get("lmstudio_base_url") or _LM_STUDIO_DEFAULT_BASE_URL).strip().rstrip("/")
-    model = str(payload.get("lmstudio_model") or payload.get("model_file") or "").strip()
-    api_key = str(payload.get("lmstudio_api_key") or "").strip()
-    if not base_url:
-        raise ValueError("LM Studio base URL is empty.")
-    if not model:
-        raise ValueError("Enter the LM Studio vision model name shown in LM Studio.")
     images = list(pil_images or [])
     if not images:
         raise ValueError("LM Studio vision needs at least one image.")
-    content = [{"type": "text", "text": instruction_text}]
+    content = [{"type": "message", "role": "user", "content": str(instruction_text or "")}]
     for image in images:
         content.append({
-            "type": "image_url",
-            "image_url": {"url": _pil_image_to_data_url(image)},
+            "type": "image",
+            "data_url": _pil_image_to_data_url(image),
         })
-    body = {
-        "model": model,
-        "messages": [{"role": "user", "content": content}],
-        "temperature": float(temperature),
-        "top_p": float(top_p),
-        "max_tokens": int(max_new_tokens),
-        "stream": False,
-    }
-    if payload.get("seed") is not None:
-        body["seed"] = int(payload.get("seed"))
-    headers = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    request = urllib.request.Request(
-        f"{base_url}/chat/completions",
-        data=json.dumps(body).encode("utf-8"),
-        headers=headers,
-        method="POST",
+    return _run_lm_studio_native_chat(
+        payload,
+        content,
+        temperature,
+        top_p,
+        max_new_tokens,
+        payload.get("lmstudio_timeout") or 300,
+        "vision ",
     )
-    try:
-        with urllib.request.urlopen(request, timeout=float(payload.get("lmstudio_timeout") or 300)) as response:
-            data = json.loads(response.read().decode("utf-8", errors="replace"))
-    except urllib.error.HTTPError as exc:
-        details = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
-        raise RuntimeError(f"LM Studio vision request failed ({exc.code}): {details or exc.reason}") from exc
-    except urllib.error.URLError as exc:
-        raise RuntimeError(f"Could not connect to LM Studio at {base_url}. Make sure LM Studio's local server is running.") from exc
-    choices = data.get("choices") if isinstance(data, dict) else None
-    if not choices:
-        raise ValueError("LM Studio vision returned no choices.")
-    message = choices[0].get("message") if isinstance(choices[0], dict) else {}
-    text = message.get("content") if isinstance(message, dict) else ""
-    text = str(text or "").strip()
-    if not text:
-        raise ValueError("LM Studio vision returned empty text.")
-    return text
 
 
 def _list_lm_studio_models(payload):
@@ -3934,6 +3976,7 @@ def _format_minimax_h3_prompt(text, payload=None, instruction_key=""):
 
 
 def _run_builder_text_llm(payload, instruction_text, temperature=0.6, top_p=0.95, max_new_tokens=1200, label="Gemma", preserve_paragraphs=False):
+    max_new_tokens = _runner_output_token_limit(payload, max_new_tokens)
     if _llm_runner_from_payload(payload) == "lm_studio":
         text = _run_lm_studio_text(
             payload,
@@ -5037,7 +5080,7 @@ def _generate_builder_t2i_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or (0.25 if has_ref_image else 0.6))
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or (1000 if has_ref_image else 1200))
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or (1000 if has_ref_image else 1200)))
     unload_after = bool(payload.get("unload_after", True))
     seed = payload.get("seed")
 
@@ -5215,7 +5258,7 @@ def _generate_builder_i2v_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or (0.25 if has_image_reference else 0.7))
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or 4000)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 4000))
     unload_after = bool(payload.get("unload_after", True))
     seed = payload.get("seed")
 
@@ -5569,7 +5612,7 @@ def _generate_builder_chained_i2v_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.9)
-    max_new_tokens = int(payload.get("max_new_tokens") or 1200)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 1200))
     unload_after = bool(payload.get("unload_after", True))
     seed = payload.get("seed")
 
@@ -5730,6 +5773,7 @@ def _generate_builder_t2v_prompt(payload):
     no_character_present = bool(payload.get("no_character_present") or payload.get("no_subject") or payload.get("no_visible_subject"))
     instruction_key = _safe_builder_instruction_key(payload.get("builder_instruction_key") or payload.get("instruction_key") or "t2v")
     is_minimax_h3_prompt = instruction_key.startswith("minimax_h3_")
+    prompt_only_scene_inspiration = bool(payload.get("prompt_only_scene_inspiration"))
     text_runner = _llm_runner_from_payload(payload)
     if not model_file and text_runner not in {"lm_studio", "llm_api"}:
         raise ValueError("Choose a T2V Gemma model first.")
@@ -5744,7 +5788,7 @@ def _generate_builder_t2v_prompt(payload):
         except Exception:
             image_references = [{"path": line.strip()} for line in image_references.splitlines() if line.strip()]
     if isinstance(image_references, list):
-        reference_limit = 9 if is_minimax_h3_prompt else 4
+        reference_limit = 10 if is_minimax_h3_prompt and prompt_only_scene_inspiration else 9 if is_minimax_h3_prompt else 4
         for index, item in enumerate(image_references[:reference_limit], start=1):
             if isinstance(item, str):
                 item = {"path": item}
@@ -5904,6 +5948,14 @@ def _generate_builder_t2v_prompt(payload):
             )
     elif has_image_reference and is_minimax_h3_prompt:
         image_guidance = (
+            "MiniMax H3 prompt-only scene-inspiration guidance:\n"
+            "- Attached <Picture 1> is vision input for prompt writing only. It is never supplied to the MiniMax renderer and must never appear as Image 1 or any Image N in the finished prompt.\n"
+            "- Follow the scene context's exact environment-only or environment-plus-framing extraction limits for <Picture 1>. Always ignore all character identity, appearance, clothing, body, pose, placement, and activity visible in it.\n"
+            "- Attached <Picture 2> corresponds to renderer Image 1, <Picture 3> to renderer Image 2, and so on. Inspect each renderer picture only for its assigned purpose.\n"
+            "- In the finished prompt, use only renderer Image N labels. Convert permitted observations from <Picture 1> into direct scene prose without mentioning pictures, inspiration, analysis, or source imagery.\n"
+            "- Do not merge a storyboard grid into a collage output; interpret its panels as ordered visual guidance.\n\n"
+            if prompt_only_scene_inspiration
+            else
             "MiniMax H3 ordered visual-reference guidance:\n"
             "- The attached pictures are in the exact <Picture 1>, <Picture 2>, and subsequent order stated in the scene context.\n"
             "- Inspect every attached picture and use it only for the purpose assigned to its matching tag.\n"
@@ -5938,7 +5990,7 @@ def _generate_builder_t2v_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.7)
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or 4000)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 4000))
     unload_after = bool(payload.get("unload_after", True))
 
     try:
@@ -6341,7 +6393,7 @@ def _edit_builder_video_prompt(payload):
 
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.9)
-    max_new_tokens = int(payload.get("max_new_tokens") or 1200)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 1200))
     unload_after = bool(payload.get("unload_after", True))
     n_ctx = int(payload.get("n_ctx") or 8000)
     n_gpu_layers = int(payload.get("n_gpu_layers") or 99)
@@ -6581,7 +6633,7 @@ def _edit_builder_image_prompt(payload):
 
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.9)
-    max_new_tokens = int(payload.get("max_new_tokens") or 1200)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 1200))
     unload_after = bool(payload.get("unload_after", True))
     n_ctx = int(payload.get("n_ctx") or 8000)
     n_gpu_layers = int(payload.get("n_gpu_layers") or 99)
@@ -6912,7 +6964,7 @@ def _generate_builder_reference_description(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.2)
     top_p = float(payload.get("top_p") or 0.9)
-    max_new_tokens = int(payload.get("max_new_tokens") or 180)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 180))
     seed = payload.get("seed")
     clear_before_load = bool(payload.get("clear_before_load", False))
     unload_after = bool(payload.get("unload_after", True))
@@ -7102,7 +7154,7 @@ def _generate_flux_klein_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or 350)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 350))
     seed = payload.get("seed")
     clear_before_load = bool(payload.get("clear_before_load", True))
     unload_after = bool(payload.get("unload_after", True))
@@ -7194,7 +7246,7 @@ def _analyze_builder_story_references(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or 500)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 500))
     unload_after = bool(payload.get("unload_after", True))
     try:
         model = None
@@ -7476,7 +7528,7 @@ def _generate_nb_image_prompt(payload):
     chat_format = str(payload.get("chat_format", "") or "").strip()
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.95)
-    max_new_tokens = int(payload.get("max_new_tokens") or 900)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 900))
     seed = payload.get("seed")
     clear_before_load = bool(payload.get("clear_before_load", True))
     unload_after = bool(payload.get("unload_after", True))
@@ -7668,7 +7720,7 @@ def _generate_flux_reference_location_map(payload):
 
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.8)
-    max_new_tokens = int(payload.get("max_new_tokens") or 5000)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 5000))
     text, run_info = _run_builder_text_llm(
         payload,
         instruction,
@@ -8175,7 +8227,7 @@ def _generate_flux_reference_zimage_prompt(payload):
 
     temperature = float(payload.get("temperature") or 0.25)
     top_p = float(payload.get("top_p") or 0.8)
-    max_new_tokens = int(payload.get("max_new_tokens") or 900)
+    max_new_tokens = _runner_output_token_limit(payload, int(payload.get("max_new_tokens") or 900))
 
     text, run_info = _run_builder_text_llm(
         payload,
@@ -8207,10 +8259,15 @@ def _gemma_choices():
 
 _MODEL_DEFAULT_KEYS = (
     "text_gemma_runner",
+    "llm_max_tokens",
     "gemma_context_limit",
+    "gemma_output_token_limit",
+    "gemma_gpu_layers",
     "lm_studio_base_url",
     "lm_studio_model",
     "lm_studio_api_key",
+    "lm_studio_context_limit",
+    "lm_studio_output_token_limit",
     "image_model_mode",
     "zimage_settings",
     "reference_krea2_settings",

--- a/VRGDG_MusicVideoPromptCreatorNodes.py
+++ b/VRGDG_MusicVideoPromptCreatorNodes.py
@@ -15,6 +15,7 @@ from .VRGDG_MusicVideoBuilderNodes import (
     _prompts_folder,
     _run_builder_text_llm,
     _llm_runner_from_payload,
+    _runner_output_token_limit,
     _safe_project_name,
     _session_path,
     _srt_path,
@@ -934,6 +935,8 @@ def _run_text_gemma(model_file, prompt, overrides=None, payload=None):
     settings = dict(_LLM_SETTINGS)
     if isinstance(overrides, dict):
         settings.update({key: value for key, value in overrides.items() if value not in (None, "")})
+    settings["n_ctx"] = int(runner_payload.get("n_ctx") or runner_payload.get("gemma_context_limit") or settings["n_ctx"])
+    settings["max_new_tokens"] = _runner_output_token_limit(runner_payload, settings["max_new_tokens"])
 
     llm = VRGDG_SuperGemmaGGUFChat()
     model_path = llm._resolve_dropdown_path(str(model_file), llm.MISSING_MODEL_OPTION)
@@ -1000,6 +1003,8 @@ def _run_text_gemma_custom(model_file, custom_instructions, user_input, override
     settings = dict(_LLM_SETTINGS)
     if isinstance(overrides, dict):
         settings.update({key: value for key, value in overrides.items() if value not in (None, "")})
+    settings["n_ctx"] = int(runner_payload.get("n_ctx") or runner_payload.get("gemma_context_limit") or settings["n_ctx"])
+    settings["max_new_tokens"] = _runner_output_token_limit(runner_payload, settings["max_new_tokens"])
 
     llm = VRGDG_SuperGemmaGGUFChat()
     text, used_model, status = llm.generate_prompt(
@@ -1476,9 +1481,13 @@ def _save_prompt_creator_draft(payload):
         "append_subject_to_prompts": _payload_bool(payload.get("append_subject_to_prompts", True), True),
         "repair_lyric_segments": _payload_bool(payload.get("repair_lyric_segments", False), False),
         "text_gemma_runner": str(payload.get("text_gemma_runner") or payload.get("text_runner") or "builtin"),
+        "gemma_context_limit": payload.get("gemma_context_limit", payload.get("n_ctx", payload.get("llm_max_tokens", 8000))),
+        "gemma_output_token_limit": payload.get("gemma_output_token_limit", payload.get("llm_max_tokens", 8192)),
         "lm_studio_base_url": str(payload.get("lm_studio_base_url") or payload.get("lmstudio_base_url") or "http://127.0.0.1:1234/v1"),
         "lm_studio_model": str(payload.get("lm_studio_model") or payload.get("lmstudio_model") or ""),
         "lm_studio_api_key": "",
+        "lm_studio_context_limit": payload.get("lm_studio_context_limit", payload.get("lmstudio_context_limit", 32768)),
+        "lm_studio_output_token_limit": payload.get("lm_studio_output_token_limit", payload.get("lmstudio_output_token_limit", payload.get("llm_max_tokens", 8192))),
         "llm_api_provider": str(payload.get("llm_api_provider") or "openai"),
         "llm_api_model": str(payload.get("llm_api_model") or ""),
         "full_lyrics": str(payload.get("full_lyrics", "") or ""),

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -2475,6 +2475,93 @@ def _patch_minimax_h3_advanced_settings(prompt, payload):
     }
 
 
+def _patch_minimax_h3_turbo(prompt, payload):
+    enabled = _bool_payload(payload, "use_turbo_lora", False)
+    if not enabled:
+        return {
+            "enabled": False,
+            "lora_name": "",
+            "strength": 0.0,
+            "scheduler": "",
+            "steps": 0,
+        }
+
+    try:
+        import nodes as comfy_nodes
+        mappings = getattr(comfy_nodes, "NODE_CLASS_MAPPINGS", {}) or {}
+    except Exception as exc:
+        raise ValueError(
+            "MiniMax-H3 Turbo could not inspect ComfyUI custom-node registrations. "
+            "Restart ComfyUI after installing ComfyUI-MiniMax-H3-Turbo."
+        ) from exc
+    required_nodes = ("MiniMaxH3TurboLoRA", "MiniMaxH3TurboSampler")
+    missing_nodes = [name for name in required_nodes if name not in mappings]
+    if missing_nodes:
+        raise ValueError(
+            "MiniMax-H3 Turbo is enabled, but the required custom nodes are not registered: "
+            + ", ".join(missing_nodes)
+            + ". Install or update ComfyUI-MiniMax-H3-Turbo, then restart ComfyUI."
+        )
+
+    lora_name = str(
+        payload.get("turbo_lora_name") or "minimax_h3_turbo_4step_ema_ckpt850.safetensors"
+    ).strip()
+    if not lora_name:
+        raise ValueError("MiniMax-H3 Turbo is enabled, but no Turbo LoRA file is selected.")
+    if not _model_choice_exists("loras", lora_name):
+        raise ValueError(
+            f"MiniMax-H3 Turbo LoRA '{lora_name}' was not found in ComfyUI/models/loras. "
+            "Download the LoRA, refresh/restart ComfyUI, and select it in MiniMax Video Settings."
+        )
+    strength = _float_payload(payload, "turbo_lora_strength", 1.0, -10.0, 10.0)
+    turbo_steps = _int_payload(payload, "steps", 6, 4, 1000)
+
+    scheduler_id = _api_node_id_by_class(prompt, "BasicScheduler", fallback="124")
+    guider_id = _api_node_id_by_class(prompt, "BasicGuider", fallback="126")
+    sampler_advanced_id = _api_node_id_by_class(prompt, "SamplerCustomAdvanced", fallback="125")
+    stock_sampler_id = _optional_api_node_id_by_class(prompt, "KSamplerSelect", fallback_ids=("123",))
+    scheduler_inputs = prompt.get(scheduler_id, {}).get("inputs", {})
+    model_ref = scheduler_inputs.get("model")
+    if not isinstance(model_ref, list) or len(model_ref) != 2:
+        raise ValueError("MiniMax-H3 Turbo could not find the current model connection feeding BasicScheduler.")
+
+    turbo_lora_id = "9001"
+    while turbo_lora_id in prompt:
+        turbo_lora_id = str(int(turbo_lora_id) + 1)
+    turbo_sampler_id = str(int(turbo_lora_id) + 1)
+    while turbo_sampler_id in prompt:
+        turbo_sampler_id = str(int(turbo_sampler_id) + 1)
+    prompt[turbo_lora_id] = {
+        "class_type": "VRGDG_MiniMaxH3TurboLoRACompat",
+        "inputs": {
+            "model": list(model_ref),
+            "lora_name": lora_name,
+            "strength": strength,
+        },
+    }
+    prompt[turbo_sampler_id] = {
+        "class_type": "MiniMaxH3TurboSampler",
+        "inputs": {},
+    }
+    _set_api_input(prompt, scheduler_id, "model", [turbo_lora_id, 0])
+    _set_api_input(prompt, scheduler_id, "scheduler", "simple")
+    _set_api_input(prompt, scheduler_id, "steps", turbo_steps)
+    _set_api_input(prompt, guider_id, "model", [turbo_lora_id, 0])
+    _set_api_input(prompt, sampler_advanced_id, "sampler", [turbo_sampler_id, 0])
+    if stock_sampler_id:
+        prompt.pop(stock_sampler_id, None)
+
+    return {
+        "enabled": True,
+        "lora_name": lora_name,
+        "strength": strength,
+        "scheduler": "simple",
+        "steps": turbo_steps,
+        "lora_node": "VRGDG_MiniMaxH3TurboLoRACompat",
+        "sampler_node": "MiniMaxH3TurboSampler",
+    }
+
+
 def _build_minimax_h3_api_prompt(payload):
     raw_audio_mode = str(payload.get("audio_mode") or payload.get("audioMode") or "input_audio").strip().lower().replace("-", "_").replace(" ", "_")
     audio_mode = "built_in_audio" if raw_audio_mode in {"built_in_audio", "native_audio", "generated_audio"} else "input_audio"
@@ -2613,6 +2700,14 @@ def _build_minimax_h3_api_prompt(payload):
     # exact scene trimmer receives them.
     _set_api_input(prompt, "142", "trim_to_audio", False)
     advanced_settings = _patch_minimax_h3_advanced_settings(prompt, payload)
+    turbo_settings = _patch_minimax_h3_turbo(prompt, payload)
+    if turbo_settings["enabled"]:
+        advanced_settings = {
+            **advanced_settings,
+            "effective_sampler_name": "MiniMaxH3TurboSampler",
+            "effective_scheduler": "simple",
+            "effective_steps": turbo_settings["steps"],
+        }
 
     return {
         "workflow_path": workflow_path,
@@ -2638,6 +2733,7 @@ def _build_minimax_h3_api_prompt(payload):
             "audio_vae_name": audio_vae_name,
         },
         "advanced_settings": advanced_settings,
+        "turbo_settings": turbo_settings,
     }
 
 
@@ -4380,6 +4476,175 @@ def _ensure_workflow_runner_routes():
     _VRGDG_WORKFLOW_RUNNER_ROUTES_REGISTERED = True
 
 
+class VRGDG_MiniMaxH3TurboLoRACompat:
+    """Apply the upstream Turbo LoRA with its missing pruned Ref2VA audio-row fix.
+
+    The upstream v1.2.1 adapter derives only video/audio and visual-reference
+    time rows for pruned MiniMax checkpoints. Reference audio adds another row
+    in ComfyUI core, causing AdaLN's base projection to have three rows while
+    the LoRA delta has two. Delegate whenever upstream includes audio-row
+    support; otherwise reproduce its pruned path with the complete core layout.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "lora_name": (folder_paths.get_filename_list("loras"),),
+                "strength": (
+                    "FLOAT",
+                    {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "apply_lora"
+    CATEGORY = "VRGDG/Compatibility"
+    DESCRIPTION = (
+        "MiniMax-H3 Turbo LoRA adapter with pruned-model reference-audio "
+        "conditioning compatibility."
+    )
+
+    @staticmethod
+    def _condition_times(upstream, timestep, payload, shift_v, shift_a):
+        sigma_v = float((timestep.flatten()[0] / 1000.0).clamp(min=1e-6))
+        t_video = 1.0 - sigma_v
+        t_audio = 1.0 - upstream._time_shift_sigma(sigma_v, shift_v, shift_a)
+        layout = payload.get("layout")
+        if layout is not None:
+            segments = getattr(layout, "segments", ()) or ()
+            has_visual_condition = any(
+                kind in ("cond", "ref_img") for _, _, kind in segments
+            )
+            has_audio_condition = any(
+                kind == "ref_audio" for _, _, kind in segments
+            )
+        else:
+            refs = payload.get("refs") or ()
+            ref_kinds = {
+                str(item.get("kind") or "")
+                for item in refs
+                if isinstance(item, dict)
+            }
+            has_visual_condition = bool(payload.get("keyframes")) or bool(
+                ref_kinds.intersection({"image", "video", "video_audio"})
+            )
+            has_audio_condition = bool(
+                ref_kinds.intersection({"audio", "video_audio"})
+            )
+        visual_aug = float(payload.get("visual_cond_noise_aug", 0.999))
+        audio_aug = float(payload.get("audio_cond_noise_aug", 1.0))
+        times = {t_video, t_audio}
+        if has_visual_condition:
+            times.add(max(t_video, visual_aug))
+        if has_audio_condition:
+            times.add(max(t_audio, audio_aug))
+        return sorted(times)
+
+    def apply_lora(self, model, lora_name, strength):
+        import inspect
+        import nodes as comfy_nodes
+
+        upstream_class = (getattr(comfy_nodes, "NODE_CLASS_MAPPINGS", {}) or {}).get(
+            "MiniMaxH3TurboLoRA"
+        )
+        if upstream_class is None:
+            raise RuntimeError(
+                "MiniMaxH3TurboLoRA is not registered. Install or update "
+                "ComfyUI-MiniMax-H3-Turbo, then restart ComfyUI."
+            )
+        upstream = sys.modules.get(upstream_class.__module__)
+        if upstream is None:
+            upstream = importlib.import_module(upstream_class.__module__)
+        upstream_node = upstream_class()
+        unique_t = getattr(upstream, "_unique_t", None)
+        upstream_supports_audio = False
+        if callable(unique_t):
+            try:
+                upstream_supports_audio = "has_aud_cond" in inspect.signature(unique_t).parameters
+            except (TypeError, ValueError):
+                upstream_supports_audio = False
+
+        diffusion_model = model.model.diffusion_model
+        pruned = bool(getattr(diffusion_model, "use_adaln_curves", False))
+        if not pruned or upstream_supports_audio:
+            return upstream_node.apply_lora(model, lora_name, strength)
+
+        required_helpers = (
+            "_apply_bypass_lora",
+            "_egrid",
+            "_interp_egrid",
+            "_AdalnDelta",
+            "_add_dbg_wrapper",
+            "_time_shift_sigma",
+        )
+        missing_helpers = [name for name in required_helpers if not hasattr(upstream, name)]
+        if missing_helpers:
+            raise RuntimeError(
+                "The installed ComfyUI-MiniMax-H3-Turbo version is incompatible "
+                "with Builder reference-audio support. Missing helpers: "
+                + ", ".join(missing_helpers)
+                + ". Update the Turbo extension and restart ComfyUI."
+            )
+
+        lora_path = folder_paths.get_full_path("loras", lora_name)
+        if not lora_path:
+            raise RuntimeError(f"MiniMax-H3 Turbo LoRA was not found: {lora_name}")
+        lora = upstream.comfy.utils.load_torch_file(lora_path, safe_load=True)
+        modules = sorted({key.rsplit(".lora_", 1)[0] for key in lora})
+        new_model = model.clone()
+        backbone = [name for name in modules if "adaln_proj" not in name]
+        adaln = [name for name in modules if "adaln_proj" in name]
+        bound = upstream._apply_bypass_lora(new_model, lora, backbone, strength)
+
+        embedding_grid = upstream._egrid()
+        shared = {"silu_temb": None}
+        shift_v = float(getattr(diffusion_model, "sigma_shift_video", upstream.SHIFT_V))
+        shift_a = float(getattr(diffusion_model, "sigma_shift_audio", upstream.SHIFT_A))
+
+        def wrap(executor, *args, **kwargs):
+            timestep = args[1] if len(args) > 1 else kwargs.get("timestep")
+            context = args[2] if len(args) > 2 else kwargs.get("context")
+            payload = kwargs.get("minimax_payload") or {}
+            times = self._condition_times(upstream, timestep, payload, shift_v, shift_a)
+            shared["silu_temb"] = upstream._interp_egrid(
+                times,
+                embedding_grid,
+                context.device,
+                context.dtype,
+            )
+            return executor(*args, **kwargs)
+
+        new_model.add_wrapper_with_key(
+            upstream.comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+            "vrgdg_h3turbo_ref_audio",
+            wrap,
+        )
+        for name in adaln:
+            lora_a = lora[name + ".lora_A.weight"]
+            lora_b = lora[name + ".lora_B.weight"] * strength
+            model_key = "diffusion_model." + name.rsplit(".linear", 1)[0]
+            new_model.add_object_patch(
+                model_key,
+                upstream._AdalnDelta(
+                    new_model.get_model_object(model_key),
+                    lora_a,
+                    lora_b,
+                    shared,
+                ),
+            )
+        print(
+            "[VRGDG MiniMaxH3TurboLoRACompat] pruned base: "
+            f"{bound} backbone adapters + {len(adaln)} AdaLN adapters; "
+            "reference-audio time rows enabled",
+            flush=True,
+        )
+        upstream._add_dbg_wrapper(new_model, diffusion_model, "pruned-ref-audio-compat")
+        return (new_model,)
+
+
 class VRGDG_ZImageWorkflowRunnerUI:
     @classmethod
     def INPUT_TYPES(cls):
@@ -4438,11 +4703,13 @@ _ensure_workflow_runner_routes()
 
 
 NODE_CLASS_MAPPINGS = {
+    "VRGDG_MiniMaxH3TurboLoRACompat": VRGDG_MiniMaxH3TurboLoRACompat,
     "VRGDG_ZImageWorkflowRunnerUI": VRGDG_ZImageWorkflowRunnerUI,
     "VRGDG_ClearMemoryButtonUI": VRGDG_ClearMemoryButtonUI,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
+    "VRGDG_MiniMaxH3TurboLoRACompat": "VRGDG MiniMax-H3 Turbo LoRA Compatibility",
     "VRGDG_ZImageWorkflowRunnerUI": "VRGDG Z-Image Workflow Runner UI",
     "VRGDG_ClearMemoryButtonUI": "VRGDG Clear Memory Button",
 }

--- a/tests/test_builder_llm_runner_token_limits.py
+++ b/tests/test_builder_llm_runner_token_limits.py
@@ -1,0 +1,143 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_UI = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+PROMPT_CREATOR_UI = (ROOT / "web" / "VRGDG_MusicVideoPromptCreatorUI.js").read_text(encoding="utf-8")
+BUILDER_BACKEND = (ROOT / "VRGDG_MusicVideoBuilderNodes.py").read_text(encoding="utf-8")
+PROMPT_CREATOR_BACKEND = (ROOT / "VRGDG_MusicVideoPromptCreatorNodes.py").read_text(encoding="utf-8")
+
+
+def load_token_helpers():
+    wanted = {
+        "_llm_runner_from_payload",
+        "_normalized_token_limit",
+        "_runner_output_token_limit",
+        "_lm_studio_context_limit",
+        "_lm_studio_api_root",
+        "_lm_studio_native_output_text",
+    }
+    tree = ast.parse(BUILDER_BACKEND)
+    nodes = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
+            nodes.append(node)
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "_LM_STUDIO_DEFAULT_BASE_URL"
+            for target in node.targets
+        ):
+            nodes.append(node)
+    namespace = {}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), "token_helpers", "exec"), namespace)
+    return namespace
+
+
+TOKEN_HELPERS = load_token_helpers()
+
+
+class BuilderLlmRunnerTokenLimitTests(unittest.TestCase):
+    def test_runner_modal_exposes_requested_limits(self):
+        self.assertIn('makeField("Context limit / n_ctx", gemmaContextLimit)', BUILDER_UI)
+        self.assertIn('makeField("Maximum output tokens", gemmaOutputTokenLimit)', BUILDER_UI)
+        self.assertIn('makeField("Input context limit", lmStudioContextLimit)', BUILDER_UI)
+        self.assertIn('makeField("Maximum output tokens", lmStudioOutputTokenLimit)', BUILDER_UI)
+
+    def test_limits_reach_runner_payload_and_persist(self):
+        for key in (
+            "gemma_output_token_limit",
+            "lmstudio_context_limit",
+            "lmstudio_output_token_limit",
+            "lm_studio_context_limit",
+            "lm_studio_output_token_limit",
+        ):
+            self.assertIn(key, BUILDER_UI)
+        self.assertIn('"gemma_output_token_limit"', BUILDER_BACKEND)
+        self.assertIn('"lm_studio_context_limit"', BUILDER_BACKEND)
+        self.assertIn('"lm_studio_output_token_limit"', BUILDER_BACKEND)
+
+    def test_backend_replaces_direct_per_task_caps(self):
+        self.assertIn(
+            "max_new_tokens = _runner_output_token_limit(payload, max_new_tokens)",
+            BUILDER_BACKEND,
+        )
+        self.assertGreaterEqual(
+            BUILDER_BACKEND.count("max_new_tokens = _runner_output_token_limit"),
+            13,
+        )
+
+    def test_lm_studio_receives_context_and_output_limits(self):
+        self.assertIn('f"{api_root}/api/v1/chat"', BUILDER_BACKEND)
+        self.assertIn('"context_length": _lm_studio_context_limit(payload)', BUILDER_BACKEND)
+        self.assertIn('"max_output_tokens": _runner_output_token_limit(payload, max_new_tokens)', BUILDER_BACKEND)
+        self.assertIn('"type": "image",', BUILDER_BACKEND)
+
+    def test_configured_limits_override_old_task_defaults(self):
+        output_limit = TOKEN_HELPERS["_runner_output_token_limit"]
+        context_limit = TOKEN_HELPERS["_lm_studio_context_limit"]
+        self.assertEqual(
+            64000,
+            output_limit(
+                {"text_runner": "builtin", "gemma_output_token_limit": 64000},
+                180,
+            ),
+        )
+        self.assertEqual(
+            48000,
+            output_limit(
+                {"text_runner": "lm_studio", "lmstudio_output_token_limit": 48000},
+                500,
+            ),
+        )
+        self.assertEqual(
+            65536,
+            context_limit({"lmstudio_context_limit": 65536}),
+        )
+
+    def test_pr_114_legacy_limit_migrates_but_api_runner_ignores_it(self):
+        output_limit = TOKEN_HELPERS["_runner_output_token_limit"]
+        self.assertEqual(
+            12000,
+            output_limit({"text_runner": "builtin", "llm_max_tokens": 12000}, 180),
+        )
+        self.assertEqual(
+            12000,
+            output_limit({"text_runner": "lm_studio", "llm_max_tokens": 12000}, 500),
+        )
+        self.assertEqual(
+            500,
+            output_limit(
+                {
+                    "text_runner": "llm_api",
+                    "llm_max_tokens": 12000,
+                    "gemma_output_token_limit": 16000,
+                    "lmstudio_output_token_limit": 24000,
+                },
+                500,
+            ),
+        )
+        self.assertIn("legacyLlmMaxTokens", BUILDER_UI)
+        self.assertIn("data.session.llm_max_tokens", BUILDER_UI)
+
+    def test_runner_labels_only_force_builtin_for_the_actual_local_only_draft(self):
+        self.assertEqual(1, BUILDER_UI.count("forceBuiltin: true"))
+        self.assertIn(
+            'progress.set(`Creating draft from your notes...\\n${gemmaRunnerLine({ forceBuiltin: true })}`',
+            BUILDER_UI,
+        )
+        self.assertIn(
+            'gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit)',
+            BUILDER_UI,
+        )
+
+    def test_prompt_creator_preserves_and_uses_runner_limits(self):
+        self.assertIn("gemma_output_token_limit", PROMPT_CREATOR_UI)
+        self.assertIn("lmstudio_context_limit", PROMPT_CREATOR_UI)
+        self.assertIn("lmstudio_output_token_limit", PROMPT_CREATOR_UI)
+        self.assertIn("_runner_output_token_limit", PROMPT_CREATOR_BACKEND)
+        self.assertIn('runner_payload.get("gemma_context_limit")', PROMPT_CREATOR_BACKEND)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_cut_frequency.py
+++ b/tests/test_builder_minimax_cut_frequency.py
@@ -1,0 +1,95 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STORYBOARD_SOURCE = (ROOT / "web" / "VRGDG_StoryboardBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+INSTRUCTION_SOURCE = (ROOT / "VRGDG_MiniMaxH3PromptInstructions.py").read_text(
+    encoding="utf-8"
+)
+
+
+class BuilderMiniMaxCutFrequencyTests(unittest.TestCase):
+    def test_scene_defaults_exposes_minimax_only_zero_to_ten_slider(self):
+        self.assertIn('cutFrequencyLabel.textContent = "Cut frequency"', STORYBOARD_SOURCE)
+        self.assertIn('cutFrequencyInput.min = "0"', STORYBOARD_SOURCE)
+        self.assertIn('cutFrequencyInput.max = "10"', STORYBOARD_SOURCE)
+        self.assertIn(
+            'const cutFrequencyEligible = isVideoPrepMode && state.projectVideoEngine === "minimax_h3"',
+            STORYBOARD_SOURCE,
+        )
+
+    def test_cut_plan_scales_against_exact_segment_duration(self):
+        self.assertIn(
+            "export function storyboardCutPlanForDuration(durationValue, frequencyValue)",
+            STORYBOARD_SOURCE,
+        )
+        self.assertIn(
+            "const maximumCuts = Math.max(0, Math.ceil(Math.max(0, duration - 0.000001)) - 1)",
+            STORYBOARD_SOURCE,
+        )
+        self.assertIn(
+            "frequency >= 10\n      ? maximumCuts",
+            STORYBOARD_SOURCE,
+        )
+        self.assertIn(
+            "Array.from({ length: cutCount }, (_, index) => index + 1)",
+            STORYBOARD_SOURCE,
+        )
+
+    def test_zero_is_continuous_and_active_plans_require_explicit_cut_to(self):
+        self.assertIn(
+            "Use one smooth, continuous, uninterrupted shot",
+            STORYBOARD_SOURCE,
+        )
+        self.assertIn(
+            "write an explicit new timestamp block beginning with CUT TO:",
+            STORYBOARD_SOURCE,
+        )
+
+    def test_saved_default_reaches_all_minimax_prompt_creation_paths(self):
+        self.assertIn(
+            "minimax_h3_cut_frequency: cutFrequency",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "const cutPlan = storyboardCutPlanForDuration(duration, state.builderStoryboardDefaults?.minimax_h3_cut_frequency)",
+            BUILDER_SOURCE,
+        )
+        self.assertIn("cutPlan.instruction,", BUILDER_SOURCE)
+        self.assertIn(
+            "cut_plan: cutPlan",
+            BUILDER_SOURCE,
+        )
+
+    def test_permanent_minimax_instructions_make_cut_plan_authoritative(self):
+        self.assertIn("EDITING / CUT PLAN AUTHORITY", INSTRUCTION_SOURCE)
+        self.assertIn(
+            "It overrides TIMELINE DENSITY",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "never write `CUT TO:`",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "begin its visual description with the literal words `CUT TO:`",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "Do not omit, merge, add, or shift a scheduled cut.",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "A supplied `EDITING / CUT PLAN — MANDATORY` contract is also locked",
+            INSTRUCTION_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_start_frame_character_influence.py
+++ b/tests/test_builder_minimax_start_frame_character_influence.py
@@ -1,0 +1,198 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+INSTRUCTION_SOURCE = (ROOT / "VRGDG_MiniMaxH3PromptInstructions.py").read_text(
+    encoding="utf-8"
+)
+NODE_SOURCE = (ROOT / "VRGDG_MusicVideoBuilderNodes.py").read_text(
+    encoding="utf-8"
+)
+
+
+class BuilderMiniMaxStartFrameCharacterInfluenceTests(unittest.TestCase):
+    def test_reference_to_video_exposes_saved_character_influence_dropdown(self):
+        self.assertIn(
+            'label: "Face + hair only (keep the rest of the start frame)"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'label: "Full character identity (face, hair, clothing, and body)"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "segment.minimax_h3_start_frame_character_influence = normalizeMiniMaxH3StartFrameCharacterInfluence(",
+            BUILDER_SOURCE,
+        )
+
+    def test_scene_image_use_and_influence_apply_to_all_eligible_scenes(self):
+        self.assertIn(
+            'label: "Environment inspiration only (LLM only — ignore framing)"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'label: "Environment + framing inspiration (LLM only)"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'miniMaxH3ModeForSegment(item) === "reference_to_video"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "item.minimax_h3_scene_image_use = sceneImageUse;",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Skipped ${blocked.length} scene",
+            BUILDER_SOURCE,
+        )
+
+    def test_global_start_frame_controls_never_change_locked_scenes(self):
+        self.assertIn(
+            "const sceneLocked = Boolean(segment.use_scene_minimax_h3_settings);",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "&& (sceneLocked || !item.use_scene_minimax_h3_settings)",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            '"Scene image use — this locked scene"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            '"Character reference influence — this locked scene"',
+            BUILDER_SOURCE,
+        )
+
+    def test_environment_only_contract_ignores_framing_and_all_character_details(self):
+        self.assertIn(
+            '"PROMPT-ONLY SCENE-IMAGE INSPIRATION — MANDATORY:\\n"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Explicitly ignore camera framing and shot distance, camera angle and lens, and image composition.",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Always ignore every visible character's identity, face, hair, body, clothing, accessories, pose, placement, and activity",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "assigned character-reference images are the sole visual authority",
+            INSTRUCTION_SOURCE,
+        )
+
+    def test_prompt_only_scene_image_is_vision_first_but_not_a_renderer_reference(self):
+        self.assertIn(
+            "return path || data ? [{ path, data, prompt_only_scene_inspiration: true }, ...rendererImages] : rendererImages;",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Attached Picture 1 is shown only to the prompt-writing vision LLM. It is NOT supplied to the MiniMax H3 renderer",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Renderer Image 1 is attached as Picture 2",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(segment)",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'reference_limit = 10 if is_minimax_h3_prompt and prompt_only_scene_inspiration else 9 if is_minimax_h3_prompt else 4',
+            NODE_SOURCE,
+        )
+        self.assertIn(
+            "Attached <Picture 1> is vision input for prompt writing only.",
+            NODE_SOURCE,
+        )
+
+    def test_legacy_checkbox_state_migrates_to_exact_start_frame(self):
+        self.assertIn(
+            "normalizeMiniMaxH3SceneImageUse(\n      segment.minimax_h3_scene_image_use,\n      Boolean(segment.minimax_h3_use_scene_image_as_start_frame)",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'segment.minimax_h3_use_scene_image_as_start_frame = segment.minimax_h3_scene_image_use === "exact_start_frame";',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "!item?.use_scene_minimax_h3_settings\n        && miniMaxH3ContinuityModeForSegment(item)",
+            BUILDER_SOURCE,
+        )
+
+    def test_face_hair_mode_changes_ordered_media_assignments(self):
+        self.assertIn(
+            '"exact start frame and authority for every visible detail except face identity and hair"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            '"face identity and hair reference only; do not copy clothing, body proportions, pose, accessories, framing, lighting, or background"',
+            BUILDER_SOURCE,
+        )
+
+    def test_llm_context_receives_strict_first_frame_priority_contract(self):
+        self.assertIn(
+            '"START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY:\\n"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Character-reference images may override Image 1 ONLY for the subject's face identity, facial features, and hair.",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "The literal first generated frame must already depict the character-reference face and hair",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "never describe or show a face swap, replacement process, morph, transition, or transformation",
+            BUILDER_SOURCE,
+        )
+
+    def test_permanent_reference_to_video_instructions_enforce_selected_scope(self):
+        self.assertIn(
+            "obey the supplied `START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY` contract exactly",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "Character-reference images are authoritative ONLY for face identity, facial features, and hair.",
+            INSTRUCTION_SOURCE,
+        )
+        self.assertIn(
+            "never import the character reference's clothing, body, pose, accessories, framing, lighting, or background",
+            INSTRUCTION_SOURCE,
+        )
+
+    def test_managed_subject_count_block_respects_face_hair_only_scope(self):
+        self.assertIn(
+            'use those views ONLY to learn that one person\'s face identity, facial features, and hair.',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Image 1 remains authoritative for clothing, body proportions, pose, accessories, framing, lighting, and background.",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "Extract only the character properties granted by its ordered assignment",
+            INSTRUCTION_SOURCE,
+        )
+
+    def test_prompt_guidance_avoids_implied_on_screen_replacement(self):
+        self.assertIn(
+            "Do not use temporal comparison language such as 'now featuring,' 'becomes,' 'changes into,' or 'replaced by'",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "do not use temporal comparison language such as `now featuring`, `becomes`, `changes into`, or `replaced by`",
+            INSTRUCTION_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_turbo.py
+++ b/tests/test_builder_minimax_turbo.py
@@ -1,0 +1,173 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+RUNNER_SOURCE = (ROOT / "VRGDG_WorkflowRunnerNodes.py").read_text(
+    encoding="utf-8"
+)
+
+
+class BuilderMiniMaxTurboTests(unittest.TestCase):
+    def test_video_settings_exposes_turbo_checkbox_picker_and_strength(self):
+        self.assertIn(
+            'makeCheckbox("Use MiniMax-H3 Turbo LoRA (4-step)"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'turbo_lora_name: "minimax_h3_turbo_4step_ema_ckpt850.safetensors"',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'const miniMaxTurboSection = makeSettingsSection("Turbo acceleration"',
+            BUILDER_SOURCE,
+        )
+
+    def test_turbo_settings_follow_existing_global_or_locked_scene_settings(self):
+        self.assertIn(
+            "use_turbo_lora: turboEnabled",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "turbo_lora_name: miniMaxTurboLoraPicker.input.value",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "turbo_lora_strength: miniMaxTurboLoraStrength.value",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "if (segment?.use_scene_minimax_h3_settings)",
+            BUILDER_SOURCE,
+        )
+
+    def test_render_payload_sends_turbo_settings_to_hidden_workflow_builder(self):
+        self.assertIn(
+            "use_turbo_lora: miniMaxSettings.use_turbo_lora",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "turbo_lora_name: miniMaxSettings.turbo_lora_name",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "turbo_lora_strength: miniMaxSettings.turbo_lora_strength",
+            BUILDER_SOURCE,
+        )
+
+    def test_hidden_api_graph_injects_both_required_custom_nodes(self):
+        self.assertIn(
+            '"class_type": "VRGDG_MiniMaxH3TurboLoRACompat"',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '"class_type": "MiniMaxH3TurboSampler"',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '_set_api_input(prompt, guider_id, "model", [turbo_lora_id, 0])',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '_set_api_input(prompt, scheduler_id, "model", [turbo_lora_id, 0])',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '_set_api_input(prompt, sampler_advanced_id, "sampler", [turbo_sampler_id, 0])',
+            RUNNER_SOURCE,
+        )
+
+    def test_pruned_reference_audio_uses_layout_aware_compatibility_adapter(self):
+        self.assertIn(
+            'class VRGDG_MiniMaxH3TurboLoRACompat:',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            'kind == "ref_audio" for _, _, kind in segments',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            'times.add(max(t_audio, audio_aug))',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            'upstream_supports_audio = "has_aud_cond" in inspect.signature(unique_t).parameters',
+            RUNNER_SOURCE,
+        )
+
+    def test_turbo_forces_required_sampler_but_allows_four_or_more_steps(self):
+        self.assertIn(
+            '_set_api_input(prompt, scheduler_id, "scheduler", "simple")',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            'turbo_steps = _int_payload(payload, "steps", 6, 4, 1000)',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '_set_api_input(prompt, scheduler_id, "steps", turbo_steps)',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '"effective_sampler_name": "MiniMaxH3TurboSampler"',
+            RUNNER_SOURCE,
+        )
+
+    def test_turbo_ui_keeps_steps_and_easy_cache_available(self):
+        self.assertIn(
+            'miniMaxSteps.disabled = false;',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'miniMaxSteps.min = settings.use_turbo_lora ? "4" : "1";',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "EasyCache bypass is enabled automatically",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'miniMaxSteps.value = "6";',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "currentSettings.steps_before_turbo",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "migrateOldTurboDefault ? 6 : rawSteps",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "miniMaxEasyCacheBypass.input.checked = true;",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "currentSettings.easy_cache_bypass_before_turbo",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "settings.use_turbo_lora && !sceneHasPreTurboEasyCache",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'model_ref = scheduler_inputs.get("model")',
+            RUNNER_SOURCE,
+        )
+
+    def test_missing_extension_or_lora_produces_actionable_error(self):
+        self.assertIn(
+            "Install or update ComfyUI-MiniMax-H3-Turbo, then restart ComfyUI.",
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            "was not found in ComfyUI/models/loras",
+            RUNNER_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -15,6 +15,10 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
         release = UPDATE_NOTES["releases"][0]
         self.assertEqual(
             release["id"],
+            "2026-08-06-minimax-turbo-reference-llm-controls",
+        )
+        self.assertEqual(
+            UPDATE_NOTES["releases"][1]["id"],
             "2026-08-06-timeline-editing-minimax-prompt-reliability",
         )
         items = "\n".join(
@@ -23,21 +27,44 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
             for item in section.get("items", [])
         )
         for expected in (
-            "LTX video prompt",
-            "silent timeline playback",
-            "playhead trimming",
-            "Delete ALL Videos",
-            "complete saved right-panel prompt",
+            "6 editable steps",
+            "automatically bypasses EasyCache",
+            "environment inspiration",
+            "Face + hair only",
+            "Cut frequency",
+            "maximum-output controls",
+            "AI Video Builder product name",
+            "3-versus-2 AdaLN tensor mismatch",
+            "Video Wizard button",
         ):
             self.assertIn(expected, items)
 
     def test_banner_uses_the_ai_video_builder_name(self):
+        self.assertNotIn("LTX 2.3 Video Builder", BUILDER_SOURCE)
+        self.assertIn(
+            'updateStatusText.textContent = "AI Video Builder — Checking for updates…"',
+            BUILDER_SOURCE,
+        )
         self.assertIn(
             'heading.textContent = "What\'s New in AI Video Builder"',
             BUILDER_SOURCE,
         )
         self.assertIn(
             '"Dismiss AI Video Builder version status"',
+            BUILDER_SOURCE,
+        )
+
+    def test_topbar_has_live_project_video_engine_badge(self):
+        self.assertIn(
+            'projectVideoEngineBadge.textContent = miniMaxProject ? "◈ MiniMax" : "◈ LTX";',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'projectVideoEngineBadge.dataset.engine = miniMaxProject ? "minimax_h3" : "ltx";',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "utilityActions.append(projectVideoEngineBadge, stopWorkflowButton",
             BUILDER_SOURCE,
         )
 

--- a/tests/test_builder_wizard_button.py
+++ b/tests/test_builder_wizard_button.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+
+SETTINGS_START = BUILDER_SOURCE.index("function openSettingsModal()")
+SETTINGS_END = BUILDER_SOURCE.index("async function importPromptJson", SETTINGS_START)
+SETTINGS_SOURCE = BUILDER_SOURCE[SETTINGS_START:SETTINGS_END]
+
+WIZARD_START = BUILDER_SOURCE.index("function openWizardFromBuilder()")
+WIZARD_END = BUILDER_SOURCE.index("for (const control of [labelInput", WIZARD_START)
+WIZARD_SOURCE = BUILDER_SOURCE[WIZARD_START:WIZARD_END]
+
+
+class BuilderWizardButtonTests(unittest.TestCase):
+    def test_project_storage_handlers_stay_inside_settings_modal_scope(self):
+        for handler in (
+            "chooseProjectRootButton.onclick",
+            "saveProjectRootButton.onclick",
+            "clearProjectRootButton.onclick",
+        ):
+            self.assertIn(handler, SETTINGS_SOURCE)
+            self.assertNotIn(handler, WIZARD_SOURCE)
+
+    def test_wizard_button_surfaces_opening_errors(self):
+        self.assertIn("wizardButton.onclick = () => {", BUILDER_SOURCE)
+        self.assertIn("openWizardFromBuilder();", BUILDER_SOURCE)
+        self.assertIn(
+            'console.error("VRGDG Video Wizard failed to open", error)',
+            BUILDER_SOURCE,
+        )
+        self.assertIn("Video Wizard failed to open:", BUILDER_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,54 @@
   "product": "AI Video Builder",
   "releases": [
     {
+      "id": "2026-08-06-minimax-turbo-reference-llm-controls",
+      "version": "2026.08.06-minimax-builder-controls",
+      "date": "2026-08-06",
+      "title": "MiniMax Turbo, reference control, and larger LLM output",
+      "commit": "a8779f500033acb06764cd224aa6c889254ac0e5",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added optional MiniMax-H3 Turbo LoRA acceleration to MiniMax Video Settings. The hidden workflow injects the required Turbo LoRA and dedicated sampler, defaults to 6 editable steps with a minimum of 4, automatically bypasses EasyCache, and restores the previous normal steps and EasyCache preference when Turbo is turned off.",
+            "Added a scope-aware MiniMax Reference-to-Video Scene image use dropdown. A scene image can be unused, supplied to both the LLM and MiniMax as the exact start frame, or supplied only to the vision LLM as environment inspiration with camera framing either ignored or optionally considered.",
+            "Added Face + hair only exact-start priority. Character references can replace only face identity and hair from the first generated frame while the start image remains authoritative for body, clothing, pose, composition, lighting, environment, and every other visible detail.",
+            "Added a MiniMax-only Cut frequency Scene Default from 0–10. Zero requests one continuous uninterrupted take, while 10 schedules one continuity-preserving CUT TO per second within each segment's exact duration.",
+            "Added separate persistent input-context and maximum-output controls for Gemma Local and LM Studio so longer MiniMax prompts are no longer constrained by the former small hardcoded task limits."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Prompt-only scene-image inspiration is never sent to MiniMax, never receives an Image N label, and never consumes a renderer reference slot. Character references remain authoritative for character identity and appearance.",
+            "Builder, Storyboard, Wizard, Prompt Creator, and image-reference vision jobs now honor the selected local-runner output ceiling. LM Studio receives both context length and maximum output tokens through its native chat API.",
+            "Project-global MiniMax mode, model, video, scene-image, and character-priority changes now update every eligible unlocked scene while preserving independently locked scene settings.",
+            "The top status bar consistently uses the AI Video Builder product name and includes a persistent live badge showing whether the project is using LTX or MiniMax.",
+            "Existing projects saved with Turbo's old 20-step default migrate to 6 steps, and existing Turbo projects or locked scenes migrate to EasyCache bypass without overwriting later manual experimentation."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "MiniMax-H3 Turbo now uses a packaged compatibility LoRA adapter for pruned models with reference audio, preventing the SamplerCustomAdvanced 3-versus-2 AdaLN tensor mismatch while automatically delegating to the upstream node once it includes the same fix.",
+            "The Video Wizard button opens again; Project Storage handlers no longer throw an out-of-scope JavaScript error during the Builder-to-Wizard handoff.",
+            "The MiniMax managed subject-count block respects Face + hair only start-frame priority and no longer grants character sheets conflicting authority over clothing or body proportions.",
+            "Runner progress labels correctly report LM Studio for selected-runner vision jobs, while genuinely local-only Gemma work remains labeled as built-in and honors the configured output limit.",
+            "Projects created from the PR #114 development branch migrate its legacy llm_max_tokens setting into the new Gemma and LM Studio limits; commercial LLM API requests continue ignoring local-runner limits."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "MiniMax-H3 Turbo requires ComfyUI-MiniMax-H3-Turbo and the selected Turbo LoRA file. Standard MiniMax rendering remains unchanged when Turbo is disabled.",
+            "Existing LTX projects remain on the LTX engine unless MiniMax is explicitly selected. Prompt-only scene-image modes affect newly generated prompts, so regenerate an existing MiniMax prompt after changing that setting."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-06-timeline-editing-minimax-prompt-reliability",
       "version": "2026.08.06-builder-workflow-updates",
       "date": "2026-08-06",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -9,6 +9,8 @@ import {
   STORYBOARD_IMAGE_SHOT_FLOW_PRESETS,
   storyboardFacialPerformancePreset,
   storyboardCameraFlowEntry,
+  storyboardCutFrequencyValue,
+  storyboardCutPlanForDuration,
   storyboardGptPayload,
   storyboardImageAestheticPreset,
   storyboardImageShotFlowEntry,
@@ -225,20 +227,37 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   sampler_name: "res_multistep",
   scheduler: "simple",
   steps: 20,
+  steps_before_turbo: 20,
   denoise: 1,
   easy_cache_bypass: false,
+  easy_cache_bypass_before_turbo: false,
   easy_cache_reuse_threshold: 0.3,
   easy_cache_start_percent: 0.2,
   easy_cache_end_percent: 0.9,
   easy_cache_verbose: false,
   sage_attention: "auto",
   enable_fp16_accumulation: true,
+  use_turbo_lora: false,
+  turbo_lora_name: "minimax_h3_turbo_4step_ema_ckpt850.safetensors",
+  turbo_lora_strength: 1,
 };
 
 const MINIMAX_H3_CONTINUITY_OPTIONS = [
   { value: "off", label: "Off" },
   { value: "spatial_reference", label: "Previous final frame — spatial reference" },
   { value: "exact_start_frame", label: "Previous final frame — exact start frame" },
+];
+
+const MINIMAX_H3_START_FRAME_CHARACTER_INFLUENCE_OPTIONS = [
+  { value: "face_hair_only", label: "Face + hair only (keep the rest of the start frame)" },
+  { value: "full_character", label: "Full character identity (face, hair, clothing, and body)" },
+];
+
+const MINIMAX_H3_SCENE_IMAGE_USE_OPTIONS = [
+  { value: "off", label: "Do not use scene image" },
+  { value: "exact_start_frame", label: "Exact start frame (LLM + MiniMax)" },
+  { value: "environment_inspiration", label: "Environment inspiration only (LLM only — ignore framing)" },
+  { value: "environment_framing_inspiration", label: "Environment + framing inspiration (LLM only)" },
 ];
 
 const MINIMAX_H3_SAGE_ATTENTION_OPTIONS = [
@@ -267,6 +286,21 @@ function normalizeMiniMaxH3ContinuityMode(value) {
   if (["spatial", "spatial_reference", "continuity_reference"].includes(clean)) return "spatial_reference";
   if (["exact", "exact_start", "exact_start_frame", "continuous_start"].includes(clean)) return "exact_start_frame";
   return "off";
+}
+
+function normalizeMiniMaxH3StartFrameCharacterInfluence(value) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return ["face_hair_only", "face_and_hair_only", "identity_face_hair_only"].includes(clean)
+    ? "face_hair_only"
+    : "full_character";
+}
+
+function normalizeMiniMaxH3SceneImageUse(value, legacyExactStartFrame = false) {
+  const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (["exact", "exact_start", "exact_start_frame"].includes(clean)) return "exact_start_frame";
+  if (["environment", "environment_only", "environment_inspiration", "inspiration"].includes(clean)) return "environment_inspiration";
+  if (["environment_framing", "environment_framing_inspiration", "inspiration_with_framing"].includes(clean)) return "environment_framing_inspiration";
+  return legacyExactStartFrame ? "exact_start_frame" : "off";
 }
 
 function normalizeMiniMaxH3Voice(value = {}) {
@@ -322,6 +356,14 @@ function normalizeMiniMaxH3VideoPurpose(value) {
 
 function cloneMiniMaxH3Settings(value = {}) {
   const source = value && typeof value === "object" ? value : {};
+  const turboEnabled = Boolean(source.use_turbo_lora ?? source.useTurboLora ?? DEFAULT_MINIMAX_H3_SETTINGS.use_turbo_lora);
+  const rawSteps = Math.max(1, Math.min(1000, Math.trunc(Number(source.steps ?? DEFAULT_MINIMAX_H3_SETTINGS.steps) || DEFAULT_MINIMAX_H3_SETTINGS.steps)));
+  const hasSavedPreTurboSteps = source.steps_before_turbo != null || source.stepsBeforeTurbo != null;
+  const migrateOldTurboDefault = turboEnabled
+    && !hasSavedPreTurboSteps
+    && rawSteps === DEFAULT_MINIMAX_H3_SETTINGS.steps;
+  const hasSavedPreTurboEasyCache = source.easy_cache_bypass_before_turbo != null || source.easyCacheBypassBeforeTurbo != null;
+  const rawEasyCacheBypass = Boolean(source.easy_cache_bypass ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_bypass);
   return {
     ...DEFAULT_MINIMAX_H3_SETTINGS,
     ...source,
@@ -339,9 +381,11 @@ function cloneMiniMaxH3Settings(value = {}) {
     cooldown_frames: Math.max(0, Math.trunc(Number(source.cooldown_frames || 0))),
     sampler_name: String(source.sampler_name || DEFAULT_MINIMAX_H3_SETTINGS.sampler_name),
     scheduler: String(source.scheduler || DEFAULT_MINIMAX_H3_SETTINGS.scheduler),
-    steps: Math.max(1, Math.min(1000, Math.trunc(Number(source.steps ?? DEFAULT_MINIMAX_H3_SETTINGS.steps) || DEFAULT_MINIMAX_H3_SETTINGS.steps))),
+    steps: migrateOldTurboDefault ? 6 : rawSteps,
+    steps_before_turbo: Math.max(1, Math.min(1000, Math.trunc(Number(source.steps_before_turbo ?? source.stepsBeforeTurbo ?? rawSteps) || DEFAULT_MINIMAX_H3_SETTINGS.steps_before_turbo))),
     denoise: Math.max(0, Math.min(1, Number(source.denoise ?? DEFAULT_MINIMAX_H3_SETTINGS.denoise))),
-    easy_cache_bypass: Boolean(source.easy_cache_bypass ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_bypass),
+    easy_cache_bypass: turboEnabled && !hasSavedPreTurboEasyCache ? true : rawEasyCacheBypass,
+    easy_cache_bypass_before_turbo: Boolean(source.easy_cache_bypass_before_turbo ?? source.easyCacheBypassBeforeTurbo ?? rawEasyCacheBypass),
     easy_cache_reuse_threshold: Math.max(0, Math.min(1, Number(source.easy_cache_reuse_threshold ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_reuse_threshold))),
     easy_cache_start_percent: Math.max(0, Math.min(1, Number(source.easy_cache_start_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_start_percent))),
     easy_cache_end_percent: Math.max(0, Math.min(1, Number(source.easy_cache_end_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_end_percent))),
@@ -350,6 +394,9 @@ function cloneMiniMaxH3Settings(value = {}) {
       ? source.sage_attention
       : DEFAULT_MINIMAX_H3_SETTINGS.sage_attention,
     enable_fp16_accumulation: Boolean(source.enable_fp16_accumulation ?? DEFAULT_MINIMAX_H3_SETTINGS.enable_fp16_accumulation),
+    use_turbo_lora: turboEnabled,
+    turbo_lora_name: String(source.turbo_lora_name || source.turboLoraName || DEFAULT_MINIMAX_H3_SETTINGS.turbo_lora_name),
+    turbo_lora_strength: Math.max(-10, Math.min(10, Number(source.turbo_lora_strength ?? source.turboLoraStrength ?? DEFAULT_MINIMAX_H3_SETTINGS.turbo_lora_strength))),
   };
 }
 const LTX_MODEL_DOWNLOADS = [
@@ -2240,6 +2287,8 @@ function audioUrl(path) {
     minimax_h3_prompt_origin: "manual",
     minimax_h3_reference_keys: null,
     minimax_h3_use_scene_image_as_start_frame: false,
+    minimax_h3_scene_image_use: "off",
+    minimax_h3_start_frame_character_influence: "full_character",
     minimax_h3_video_references: [],
     ref_image_path: "",
     use_vision_reference: false,
@@ -2381,7 +2430,7 @@ function openBuilder(node) {
   updateStatusDot.style.cssText = "width:9px;height:9px;flex:0 0 9px;border-radius:999px;background:#a1a1aa;box-shadow:0 0 0 3px rgba(161,161,170,.16);";
   const updateStatusText = document.createElement("span");
   updateStatusText.style.cssText = "min-width:0;flex:1 1 auto;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
-  updateStatusText.textContent = "LTX 2.3 Video Builder — Checking for updates…";
+  updateStatusText.textContent = "AI Video Builder — Checking for updates…";
   const updateWhatsNewAction = makeButton("What's New");
   updateWhatsNewAction.style.cssText += "display:none;padding:4px 10px;min-height:24px;background:#164e63;border-color:#22d3ee;color:#ecfeff;font-size:11px;font-weight:900;";
   const updateStatusAction = makeButton("Update");
@@ -2551,7 +2600,7 @@ function openBuilder(node) {
 
   const refreshV10UpdateStatus = async () => {
     updateStatusPayload = null;
-    setUpdateStatusAppearance("checking", "LTX 2.3 Video Builder — Checking for updates…");
+    setUpdateStatusAppearance("checking", "AI Video Builder — Checking for updates…");
     try {
       const response = await api.fetchApi("/vrgdg/update/v10/status");
       const payload = await response.json();
@@ -2572,7 +2621,7 @@ function openBuilder(node) {
           : countText;
         setUpdateStatusAppearance(
           "outdated",
-          `LTX 2.3 Video Builder build ${installed} — Update available (${reason}; latest ${latest})`,
+          `AI Video Builder build ${installed} — Update available (${reason}; latest ${latest})`,
           `This installation is not at the latest production version on main (${reason}). Click Update to run the safe updater.`
         );
       } else {
@@ -2582,15 +2631,15 @@ function openBuilder(node) {
         const localNote = localNotes.length ? ` · ${localNotes.join(" · ")}` : "";
         setUpdateStatusAppearance(
           "current",
-          `LTX 2.3 Video Builder build ${installed} — Up to date${localNote}`,
-          `Installed LTX 2.3 Video Builder commit: ${payload.installed_commit}`
+          `AI Video Builder build ${installed} — Up to date${localNote}`,
+          `Installed AI Video Builder commit: ${payload.installed_commit}`
         );
       }
     } catch (error) {
       updateStatusPayload = null;
       setUpdateStatusAppearance(
         "unavailable",
-        "LTX 2.3 Video Builder — Could not check for updates",
+        "AI Video Builder — Could not check for updates",
         String(error?.message || error)
       );
     }
@@ -2607,9 +2656,9 @@ function openBuilder(node) {
   pickSrtButton.textContent = "Choose SRT";
   const settingsButton = makeButton("Settings");
   const reviewGuideButton = makeButton("Review Guide");
-  reviewGuideButton.title = "Open the LTX 2.3 Video Builder guide on GitHub.";
+  reviewGuideButton.title = "Open the AI Video Builder guide on GitHub.";
   const whatsNewMenuButton = makeButton("What's New");
-  whatsNewMenuButton.title = "Review recent LTX 2.3 Video Builder features, improvements, and fixes.";
+  whatsNewMenuButton.title = "Review recent AI Video Builder features, improvements, and fixes.";
   const loadButton = makeButton("Load Audio", "primary");
   const loadSrtButton = makeButton("Load SRT", "primary");
   const menuButton = makeButton("Menu");
@@ -2713,7 +2762,13 @@ function openBuilder(node) {
   centerActions.append(importActions, batchActions);
   const utilityActions = document.createElement("div");
   utilityActions.style.cssText = "display:flex;gap:8px;align-items:center;justify-content:flex-end;flex-wrap:nowrap;min-width:max-content;";
-  utilityActions.append(stopWorkflowButton, downloadModelsButton, clearMemoryButton, fullscreenButton, closeButton);
+  const projectVideoEngineBadge = document.createElement("div");
+  projectVideoEngineBadge.textContent = "◈ LTX";
+  projectVideoEngineBadge.title = "Project video engine: LTX";
+  projectVideoEngineBadge.setAttribute("role", "status");
+  projectVideoEngineBadge.setAttribute("aria-live", "polite");
+  projectVideoEngineBadge.style.cssText = "height:26px;box-sizing:border-box;display:inline-flex;align-items:center;padding:0 9px;border:1px solid #60a5fa;border-radius:999px;background:#172554;color:#bfdbfe;font-size:11px;font-weight:950;letter-spacing:.03em;white-space:nowrap;";
+  utilityActions.append(projectVideoEngineBadge, stopWorkflowButton, downloadModelsButton, clearMemoryButton, fullscreenButton, closeButton);
   topbar.append(projectActions, centerActions, utilityActions, menuDropdown);
 
   const main = document.createElement("div");
@@ -5016,6 +5071,23 @@ function openBuilder(node) {
   const miniMaxNoGgufNote = document.createElement("div");
   miniMaxNoGgufNote.textContent = "MiniMax H3 currently uses the standard diffusion-model loader. GGUF is not enabled yet.";
   miniMaxNoGgufNote.style.cssText = "font-size:11px;color:#fcd34d;line-height:1.4;";
+  const miniMaxUseTurboLora = makeCheckbox("Use MiniMax-H3 Turbo LoRA (4-step)", false);
+  miniMaxUseTurboLora.wrapper.title = "Conditionally injects MiniMaxH3TurboLoRA and MiniMaxH3TurboSampler into the hidden API workflow.";
+  const miniMaxTurboLoraPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.turbo_lora_name);
+  const miniMaxTurboLoraField = makeField("Turbo LoRA", miniMaxTurboLoraPicker.wrapper);
+  const miniMaxTurboLoraStrength = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.turbo_lora_strength), "number");
+  miniMaxTurboLoraStrength.min = "-10";
+  miniMaxTurboLoraStrength.max = "10";
+  miniMaxTurboLoraStrength.step = "0.01";
+  const miniMaxTurboLoraStrengthField = makeField("Turbo LoRA strength", miniMaxTurboLoraStrength);
+  const miniMaxTurboNote = document.createElement("div");
+  miniMaxTurboNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+  const miniMaxTurboSection = makeSettingsSection("Turbo acceleration", [
+    miniMaxUseTurboLora.wrapper,
+    miniMaxTurboLoraField,
+    miniMaxTurboLoraStrengthField,
+    miniMaxTurboNote,
+  ]);
   const miniMaxAspectRatio = makeSelect([
     "16:9 (Widescreen)",
     "9:16 (Portrait Widescreen)",
@@ -5129,12 +5201,16 @@ function openBuilder(node) {
   const miniMaxReferenceModeNote = document.createElement("div");
   miniMaxReferenceModeNote.textContent = "Uses ordered character, location, ingredients-sheet, or storyboard-grid images. Add and map the library from the existing Reference Builder button at the top of the Builder.";
   miniMaxReferenceModeNote.style.cssText = miniMaxTextModeNote.style.cssText;
-  const miniMaxUseSceneImageAsStartFrame = makeCheckbox("Use scene image as exact start frame", false);
-  miniMaxUseSceneImageAsStartFrame.wrapper.title = "Prepends this scene's selected timeline image as Image 1. Character, location, and storyboard references follow in their saved order.";
+  const miniMaxSceneImageUse = makeSelect(MINIMAX_H3_SCENE_IMAGE_USE_OPTIONS, "off");
+  const miniMaxSceneImageUseField = makeField("Scene image use — all unlocked Reference-to-Video scenes", miniMaxSceneImageUse);
+  miniMaxSceneImageUseField.title = "Choose whether each scene image is unused, becomes the exact MiniMax start frame, or is shown only to the prompt-writing vision LLM as inspiration.";
+  const miniMaxStartFrameCharacterInfluence = makeSelect(MINIMAX_H3_START_FRAME_CHARACTER_INFLUENCE_OPTIONS, "full_character");
+  const miniMaxStartFrameCharacterInfluenceField = makeField("Character reference influence — all Reference-to-Video scenes", miniMaxStartFrameCharacterInfluence);
+  miniMaxStartFrameCharacterInfluenceField.title = "Applies this character-reference priority across every eligible base scene that uses the scene image as its exact start frame.";
   const miniMaxStartFrameReferenceNote = document.createElement("div");
-  miniMaxStartFrameReferenceNote.textContent = "When enabled, Image 1 locks the exact opening composition. Character and location references begin at Image 2 and preserve identity or environment details that are not visible in the start frame.";
+  miniMaxStartFrameReferenceNote.textContent = "Choose whether the scene image is unused, becomes MiniMax's exact start frame, or is shown only to the prompt-writing vision LLM as environment inspiration.";
   miniMaxStartFrameReferenceNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
-  miniMaxReferenceModePanel.append(miniMaxReferenceModeNote, miniMaxUseSceneImageAsStartFrame.wrapper, miniMaxStartFrameReferenceNote, miniMaxReferencesButton);
+  miniMaxReferenceModePanel.append(miniMaxReferenceModeNote, miniMaxSceneImageUseField, miniMaxStartFrameCharacterInfluenceField, miniMaxStartFrameReferenceNote, miniMaxReferencesButton);
   const miniMaxVideoModePanel = makeSettingsPanel([]);
   const miniMaxVideoModeNote = document.createElement("div");
   miniMaxVideoModeNote.textContent = "Add up to three source/reference videos. You can also choose ordered Reference Builder images to replace or preserve people, backgrounds, locations, props, or visual style during the edit.";
@@ -5231,6 +5307,7 @@ function openBuilder(node) {
           makeField("Previous rendered final frame", miniMaxContinuityMode),
           miniMaxContinuityNote,
         ]),
+        miniMaxTurboSection,
         ...Object.values(miniMaxModePanels),
         makeSettingsSection("Render Settings", [miniMaxRenderSettingsGrid]),
         miniMaxAdvancedSettings,
@@ -5898,11 +5975,13 @@ function openBuilder(node) {
     const motionDefaults = source.motion_defaults && typeof source.motion_defaults === "object" ? source.motion_defaults : {};
     const cameraSpeed = Math.max(0, Math.min(10, Number(source.camera_motion_speed ?? source.cameraMotionSpeed ?? motionDefaults.camera_motion_speed ?? 4)));
     const characterSpeed = Math.max(0, Math.min(10, Number(source.character_motion_speed ?? source.characterMotionSpeed ?? motionDefaults.character_motion_speed ?? 4)));
+    const cutFrequency = storyboardCutFrequencyValue(source.minimax_h3_cut_frequency ?? source.cut_frequency ?? source.cutFrequency);
     const temporalIntensity = Math.max(0, Math.min(10, Number(source.temporal_background_intensity ?? source.temporalBackgroundIntensity ?? 8)));
     return {
       global_consistency_phrase: String(source.global_consistency_phrase || source.globalConsistencyPhrase || ""),
       camera_motion_speed: Number.isFinite(cameraSpeed) ? cameraSpeed : 4,
       character_motion_speed: Number.isFinite(characterSpeed) ? characterSpeed : 4,
+      minimax_h3_cut_frequency: cutFrequency,
       camera_guidance: String(source.camera_guidance || motionDefaults.camera_guidance || ""),
       character_guidance: String(source.character_guidance || motionDefaults.character_guidance || ""),
       performance_style: String(source.performance_style || source.performanceStyle || source.performance_style_default || ""),
@@ -6006,10 +6085,13 @@ function openBuilder(node) {
     subjectScenePath: "",
     textGemmaRunner: "builtin",
     gemmaContextLimit: 8000,
+    gemmaOutputTokenLimit: 8192,
     gemmaGpuLayers: 99,
     lmStudioBaseUrl: "http://127.0.0.1:1234/v1",
     lmStudioModel: "",
     lmStudioApiKey: "",
+    lmStudioContextLimit: 32768,
+    lmStudioOutputTokenLimit: 8192,
     llmApiProvider: "openai",
     llmApiModel: "",
     llmApiKey: "",
@@ -6070,6 +6152,14 @@ function openBuilder(node) {
 
   function syncProjectVideoEngineUI() {
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    projectVideoEngineBadge.dataset.engine = miniMaxProject ? "minimax_h3" : "ltx";
+    projectVideoEngineBadge.textContent = miniMaxProject ? "◈ MiniMax" : "◈ LTX";
+    projectVideoEngineBadge.title = miniMaxProject
+      ? "Project video engine: MiniMax H3"
+      : "Project video engine: LTX";
+    projectVideoEngineBadge.style.background = miniMaxProject ? "#083344" : "#172554";
+    projectVideoEngineBadge.style.borderColor = miniMaxProject ? "#22d3ee" : "#60a5fa";
+    projectVideoEngineBadge.style.color = miniMaxProject ? "#a5f3fc" : "#bfdbfe";
     ltxVideoPanel.style.display = miniMaxProject ? "none" : "flex";
     miniMaxEnginePanel.style.display = miniMaxProject ? "flex" : "none";
     syncMiniMaxH3Panel();
@@ -6086,6 +6176,12 @@ function openBuilder(node) {
       ...sceneSettings,
       video_mode: sceneSettings.video_mode || segment.minimax_h3_mode || globalSettings.video_mode,
     });
+    const sceneHasPreTurboEasyCache = sceneSettings.easy_cache_bypass_before_turbo != null
+      || sceneSettings.easyCacheBypassBeforeTurbo != null;
+    if (settings.use_turbo_lora && !sceneHasPreTurboEasyCache) {
+      settings.easy_cache_bypass_before_turbo = Boolean(sceneSettings.easy_cache_bypass ?? globalSettings.easy_cache_bypass);
+      settings.easy_cache_bypass = true;
+    }
     segment.minimax_h3_settings = settings;
     segment.minimax_h3_mode = settings.video_mode;
     return settings;
@@ -6105,6 +6201,25 @@ function openBuilder(node) {
     return Boolean(segment
       && miniMaxH3ContinuityModeForSegment(segment) !== "off"
       && previousAutoChainSourceSegment(segment));
+  }
+
+  function miniMaxH3StartFrameCharacterInfluenceForSegment(segment = activeSegment()) {
+    return normalizeMiniMaxH3StartFrameCharacterInfluence(
+      segment?.minimax_h3_start_frame_character_influence,
+    );
+  }
+
+  function miniMaxH3SceneImageUseForSegment(segment = activeSegment()) {
+    return normalizeMiniMaxH3SceneImageUse(
+      segment?.minimax_h3_scene_image_use,
+      Boolean(segment?.minimax_h3_use_scene_image_as_start_frame),
+    );
+  }
+
+  function miniMaxH3SceneImageIsPromptInspiration(segment = activeSegment()) {
+    return ["environment_inspiration", "environment_framing_inspiration"].includes(
+      miniMaxH3SceneImageUseForSegment(segment),
+    );
   }
 
   function setMiniMaxH3ModeForSegment(segment, value) {
@@ -6163,6 +6278,7 @@ function openBuilder(node) {
   function saveMiniMaxH3SettingsFromPanel() {
     const segment = activeSegment();
     const currentSettings = miniMaxH3SettingsForSegment(segment);
+    const turboEnabled = miniMaxUseTurboLora.input.checked;
     const settings = cloneMiniMaxH3Settings({
       video_mode: currentSettings.video_mode,
       audio_mode: miniMaxAudioMode.value,
@@ -6179,14 +6295,21 @@ function openBuilder(node) {
       sampler_name: miniMaxSamplerName.value,
       scheduler: miniMaxScheduler.value,
       steps: miniMaxSteps.value,
+      steps_before_turbo: turboEnabled ? currentSettings.steps_before_turbo : miniMaxSteps.value,
       denoise: miniMaxDenoise.value,
       easy_cache_bypass: miniMaxEasyCacheBypass.input.checked,
+      easy_cache_bypass_before_turbo: turboEnabled
+        ? currentSettings.easy_cache_bypass_before_turbo
+        : miniMaxEasyCacheBypass.input.checked,
       easy_cache_reuse_threshold: miniMaxEasyCacheReuseThreshold.value,
       easy_cache_start_percent: miniMaxEasyCacheStartPercent.value,
       easy_cache_end_percent: miniMaxEasyCacheEndPercent.value,
       easy_cache_verbose: miniMaxEasyCacheVerbose.input.checked,
       sage_attention: miniMaxSageAttention.value,
       enable_fp16_accumulation: miniMaxFp16Accumulation.input.checked,
+      use_turbo_lora: turboEnabled,
+      turbo_lora_name: miniMaxTurboLoraPicker.input.value,
+      turbo_lora_strength: miniMaxTurboLoraStrength.value,
     });
     if (segment?.use_scene_minimax_h3_settings) {
       segment.minimax_h3_settings = settings;
@@ -6202,7 +6325,11 @@ function openBuilder(node) {
     const segment = activeSegment();
     if (!segment) return;
     segment.minimax_h3_prompt = miniMaxPrompt.value || "";
-    segment.minimax_h3_use_scene_image_as_start_frame = Boolean(miniMaxUseSceneImageAsStartFrame.input.checked);
+    segment.minimax_h3_scene_image_use = normalizeMiniMaxH3SceneImageUse(miniMaxSceneImageUse.value);
+    segment.minimax_h3_use_scene_image_as_start_frame = segment.minimax_h3_scene_image_use === "exact_start_frame";
+    segment.minimax_h3_start_frame_character_influence = normalizeMiniMaxH3StartFrameCharacterInfluence(
+      miniMaxStartFrameCharacterInfluence.value,
+    );
     segment.minimax_h3_video_references = miniMaxVideoReferenceRows
       .map((row) => ({
         path: String(row.path.value || "").trim(),
@@ -6379,11 +6506,36 @@ function openBuilder(node) {
     miniMaxEasyCacheVerbose.input.checked = settings.easy_cache_verbose;
     miniMaxSageAttention.value = settings.sage_attention;
     miniMaxFp16Accumulation.input.checked = settings.enable_fp16_accumulation;
+    miniMaxUseTurboLora.input.checked = settings.use_turbo_lora;
+    miniMaxTurboLoraPicker.input.value = settings.turbo_lora_name;
+    miniMaxTurboLoraStrength.value = String(settings.turbo_lora_strength);
+    miniMaxTurboLoraField.style.display = settings.use_turbo_lora ? "flex" : "none";
+    miniMaxTurboLoraStrengthField.style.display = settings.use_turbo_lora ? "flex" : "none";
+    miniMaxTurboNote.textContent = settings.use_turbo_lora
+      ? "Turbo is ON. The hidden API workflow uses MiniMax-H3 Turbo LoRA plus the dedicated Turbo sampler and simple scheduler. Steps defaults to 6 when Turbo is switched on and remains editable with a minimum of 4. EasyCache bypass is enabled automatically; the advanced control remains editable for experiments. Normal settings are restored when Turbo is turned off."
+      : "Turbo is OFF. The normal MiniMax sampler, scheduler, and step settings are used.";
+    miniMaxSamplerName.disabled = settings.use_turbo_lora;
+    miniMaxScheduler.disabled = settings.use_turbo_lora;
+    miniMaxSteps.disabled = false;
+    miniMaxSteps.min = settings.use_turbo_lora ? "4" : "1";
     useSceneMiniMaxH3Settings.input.checked = Boolean(segment?.use_scene_minimax_h3_settings);
     useSceneMiniMaxH3Settings.input.disabled = !segment;
-    miniMaxSettingsScopeNote.textContent = segment?.use_scene_minimax_h3_settings
+    const sceneMiniMaxSettingsLocked = Boolean(segment?.use_scene_minimax_h3_settings);
+    miniMaxSettingsScopeNote.textContent = sceneMiniMaxSettingsLocked
       ? "Scene lock is ON — this scene uses its own MiniMax mode, models, and video settings."
       : "Scene lock is OFF — this scene follows the project-global MiniMax mode, models, and video settings.";
+    miniMaxSceneImageUseField.firstElementChild.textContent = sceneMiniMaxSettingsLocked
+      ? "Scene image use — this locked scene"
+      : "Scene image use — all unlocked Reference-to-Video scenes";
+    miniMaxSceneImageUseField.title = sceneMiniMaxSettingsLocked
+      ? "Changes only this locked scene. Prompt-only inspiration is sent to the vision LLM but not to MiniMax."
+      : "Applies across every eligible unlocked base scene. Locked scenes remain unchanged; prompt-only inspiration is never sent to MiniMax.";
+    miniMaxStartFrameCharacterInfluenceField.firstElementChild.textContent = sceneMiniMaxSettingsLocked
+      ? "Character reference influence — this locked scene"
+      : "Character reference influence — all unlocked Reference-to-Video scenes";
+    miniMaxStartFrameCharacterInfluenceField.title = sceneMiniMaxSettingsLocked
+      ? "Changes only this locked scene's character-reference priority."
+      : "Applies this priority across eligible unlocked base scenes; locked scenes remain unchanged.";
     const mode = settings.video_mode;
     const modeLabel = miniMaxH3ModeLabel(mode);
     for (const button of miniMaxModeButtons) {
@@ -6411,11 +6563,29 @@ function openBuilder(node) {
         : settings.continuity_mode === "exact_start_frame"
           ? "Begins each later scene on the previous rendered clip's exact final frame. The extracted frame and its prompt contract are injected when rendering. Do not also enable the scene-image exact start-frame option; Scene 1 is unaffected."
           : "Off: every scene starts independently from its normal MiniMax references.";
-    miniMaxUseSceneImageAsStartFrame.input.checked = Boolean(segment?.minimax_h3_use_scene_image_as_start_frame);
-    miniMaxUseSceneImageAsStartFrame.input.disabled = !segment || settings.continuity_mode === "exact_start_frame";
+    const sceneImageUse = miniMaxH3SceneImageUseForSegment(segment);
+    miniMaxSceneImageUse.value = sceneImageUse;
+    miniMaxSceneImageUse.disabled = !segment;
+    const exactStartFrameOption = Array.from(miniMaxSceneImageUse.options).find((option) => option.value === "exact_start_frame");
+    if (exactStartFrameOption) exactStartFrameOption.disabled = settings.continuity_mode === "exact_start_frame";
+    const startFrameCharacterInfluence = miniMaxH3StartFrameCharacterInfluenceForSegment(segment);
+    miniMaxStartFrameCharacterInfluence.value = startFrameCharacterInfluence;
+    miniMaxStartFrameCharacterInfluence.disabled = !segment
+      || sceneImageUse !== "exact_start_frame"
+      || settings.continuity_mode === "exact_start_frame";
+    miniMaxStartFrameCharacterInfluenceField.style.display = sceneImageUse === "exact_start_frame" ? "flex" : "none";
     miniMaxStartFrameReferenceNote.textContent = settings.continuity_mode === "exact_start_frame"
-      ? "Disabled because the previous rendered final frame is the sole exact opening frame. Character and location references remain supporting references."
-      : "When enabled, Image 1 locks the exact opening composition. Character and location references begin at Image 2 and preserve identity or environment details that are not visible in the start frame.";
+      && sceneImageUse === "exact_start_frame"
+      ? "The previous rendered final frame is the sole exact opening frame. Choose an LLM-only inspiration mode or Do not use instead."
+      : sceneImageUse === "environment_inspiration"
+        ? "The scene image is shown only to the prompt-writing LLM for location, environment, atmosphere, mood, lighting, weather, colors, materials, background details, relevant objects, and scene activity. It must ignore framing, shot distance, camera angle, lens, composition, and every character detail, pose, and placement. MiniMax never receives this image."
+        : sceneImageUse === "environment_framing_inspiration"
+          ? "The scene image is shown only to the prompt-writing LLM for environment plus optional shot framing, distance, angle, lens, and composition inspiration. It must ignore every character's identity, appearance, clothing, pose, and placement. MiniMax never receives this image."
+          : startFrameCharacterInfluence === "face_hair_only" && sceneImageUse === "exact_start_frame"
+        ? "Image 1 keeps its pose, body, wardrobe, accessories, composition, camera, lighting, props, and environment. Character references supply only face identity and hair from the first generated frame—there is no visible swap or transformation."
+        : sceneImageUse === "exact_start_frame"
+          ? "The scene image becomes MiniMax Image 1 and locks the exact opening composition. Character and location references follow it."
+          : "The scene image is not used by the prompt-writing LLM or MiniMax.";
     const imagePath = String(segment ? selectedSegmentImagePath(segment) || "" : "").trim();
     miniMaxImageModeSource.textContent = imagePath
       ? `Scene image input:\n${imagePath}`
@@ -8503,10 +8673,13 @@ function openBuilder(node) {
     return {
       text_runner: state.textGemmaRunner || "builtin",
       n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
       n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       lmstudio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
       lmstudio_model: state.lmStudioModel || "",
       lmstudio_api_key: state.lmStudioApiKey || "",
+      lmstudio_context_limit: normalizeLmStudioContextLimit(state.lmStudioContextLimit),
+      lmstudio_output_token_limit: normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit),
       llm_api_provider: state.llmApiProvider || "openai",
       llm_api_model: state.llmApiModel || "",
       llm_api_key: state.llmApiKey || "",
@@ -9549,7 +9722,14 @@ function openBuilder(node) {
         ? segment.minimax_h3_reference_keys.map((key) => String(key || "").trim()).filter(Boolean).slice(0, 9)
         : null;
     }
-    segment.minimax_h3_use_scene_image_as_start_frame = Boolean(segment.minimax_h3_use_scene_image_as_start_frame);
+    segment.minimax_h3_scene_image_use = normalizeMiniMaxH3SceneImageUse(
+      segment.minimax_h3_scene_image_use,
+      Boolean(segment.minimax_h3_use_scene_image_as_start_frame),
+    );
+    segment.minimax_h3_use_scene_image_as_start_frame = segment.minimax_h3_scene_image_use === "exact_start_frame";
+    segment.minimax_h3_start_frame_character_influence = normalizeMiniMaxH3StartFrameCharacterInfluence(
+      segment.minimax_h3_start_frame_character_influence,
+    );
     segment.minimax_h3_continuity_frame_path = String(segment.minimax_h3_continuity_frame_path || "");
     segment.minimax_h3_continuity_source_video_path = String(segment.minimax_h3_continuity_source_video_path || "");
     segment.minimax_h3_continuity_source_scene_id = String(segment.minimax_h3_continuity_source_scene_id || "");
@@ -10000,14 +10180,18 @@ function openBuilder(node) {
 
   function applyModelDefaults(defaults) {
     if (!defaults || typeof defaults !== "object" || Array.isArray(defaults)) return false;
+    const legacyLlmMaxTokens = defaults.llm_max_tokens ?? defaults.llmMaxTokens;
     if (defaults.text_gemma_runner || defaults.textGemmaRunner) {
       state.textGemmaRunner = defaults.text_gemma_runner || defaults.textGemmaRunner || state.textGemmaRunner || "builtin";
     }
     if (Object.prototype.hasOwnProperty.call(defaults, "gemma_gpu_layers") || Object.prototype.hasOwnProperty.call(defaults, "gemmaGpuLayers") || Object.prototype.hasOwnProperty.call(defaults, "n_gpu_layers")) {
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(defaults.gemma_gpu_layers ?? defaults.gemmaGpuLayers ?? defaults.n_gpu_layers ?? state.gemmaGpuLayers);
     }
-    if (Object.prototype.hasOwnProperty.call(defaults, "gemma_context_limit") || Object.prototype.hasOwnProperty.call(defaults, "gemmaContextLimit") || Object.prototype.hasOwnProperty.call(defaults, "n_ctx")) {
-      state.gemmaContextLimit = normalizeGemmaContextLimit(defaults.gemma_context_limit ?? defaults.gemmaContextLimit ?? defaults.n_ctx ?? state.gemmaContextLimit);
+    if (Object.prototype.hasOwnProperty.call(defaults, "gemma_context_limit") || Object.prototype.hasOwnProperty.call(defaults, "gemmaContextLimit") || Object.prototype.hasOwnProperty.call(defaults, "n_ctx") || legacyLlmMaxTokens != null) {
+      state.gemmaContextLimit = normalizeGemmaContextLimit(defaults.gemma_context_limit ?? defaults.gemmaContextLimit ?? defaults.n_ctx ?? legacyLlmMaxTokens ?? state.gemmaContextLimit);
+    }
+    if (Object.prototype.hasOwnProperty.call(defaults, "gemma_output_token_limit") || Object.prototype.hasOwnProperty.call(defaults, "gemmaOutputTokenLimit") || legacyLlmMaxTokens != null) {
+      state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(defaults.gemma_output_token_limit ?? defaults.gemmaOutputTokenLimit ?? legacyLlmMaxTokens ?? state.gemmaOutputTokenLimit);
     }
     if (defaults.lm_studio_base_url || defaults.lmStudioBaseUrl) {
       state.lmStudioBaseUrl = defaults.lm_studio_base_url || defaults.lmStudioBaseUrl || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
@@ -10017,6 +10201,12 @@ function openBuilder(node) {
     }
     if (Object.prototype.hasOwnProperty.call(defaults, "lm_studio_api_key") || Object.prototype.hasOwnProperty.call(defaults, "lmStudioApiKey")) {
       state.lmStudioApiKey = defaults.lm_studio_api_key ?? defaults.lmStudioApiKey ?? state.lmStudioApiKey ?? "";
+    }
+    if (Object.prototype.hasOwnProperty.call(defaults, "lm_studio_context_limit") || Object.prototype.hasOwnProperty.call(defaults, "lmStudioContextLimit")) {
+      state.lmStudioContextLimit = normalizeLmStudioContextLimit(defaults.lm_studio_context_limit ?? defaults.lmStudioContextLimit ?? state.lmStudioContextLimit);
+    }
+    if (Object.prototype.hasOwnProperty.call(defaults, "lm_studio_output_token_limit") || Object.prototype.hasOwnProperty.call(defaults, "lmStudioOutputTokenLimit") || legacyLlmMaxTokens != null) {
+      state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(defaults.lm_studio_output_token_limit ?? defaults.lmStudioOutputTokenLimit ?? legacyLlmMaxTokens ?? state.lmStudioOutputTokenLimit);
     }
     if (defaults.llm_api_provider || defaults.llmApiProvider) {
       state.llmApiProvider = defaults.llm_api_provider || defaults.llmApiProvider || state.llmApiProvider || "openai";
@@ -10229,10 +10419,13 @@ function openBuilder(node) {
       subjectScenePath: state.subjectScenePath,
       textGemmaRunner: state.textGemmaRunner,
       gemmaContextLimit: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      gemmaOutputTokenLimit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
       gemmaGpuLayers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       lmStudioBaseUrl: state.lmStudioBaseUrl,
       lmStudioModel: state.lmStudioModel,
       lmStudioApiKey: state.lmStudioApiKey,
+      lmStudioContextLimit: normalizeLmStudioContextLimit(state.lmStudioContextLimit),
+      lmStudioOutputTokenLimit: normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit),
       llmApiProvider: state.llmApiProvider,
       llmApiModel: state.llmApiModel,
       notificationSettings: normalizeNotificationSettings(state.notificationSettings),
@@ -10278,6 +10471,7 @@ function openBuilder(node) {
 
   function restoreHistorySnapshot(snapshot) {
     const data = JSON.parse(snapshot, historySnapshotReviver);
+    const legacyLlmMaxTokens = data.llmMaxTokens ?? data.llm_max_tokens;
     state.isRestoringHistory = true;
     state.segments = data.segments || [];
     state.overlaySegments = data.overlaySegments || data.overlay_segments || [];
@@ -10310,11 +10504,14 @@ function openBuilder(node) {
     state.storyIdeaPath = data.storyIdeaPath || "";
     state.subjectScenePath = data.subjectScenePath || "";
     state.textGemmaRunner = data.textGemmaRunner || data.text_gemma_runner || state.textGemmaRunner || "builtin";
-    state.gemmaContextLimit = normalizeGemmaContextLimit(data.gemmaContextLimit ?? data.gemma_context_limit ?? data.n_ctx ?? state.gemmaContextLimit);
+    state.gemmaContextLimit = normalizeGemmaContextLimit(data.gemmaContextLimit ?? data.gemma_context_limit ?? data.n_ctx ?? legacyLlmMaxTokens ?? state.gemmaContextLimit);
+    state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(data.gemmaOutputTokenLimit ?? data.gemma_output_token_limit ?? legacyLlmMaxTokens ?? state.gemmaOutputTokenLimit);
     state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.gemmaGpuLayers ?? data.gemma_gpu_layers ?? data.n_gpu_layers ?? state.gemmaGpuLayers);
     state.lmStudioBaseUrl = data.lmStudioBaseUrl || data.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
     state.lmStudioModel = data.lmStudioModel || data.lm_studio_model || state.lmStudioModel || "";
     state.lmStudioApiKey = data.lmStudioApiKey || data.lm_studio_api_key || state.lmStudioApiKey || "";
+    state.lmStudioContextLimit = normalizeLmStudioContextLimit(data.lmStudioContextLimit ?? data.lm_studio_context_limit ?? state.lmStudioContextLimit);
+    state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(data.lmStudioOutputTokenLimit ?? data.lm_studio_output_token_limit ?? legacyLlmMaxTokens ?? state.lmStudioOutputTokenLimit);
     state.llmApiProvider = data.llmApiProvider || data.llm_api_provider || state.llmApiProvider || "openai";
     state.llmApiModel = data.llmApiModel || data.llm_api_model || state.llmApiModel || "";
     state.notificationSettings = normalizeNotificationSettings(data.notificationSettings || data.notification_settings || state.notificationSettings);
@@ -11450,6 +11647,10 @@ function openBuilder(node) {
     add(parts, "Storyboard still shot direction", scene.shot_type || segment.shot_type);
     if (!customMotionSummary) add(parts, "Storyboard camera motion", scene.camera_motion || segment.camera_motion || segment.motion_preset);
     add(parts, "Storyboard camera motion speed guidance", defaults.camera_guidance || builderMotionSpeedGuidance(defaults.camera_motion_speed, "camera"));
+    if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+      const cutPlan = storyboardCutPlanForDuration(timelineSegmentDuration(segment), defaults.minimax_h3_cut_frequency);
+      add(parts, "Mandatory MiniMax editing / cut plan", cutPlan.instruction);
+    }
     add(parts, "Storyboard character motion guidance", segment.character_motion || defaults.character_guidance || builderMotionSpeedGuidance(defaults.character_motion_speed, "character"));
     const performanceStyle = String(segment.performance_style || defaults.performance_style || "").trim();
     const performancePreset = storyboardPerformancePreset(performanceStyle) || {};
@@ -11639,6 +11840,18 @@ function openBuilder(node) {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return 8000;
     return Math.max(512, Math.min(262144, Math.round(parsed)));
+  }
+
+  function normalizeLmStudioContextLimit(value) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return 32768;
+    return Math.max(512, Math.min(262144, Math.round(parsed)));
+  }
+
+  function normalizeOutputTokenLimit(value) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return 8192;
+    return Math.max(64, Math.min(262144, Math.round(parsed)));
   }
 
   function removeQuietFromSingingPrompt(text) {
@@ -14636,11 +14849,15 @@ function openBuilder(node) {
     if (normalizedMode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
       const startFrame = segmentImageSource(segment);
       if (startFrame?.path || startFrame?.data) {
+        const characterInfluence = miniMaxH3StartFrameCharacterInfluenceForSegment(segment);
         ordered.push({
           key: "scene:start_frame",
           kind: "start_frame",
           label: "Scene start frame",
-          description: "Exact opening frame, composition, pose, camera angle, environment, and lighting anchor.",
+          start_frame_character_influence: characterInfluence,
+          description: characterInfluence === "face_hair_only"
+            ? "Exact opening frame and authoritative source for pose, body proportions, wardrobe, accessories, composition, camera angle, environment, props, lighting, and every visible detail except face identity and hair."
+            : "Exact opening frame, composition, pose, camera angle, environment, and lighting anchor.",
           image: {
             path: String(startFrame.path || "").trim(),
             data: String(startFrame.data || "").trim(),
@@ -14661,9 +14878,21 @@ function openBuilder(node) {
     }).slice(0, 9);
   }
 
-  function miniMaxReferencePurposeText(item) {
-    if (item?.kind === "start_frame") return "exact start frame, opening composition, pose, camera angle, environment, and lighting anchor";
-    if (item?.kind === "subject") return "character identity, face, hair, clothing, and body-proportion reference";
+  function miniMaxReferencePurposeText(item, segment = null) {
+    const faceHairOnly = Boolean(
+      segment?.minimax_h3_use_scene_image_as_start_frame
+      && miniMaxH3StartFrameCharacterInfluenceForSegment(segment) === "face_hair_only"
+    );
+    if (item?.kind === "start_frame") {
+      return faceHairOnly
+        ? "exact start frame and authority for every visible detail except face identity and hair"
+        : "exact start frame, opening composition, pose, camera angle, environment, and lighting anchor";
+    }
+    if (item?.kind === "subject") {
+      return faceHairOnly
+        ? "face identity and hair reference only; do not copy clothing, body proportions, pose, accessories, framing, lighting, or background"
+        : "character identity, face, hair, clothing, and body-proportion reference";
+    }
     if (item?.kind === "location") return "environment, location, architecture, layout, and atmosphere reference";
     if (item?.kind === "ingredients") {
       const searchable = `${item?.label || ""} ${item?.description || ""}`.toLowerCase();
@@ -14686,6 +14915,8 @@ function openBuilder(node) {
     const startFrameReserved = miniMaxH3ModeForSegment(segment) === "reference_to_video"
       && Boolean(segment.minimax_h3_use_scene_image_as_start_frame)
       && Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
+    const promptInspiration = miniMaxH3ModeForSegment(segment) === "reference_to_video"
+      && miniMaxH3SceneImageIsPromptInspiration(segment);
     const continuityReserved = miniMaxH3ContinuityReferenceReserved(segment);
     const maxLibraryReferences = Math.max(0, 9 - (startFrameReserved ? 1 : 0) - (continuityReserved ? 1 : 0));
     let selectedKeys = miniMaxReferenceKeysForSegment(segment, refs).slice(0, maxLibraryReferences);
@@ -14705,7 +14936,7 @@ function openBuilder(node) {
     const note = document.createElement("div");
     note.textContent = startFrameReserved
       ? `The scene image is reserved as Image 1 and the exact start frame. Choose up to ${maxLibraryReferences} additional Reference Builder image${maxLibraryReferences === 1 ? "" : "s"}.${continuityReserved ? " One final slot is reserved for the previous rendered scene's continuity frame." : ""}`
-      : `Choose up to ${maxLibraryReferences} existing Reference Builder image${maxLibraryReferences === 1 ? "" : "s"}. The numbered order is sent into MiniMax H3 exactly as shown.${continuityReserved ? " One final slot is reserved for the previous rendered scene's continuity frame." : ""} Scene character/location mappings are used automatically until you save a custom selection.`;
+      : `Choose up to ${maxLibraryReferences} existing Reference Builder image${maxLibraryReferences === 1 ? "" : "s"}. The numbered order is sent into MiniMax H3 exactly as shown.${promptInspiration ? " The scene image is prompt-only LLM inspiration and does not consume a MiniMax reference slot." : ""}${continuityReserved ? " One final slot is reserved for the previous rendered scene's continuity frame." : ""} Scene character/location mappings are used automatically until you save a custom selection.`;
     note.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;padding:11px 15px;border-bottom:1px solid #1e293b;";
     const body = document.createElement("div");
     body.style.cssText = "display:grid;grid-template-columns:minmax(0,1.25fr) minmax(320px,.75fr);gap:12px;padding:12px;overflow:auto;min-height:260px;";
@@ -19611,7 +19842,8 @@ function openBuilder(node) {
           story_idea: storyIdea || idea,
           unload_after: true,
           n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
-          max_new_tokens: 8000,
+          gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
+          max_new_tokens: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
         }, 10 * 60 * 1000);
         const text = String(data.text || "").trim();
         if (!text) throw new Error("Gemma4 returned an empty draft.");
@@ -25422,7 +25654,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
 
     async function describeGeneratedReference(referenceType, target, prompt = "") {
       if (referenceType === "subject") {
-        setInlineProgress(`Vision Gemma describing the generated subject image...\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 91);
+        setInlineProgress(`Vision Gemma describing the generated subject image...\n${gemmaRunnerLine({ vision: true })}`, 91);
         const description = await describeReferenceImageWithGemma(target, "subject", {
           unloadAfter: true,
           clearBeforeLoad: false,
@@ -25890,7 +26122,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         for (let index = 0; index < jobs.length; index += 1) {
           const { target, label } = jobs[index];
           const isLast = index === jobs.length - 1;
-          progress.set(`Vision Gemma describing ${referenceType} image...\n${index + 1}/${jobs.length}: ${label || target.name || referenceType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing ${referenceType} image...\n${index + 1}/${jobs.length}: ${label || target.name || referenceType}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(target, referenceType, {
             unloadAfter: options.keepLoaded ? isLast : true,
             clearBeforeLoad: index === 0 && Boolean(options.clearBeforeLoad),
@@ -25918,7 +26150,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       const effectiveType = referenceType === "subject" ? (target?.reference_type || "character") : referenceType;
       const progress = createProgressWindow(referenceType === "location" ? "Describing location" : "Describing reference", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing ${effectiveType} image...\n${label || target?.name || effectiveType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing ${effectiveType} image...\n${label || target?.name || effectiveType}\n${gemmaRunnerLine({ vision: true })}`, 18);
         const description = await describeReferenceImageWithGemma(target, referenceType, { unloadAfter: true, clearBeforeLoad: false });
         applyReferenceDescription(referenceType, target, description);
         renderAll();
@@ -27973,7 +28205,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       const primarySubject = refs.subjects[0] || refs.subject;
       const progress = createProgressWindow("Describing character", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing character image...\n${subjectNameInput.value || refs.subjects[0]?.name || "Subject"}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing character image...\n${subjectNameInput.value || refs.subjects[0]?.name || "Subject"}\n${gemmaRunnerLine({ vision: true })}`, 18);
         const description = await describeReferenceImageWithGemma(primarySubject, "subject", { unloadAfter: true });
         applyReferenceDescription("subject", primarySubject, description);
         renderAll();
@@ -28455,7 +28687,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       if (!currentSheet) return;
       const progress = createProgressWindow("Describing Ingredients sheet", { zIndex: 100008 });
       try {
-        progress.set(`Vision Gemma describing sheet image...\n${currentSheet.name || "Ingredients sheet"}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 18);
+        progress.set(`Vision Gemma describing sheet image...\n${currentSheet.name || "Ingredients sheet"}\n${gemmaRunnerLine({ vision: true })}`, 18);
         await describeReferenceImageWithGemma(currentSheet, "subject", { unloadAfter: true });
         renderSheets();
         await autoSaveSessionQuiet("Gemma described ingredients sheet");
@@ -28479,7 +28711,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       try {
         for (let index = 0; index < jobs.length; index += 1) {
           const sheet = jobs[index];
-          progress.set(`Vision Gemma describing sheet image...\n${index + 1}/${jobs.length}: ${sheet.name || `Ingredients Sheet ${index + 1}`}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing sheet image...\n${index + 1}/${jobs.length}: ${sheet.name || `Ingredients Sheet ${index + 1}`}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(sheet, "subject", { unloadAfter: index === jobs.length - 1 });
           renderSheets();
           await autoSaveSessionQuiet(`Gemma described ingredients sheet ${index + 1}`);
@@ -29560,7 +29792,7 @@ Chrome vault corridor = A sealed industrial passage...</pre>`;
         for (let index = 0; index < jobs.length; index += 1) {
           const item = jobs[index];
           const effectiveType = referenceType === "subject" ? (item.reference_type || "character") : referenceType;
-          progress.set(`Vision Gemma describing ${effectiveType} image...\n${index + 1}/${jobs.length}: ${item.name || effectiveType}\n${gemmaRunnerLine({ vision: true, forceBuiltin: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
+          progress.set(`Vision Gemma describing ${effectiveType} image...\n${index + 1}/${jobs.length}: ${item.name || effectiveType}\n${gemmaRunnerLine({ vision: true })}`, 8 + Math.round((index / Math.max(1, jobs.length)) * 84));
           await describeReferenceImageWithGemma(item, referenceType, { unloadAfter: index === jobs.length - 1 });
           renderAll();
           await autoSaveSessionQuiet(`Gemma described ${referenceType} text`);
@@ -31741,6 +31973,22 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     backdrop.append(box);
     document.body.append(backdrop);
     modalClose.onclick = () => backdrop.remove();
+    chooseProjectRootButton.onclick = async () => {
+      const path = await pickPath("project_root", projectRootInput);
+      if (path) projectRootInput.value = path;
+    };
+    saveProjectRootButton.onclick = () => {
+      const root = setPreferredProjectRoot(projectRootInput.value);
+      projectRootInput.value = root;
+      toast(root
+        ? `New projects will be created under:\n${root}`
+        : "New projects will use the ComfyUI output folder.");
+    };
+    clearProjectRootButton.onclick = () => {
+      projectRootInput.value = "";
+      setPreferredProjectRoot("");
+      toast("New projects will use the ComfyUI output folder.");
+    };
     saveCustomModelsRootButton.onclick = async () => {
       try {
         saveCustomModelsRootButton.disabled = true;
@@ -32139,10 +32387,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       subject_scene_path: state.subjectScenePath,
       text_gemma_runner: state.textGemmaRunner || "builtin",
       gemma_context_limit: normalizeGemmaContextLimit(state.gemmaContextLimit),
+      gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
       gemma_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
       lm_studio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
       lm_studio_model: state.lmStudioModel || "",
       lm_studio_api_key: state.lmStudioApiKey || "",
+      lm_studio_context_limit: normalizeLmStudioContextLimit(state.lmStudioContextLimit),
+      lm_studio_output_token_limit: normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit),
       llm_api_provider: state.llmApiProvider || "openai",
       llm_api_model: state.llmApiModel || "",
       notification_settings: normalizeNotificationSettings(state.notificationSettings),
@@ -32399,11 +32650,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.renderLogs = normalizeRenderLogs(data.session.render_logs || state.renderLogs);
         state.activeRenderLogId = data.session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
         state.textGemmaRunner = data.session.text_gemma_runner || state.textGemmaRunner || "builtin";
-        state.gemmaContextLimit = normalizeGemmaContextLimit(data.session.gemma_context_limit ?? data.session.n_ctx ?? state.gemmaContextLimit);
+        state.gemmaContextLimit = normalizeGemmaContextLimit(data.session.gemma_context_limit ?? data.session.n_ctx ?? data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.gemmaContextLimit);
+        state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(data.session.gemma_output_token_limit ?? data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.gemmaOutputTokenLimit);
         state.gemmaGpuLayers = normalizeGemmaGpuLayers(data.session.gemma_gpu_layers ?? data.session.n_gpu_layers ?? state.gemmaGpuLayers);
         state.lmStudioBaseUrl = data.session.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
         state.lmStudioModel = data.session.lm_studio_model || state.lmStudioModel || "";
         state.lmStudioApiKey = data.session.lm_studio_api_key || state.lmStudioApiKey || "";
+        state.lmStudioContextLimit = normalizeLmStudioContextLimit(data.session.lm_studio_context_limit ?? state.lmStudioContextLimit);
+        state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(data.session.lm_studio_output_token_limit ?? data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.lmStudioOutputTokenLimit);
         state.notificationSettings = normalizeNotificationSettings(data.session.notification_settings || state.notificationSettings);
         state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.session.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
         state.waveformMode = data.session.waveform_mode || state.waveformMode;
@@ -32725,11 +32979,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.renderLogs = normalizeRenderLogs(session.render_logs);
       state.activeRenderLogId = session.active_render_log_id || state.renderLogs[state.renderLogs.length - 1]?.id || "";
       state.textGemmaRunner = session.text_gemma_runner || state.textGemmaRunner || "builtin";
-      state.gemmaContextLimit = normalizeGemmaContextLimit(session.gemma_context_limit ?? session.n_ctx ?? state.gemmaContextLimit);
+      state.gemmaContextLimit = normalizeGemmaContextLimit(session.gemma_context_limit ?? session.n_ctx ?? session.llm_max_tokens ?? session.llmMaxTokens ?? state.gemmaContextLimit);
+      state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(session.gemma_output_token_limit ?? session.llm_max_tokens ?? session.llmMaxTokens ?? state.gemmaOutputTokenLimit);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(session.gemma_gpu_layers ?? session.n_gpu_layers ?? state.gemmaGpuLayers);
       state.lmStudioBaseUrl = session.lm_studio_base_url || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
       state.lmStudioModel = session.lm_studio_model || state.lmStudioModel || "";
       state.lmStudioApiKey = session.lm_studio_api_key || state.lmStudioApiKey || "";
+      state.lmStudioContextLimit = normalizeLmStudioContextLimit(session.lm_studio_context_limit ?? state.lmStudioContextLimit);
+      state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(session.lm_studio_output_token_limit ?? session.llm_max_tokens ?? session.llmMaxTokens ?? state.lmStudioOutputTokenLimit);
       state.notificationSettings = normalizeNotificationSettings(session.notification_settings || state.notificationSettings);
       state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(session.automatic_memory_cleanup ?? false);
       state.waveformMode = session.waveform_mode || state.waveformMode || "medium";
@@ -35258,6 +35515,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   function miniMaxH3SubjectMultiplicityBlock(segment) {
     const mode = miniMaxH3ModeForSegment(segment);
     if (mode !== "reference_to_video" && mode !== "video_to_video") return "";
+    const faceHairOnly = mode === "reference_to_video"
+      && Boolean(segment?.minimax_h3_use_scene_image_as_start_frame)
+      && miniMaxH3StartFrameCharacterInfluenceForSegment(segment) === "face_hair_only";
     const subjectRefs = storyboardReferenceDataForSegment(segment).subject_refs || [];
     const subjects = [];
     const seen = new Set();
@@ -35273,7 +35533,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return [
       "REFERENCE SUBJECT COUNT — MANDATORY:",
       `This scene contains exactly ${count} distinct named ${count === 1 ? "subject" : "subjects"}: ${subjects.join(", ")}.`,
-      "A character/person reference image may be a multi-view character sheet, turnaround sheet, or contact sheet. Every portrait and full-body view inside one character reference image depicts the same single person; use those views only to learn that one person's identity, face, hair, clothing, and proportions.",
+      faceHairOnly
+        ? "A character/person reference image may be a multi-view character sheet, turnaround sheet, or contact sheet. Every portrait and full-body view inside one character reference image depicts the same single person; use those views ONLY to learn that one person's face identity, facial features, and hair. Image 1 remains authoritative for clothing, body proportions, pose, accessories, framing, lighting, and background."
+        : "A character/person reference image may be a multi-view character sheet, turnaround sheet, or contact sheet. Every portrait and full-body view inside one character reference image depicts the same single person; use those views only to learn that one person's identity, face, hair, clothing, and proportions.",
       "Render exactly one on-screen instance of each named subject. Do not turn alternate views from a reference sheet into additional people. Do not duplicate, clone, twin, multiply, or add background copies of any referenced subject unless the scene explicitly requests duplicates.",
     ].join("\n");
   }
@@ -35369,11 +35631,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const characterMotionSpeed = Number(segment?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed ?? 4);
     const cameraMotionGuidance = String(segment?.camera_motion_speed_guidance || state.builderStoryboardDefaults?.camera_guidance || "").trim();
     const characterMotionGuidance = String(segment?.character_motion_guidance || state.builderStoryboardDefaults?.character_guidance || "").trim();
+    const cutPlan = storyboardCutPlanForDuration(duration, state.builderStoryboardDefaults?.minimax_h3_cut_frequency);
     parts.push(
       `Camera motion speed: ${Number.isFinite(cameraMotionSpeed) ? cameraMotionSpeed : 4}/10.`,
       cameraMotionGuidance || "Follow the selected camera speed as a hard motion requirement.",
       `Character motion speed: ${Number.isFinite(characterMotionSpeed) ? characterMotionSpeed : 4}/10.`,
       characterMotionGuidance || "Include physical character action appropriate to the selected character-motion speed.",
+      cutPlan.instruction,
     );
     if (cameraMotionSpeed >= 7) {
       parts.push("MANDATORY CAMERA RULE: use energetic, visibly active camera movement. Slow, gentle, subtle, restrained, locked-off, static, and hold camera language contradicts this setting and must not appear.");
@@ -35440,11 +35704,40 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     if (mode === "reference_to_video" || mode === "video_to_video") {
       const items = miniMaxOrderedImageReferenceItemsForSegment(segment, mode);
+      const promptInspiration = mode === "reference_to_video" && miniMaxH3SceneImageIsPromptInspiration(segment);
       const assignments = items.map((item, index) => {
         const detail = [item.label, item.description].map((value) => String(value || "").trim()).filter(Boolean).join(" — ");
-        return `Image ${index + 1}: ${miniMaxReferencePurposeText(item)}${detail ? `. ${detail}` : ""}`;
+        const attachmentMapping = promptInspiration ? ` (attached Picture ${index + 2})` : "";
+        return `Image ${index + 1}${attachmentMapping}: ${miniMaxReferencePurposeText(item, segment)}${detail ? `. ${detail}` : ""}`;
       });
       if (assignments.length) parts.push(`${mode === "video_to_video" ? "Ordered supporting edit-image assignments" : "Ordered image assignments"} (exact connected order):\n${assignments.join("\n")}`);
+      if (promptInspiration) {
+        const includesFraming = miniMaxH3SceneImageUseForSegment(segment) === "environment_framing_inspiration";
+        parts.push(
+          "PROMPT-ONLY SCENE-IMAGE INSPIRATION — MANDATORY:\n"
+          + "Attached Picture 1 is shown only to the prompt-writing vision LLM. It is NOT supplied to the MiniMax H3 renderer, is NOT a start frame, is NOT a renderer reference, consumes no MiniMax reference slot, and must never be identified or mentioned as Image 1 or any Image N in the finished prompt. "
+          + "Use Attached Picture 1 only to extract location and environment, atmosphere and mood, lighting and weather, colors, materials and background details, and relevant objects or environmental activity. "
+          + (includesFraming
+            ? "Camera framing, shot distance, camera angle, lens, and image composition may be used only as optional inspiration and may be changed freely to suit the requested scene. "
+            : "Explicitly ignore camera framing and shot distance, camera angle and lens, and image composition. Choose new camera coverage freely from the scene request and camera-motion settings. ")
+          + "Always ignore every visible character's identity, face, hair, body, clothing, accessories, pose, placement, and activity in Attached Picture 1. The assigned character reference images are the sole authority for the rendered character's complete identity and appearance. "
+          + "In the finished prompt, convert permitted environmental observations into direct scene description without mentioning Attached Picture 1, inspiration, source imagery, or analysis. Renderer Image 1 is attached as Picture 2, Renderer Image 2 as Picture 3, and so on; use only the renderer Image N labels in the finished prompt.",
+        );
+      }
+      if (mode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+        const characterInfluence = miniMaxH3StartFrameCharacterInfluenceForSegment(segment);
+        if (characterInfluence === "face_hair_only") {
+          parts.push(
+            "START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY:\n"
+            + "Image 1 remains authoritative for the subject's pose, body and body proportions, clothing, wardrobe styling, accessories, framing, composition, camera angle, environment, props, lighting, colors, and every other visible detail. Character-reference images may override Image 1 ONLY for the subject's face identity, facial features, and hair. The literal first generated frame must already depict the character-reference face and hair within Image 1's otherwise unchanged visual setup. Describe the intended character as directly present from the first frame. Do not use temporal comparison language such as 'now featuring,' 'becomes,' 'changes into,' or 'replaced by'; never describe or show a face swap, replacement process, morph, transition, or transformation. Never import the character reference's clothing, body, pose, accessories, framing, lighting, or background.",
+          );
+        } else {
+          parts.push(
+            "START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY:\n"
+            + "Image 1 controls the exact opening composition, pose, camera angle, environment, and lighting. Character-reference images control the subject's face, hair, clothing, body proportions, and identity details, including details hidden in Image 1.",
+          );
+        }
+      }
     }
     if (mode === "video_to_video") {
       const assignments = (Array.isArray(segment?.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
@@ -35472,13 +35765,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       return path || data ? [{ path, data }] : [];
     }
     if (mode === "reference_to_video" || mode === "video_to_video") {
-      return miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
+      const rendererImages = miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
         .map((item) => ({
           path: String(item?.image?.path || "").trim(),
           data: String(item?.image?.data || "").trim(),
         }))
         .filter((item) => item.path || item.data)
         .slice(0, 9);
+      if (mode !== "reference_to_video" || !miniMaxH3SceneImageIsPromptInspiration(segment)) return rendererImages;
+      const inspiration = segmentImageSource(segment);
+      const path = String(inspiration?.path || selectedSegmentImagePath(segment) || "").trim();
+      const data = String(inspiration?.data || "").trim();
+      return path || data ? [{ path, data, prompt_only_scene_inspiration: true }, ...rendererImages] : rendererImages;
     }
     return [];
   }
@@ -35501,11 +35799,20 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       return;
     }
     const visionImages = miniMaxH3PromptVisionImages(segment, mode);
+    const rendererReferenceImages = mode === "reference_to_video"
+      ? miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
+      : [];
+    const sceneImageUse = miniMaxH3SceneImageUseForSegment(segment);
+    const sceneImageSourceAvailable = Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
     if (mode === "image_to_video" && !visionImages.length) {
       toast("Image to Video needs a selected scene image before the LLM can create its MiniMax prompt.", true);
       return;
     }
-    if (mode === "reference_to_video" && !visionImages.length) {
+    if (mode === "reference_to_video" && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
+      toast("The selected scene-image mode needs a timeline image for this scene before the LLM can create its MiniMax prompt.", true);
+      return;
+    }
+    if (mode === "reference_to_video" && !rendererReferenceImages.length) {
       toast("Reference to Video needs at least one ordered Reference Builder image.", true);
       return;
     }
@@ -35554,6 +35861,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         location_context: segmentMappedLocationText(segment),
         no_character_present: Boolean(segment.no_character_present),
         image_references: visionImages,
+        prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(segment),
         performance_mode: effectiveVideoPerformanceModeForSegment(segment),
         lyric_text: promptLyricText,
         singers: promptSingerNames,
@@ -36562,6 +36870,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         const imageReference = getI2VImageReference(segment);
         const referenceData = storyboardReferenceDataForSegment(segment);
         const promptSummary = storyboardSummaryForSegment(segment, imagePrompt, videoPrompt, referenceData);
+        const cutPlan = miniMaxProject
+          ? storyboardCutPlanForDuration(timelineSegmentDuration(segment), defaults.minimax_h3_cut_frequency)
+          : null;
         const subjectRefNames = (referenceData.subject_refs || [])
           .map((subject) => String(subject?.name || "").trim())
           .filter(Boolean);
@@ -36593,6 +36904,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           project_video_engine: normalizeProjectVideoEngine(state.projectVideoEngine),
           minimax_h3_mode: miniMaxH3ModeForSegment(segment),
           minimax_h3_audio_mode: miniMaxH3SettingsForSegment(segment).audio_mode,
+          ...(cutPlan ? {
+            minimax_h3_cut_frequency: cutPlan.frequency,
+            cut_plan: cutPlan,
+          } : {}),
           video_style: String(segment.minimax_h3_video_style || defaults.video_style || "").trim(),
           video_style_custom: String(segment.minimax_h3_video_style_custom || defaults.video_style_custom || "").trim(),
           temporal_world_effect_override: String(segment.temporal_world_effect_override || "global").trim(),
@@ -36660,9 +36975,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       facialPerformanceCustom: state.defaultFacialPerformanceCustom || "",
       cameraMotionSpeed: Number(defaults.camera_motion_speed ?? 4),
       characterMotionSpeed: Number(defaults.character_motion_speed ?? 4),
+      cutFrequency: storyboardCutFrequencyValue(defaults.minimax_h3_cut_frequency),
       motion_defaults: {
         camera_motion_speed: Number(defaults.camera_motion_speed ?? 4),
         character_motion_speed: Number(defaults.character_motion_speed ?? 4),
+        minimax_h3_cut_frequency: storyboardCutFrequencyValue(defaults.minimax_h3_cut_frequency),
         camera_guidance: defaults.camera_guidance || "",
         character_guidance: defaults.character_guidance || "",
       },
@@ -36805,7 +37122,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         || Object.prototype.hasOwnProperty.call(updates, "temporal_world_effect")
         || Object.prototype.hasOwnProperty.call(updates, "temporalWorldEffect")
         || Object.prototype.hasOwnProperty.call(updates, "short_film_planning_mode")
-        || Object.prototype.hasOwnProperty.call(updates, "shortFilmPlanningMode");
+        || Object.prototype.hasOwnProperty.call(updates, "shortFilmPlanningMode")
+        || Object.prototype.hasOwnProperty.call(updates, "minimax_h3_cut_frequency")
+        || Object.prototype.hasOwnProperty.call(updates, "cutFrequency");
       if (hasIncomingFacialDefault) {
         const nextDefault = String(updates.facial_performance_default ?? updates.facialPerformance ?? updates.default_facial_performance ?? "").trim();
         if (state.defaultFacialPerformance !== nextDefault) {
@@ -36837,6 +37156,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           temporal_protected_characters: updates.temporal_protected_characters ?? updates.temporalProtectedCharacters ?? updates.builder_storyboard_defaults?.temporal_protected_characters ?? updates.storyboard_defaults?.temporal_protected_characters ?? state.builderStoryboardDefaults?.temporal_protected_characters,
           temporal_protected_custom: updates.temporal_protected_custom ?? updates.temporalProtectedCustom ?? updates.builder_storyboard_defaults?.temporal_protected_custom ?? updates.storyboard_defaults?.temporal_protected_custom ?? state.builderStoryboardDefaults?.temporal_protected_custom,
           short_film_planning_mode: updates.short_film_planning_mode ?? updates.shortFilmPlanningMode ?? updates.builder_storyboard_defaults?.short_film_planning_mode ?? updates.storyboard_defaults?.short_film_planning_mode ?? state.builderStoryboardDefaults?.short_film_planning_mode,
+          minimax_h3_cut_frequency: updates.minimax_h3_cut_frequency ?? updates.cut_frequency ?? updates.cutFrequency ?? updates.builder_storyboard_defaults?.minimax_h3_cut_frequency ?? updates.storyboard_defaults?.minimax_h3_cut_frequency ?? state.builderStoryboardDefaults?.minimax_h3_cut_frequency,
           camera_motion_speed: updates.camera_motion_speed ?? updates.cameraMotionSpeed ?? updates.motion_defaults?.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed,
           character_motion_speed: updates.character_motion_speed ?? updates.characterMotionSpeed ?? updates.motion_defaults?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed,
         });
@@ -36957,9 +37277,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       add(parts, "MANDATORY exact temporal / world effect verbiage — copy word-for-word", selectedScene.temporal_world_effect_verbiage);
       const customMotionSummary = String(selectedScene.motion_summary || scene.motion_summary || scene.video_notes || "").trim();
       add(parts, "Storyboard motion/video summary", customMotionSummary);
-        if (!customMotionSummary) add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
-        if (!fullyCustomShortFilm) add(parts, "REQUIRED Storyboard camera-flow framing", selectedScene.camera_flow_guidance);
-        add(parts, "Storyboard camera motion speed guidance", selectedScene.camera_motion_speed_guidance || selectedScene.camera_guidance?.camera_motion_speed_guidance);
+      if (!customMotionSummary) add(parts, "Storyboard camera motion", selectedScene.camera_motion || scene.camera_motion);
+      if (!fullyCustomShortFilm) add(parts, "REQUIRED Storyboard camera-flow framing", selectedScene.camera_flow_guidance);
+      add(parts, "Storyboard camera motion speed guidance", selectedScene.camera_motion_speed_guidance || selectedScene.camera_guidance?.camera_motion_speed_guidance);
       add(parts, "Storyboard character motion guidance", selectedScene.character_motion_guidance || scene.character_motion);
       add(parts, "Storyboard performance direction", selectedScene.performance_direction || scene.performance_style);
       add(parts, "Storyboard facial performance direction", selectedScene.facial_performance_direction || scene.facial_performance_custom || scene.facial_performance);
@@ -37201,10 +37521,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           ? segment.minimax_h3_video_references
           : []).map((item) => ({ ...item }));
         const visionImages = miniMaxH3PromptVisionImages(workingSegment, mode);
+        const rendererReferenceImages = mode === "reference_to_video"
+          ? miniMaxOrderedImageReferenceItemsForSegment(workingSegment, mode)
+          : [];
+        const sceneImageUse = miniMaxH3SceneImageUseForSegment(workingSegment);
+        const sceneImageSourceAvailable = Boolean(segmentImageSource(workingSegment)?.path || segmentImageSource(workingSegment)?.data);
         if (mode === "image_to_video" && !visionImages.length) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Image to Video needs a selected scene image.`);
         }
-        if (mode === "reference_to_video" && !visionImages.length) {
+        if (mode === "reference_to_video" && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
+          throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: the selected scene-image mode needs a timeline image for LLM prompting.`);
+        }
+        if (mode === "reference_to_video" && !rendererReferenceImages.length) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Reference to Video needs ordered Reference Builder images.`);
         }
         if (mode === "video_to_video" && !workingSegment.minimax_h3_video_references.some((item) => String(item?.path || "").trim())) {
@@ -37231,6 +37559,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           location_context: segmentMappedLocationText(workingSegment),
           no_character_present: Boolean(workingSegment.no_character_present),
           image_references: visionImages,
+          prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(workingSegment),
           performance_mode: effectiveVideoPerformanceModeForSegment(workingSegment),
           lyric_text: segmentUsesNoLipSyncPerformance(workingSegment) || isInstrumentalLyricText(workingSegment.lyric_text) ? "" : flattenLyricForPrompt(workingSegment.lyric_text),
           singers: segmentUsesNoLipSyncPerformance(workingSegment) ? [] : (Array.isArray(workingSegment.lyric_singers) ? workingSegment.lyric_singers : []),
@@ -37563,9 +37892,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       temporalProtectedCustom: state.builderStoryboardDefaults?.temporal_protected_custom || "",
       cameraMotionSpeed: state.builderStoryboardDefaults?.camera_motion_speed ?? 4,
       characterMotionSpeed: state.builderStoryboardDefaults?.character_motion_speed ?? 4,
+      cutFrequency: state.builderStoryboardDefaults?.minimax_h3_cut_frequency ?? 0,
       motion_defaults: {
         camera_motion_speed: state.builderStoryboardDefaults?.camera_motion_speed ?? 4,
         character_motion_speed: state.builderStoryboardDefaults?.character_motion_speed ?? 4,
+        minimax_h3_cut_frequency: state.builderStoryboardDefaults?.minimax_h3_cut_frequency ?? 0,
         camera_guidance: state.builderStoryboardDefaults?.camera_guidance || "",
         character_guidance: state.builderStoryboardDefaults?.character_guidance || "",
       },
@@ -39443,6 +39774,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         easy_cache_verbose: miniMaxSettings.easy_cache_verbose,
         sage_attention: miniMaxSettings.sage_attention,
         enable_fp16_accumulation: miniMaxSettings.enable_fp16_accumulation,
+        use_turbo_lora: miniMaxSettings.use_turbo_lora,
+        turbo_lora_name: miniMaxSettings.turbo_lora_name,
+        turbo_lora_strength: miniMaxSettings.turbo_lora_strength,
         image_paths: imagePaths,
         video_references: videoReferences,
       };
@@ -43052,10 +43386,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         repair_lyric_segments: false,
         text_gemma_runner: state.textGemmaRunner || "builtin",
         gemma_context_limit: normalizeGemmaContextLimit(state.gemmaContextLimit),
+        gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
         gemma_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
         lm_studio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
         lm_studio_model: state.lmStudioModel || "",
         lm_studio_api_key: state.lmStudioApiKey || "",
+        lm_studio_context_limit: normalizeLmStudioContextLimit(state.lmStudioContextLimit),
+        lm_studio_output_token_limit: normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit),
       };
 
       progress.set("Saving Prompt Creator draft from this timeline...", 70);
@@ -45226,6 +45563,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     gemmaContextLimit.min = "512";
     gemmaContextLimit.max = "262144";
     gemmaContextLimit.step = "256";
+    const gemmaOutputTokenLimit = makeInput(String(normalizeOutputTokenLimit(state.gemmaOutputTokenLimit)), "number");
+    gemmaOutputTokenLimit.min = "64";
+    gemmaOutputTokenLimit.max = "262144";
+    gemmaOutputTokenLimit.step = "256";
     const gemmaGpuLayers = makeInput(String(normalizeGemmaGpuLayers(state.gemmaGpuLayers)), "number");
     gemmaGpuLayers.min = "0";
     gemmaGpuLayers.max = "999";
@@ -45234,13 +45575,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     builtinPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
     const builtinNote = document.createElement("div");
     builtinNote.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;";
-    builtinNote.textContent = "Advanced local GGUF settings. Context limit controls how much text Gemma Local can accept. Higher context can use much more RAM/VRAM and may slow down, hang, fail, or run out of memory.";
+    builtinNote.textContent = "Advanced local GGUF settings. Context limit is the model's total input/output window; maximum output tokens is the most text one request may generate. Their combined use must fit the loaded model. Higher values can use much more RAM/VRAM and take longer.";
     const gpuNote = document.createElement("div");
     gpuNote.style.cssText = "font-size:12px;color:#94a3b8;line-height:1.4;";
     gpuNote.textContent = "Lower GPU layers if Gemma Local runs out of VRAM; try 12 for 10GB cards. Higher values use more VRAM and may run faster.";
     builtinPanel.append(
       builtinNote,
       makeField("Context limit / n_ctx", gemmaContextLimit),
+      makeField("Maximum output tokens", gemmaOutputTokenLimit),
       gpuNote,
       makeField("GPU layers / n_gpu_layers", gemmaGpuLayers),
     );
@@ -45251,11 +45593,19 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const modelPickerRow = document.createElement("div");
     modelPickerRow.style.cssText = "display:grid;grid-template-columns:1fr auto;gap:8px;align-items:end;";
     const lmStudioApiKey = makeInput(state.lmStudioApiKey || "", "password");
+    const lmStudioContextLimit = makeInput(String(normalizeLmStudioContextLimit(state.lmStudioContextLimit)), "number");
+    lmStudioContextLimit.min = "512";
+    lmStudioContextLimit.max = "262144";
+    lmStudioContextLimit.step = "256";
+    const lmStudioOutputTokenLimit = makeInput(String(normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit)), "number");
+    lmStudioOutputTokenLimit.min = "64";
+    lmStudioOutputTokenLimit.max = "262144";
+    lmStudioOutputTokenLimit.step = "256";
     const lmPanel = document.createElement("div");
     lmPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
     const note = document.createElement("div");
     note.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;";
-    note.textContent = "In LM Studio, load your Gemma GGUF model, open the Local Server tab, start the server, then copy the model name shown there. No extra Python install is needed.";
+    note.textContent = "In LM Studio, load your model and start the Local Server. Input context and maximum output tokens are sent with every text and vision request. Their combined use must fit the model; larger values need more memory and time.";
     const test = makeButton("Test LM Studio", "primary");
     const apiPanel = document.createElement("div");
     apiPanel.style.cssText = "display:flex;flex-direction:column;gap:10px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:12px;";
@@ -45364,6 +45714,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       modelPickerRow,
       makeField("LM Studio model name", model),
       makeField("API key (usually blank for local LM Studio)", lmStudioApiKey),
+      makeField("Input context limit", lmStudioContextLimit),
+      makeField("Maximum output tokens", lmStudioOutputTokenLimit),
       test,
     );
     apiPanel.append(
@@ -45377,7 +45729,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const syncVisibility = () => {
       state.textGemmaRunner = runner.value || "builtin";
       state.gemmaContextLimit = normalizeGemmaContextLimit(gemmaContextLimit.value);
+      state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(gemmaOutputTokenLimit.value);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(gemmaGpuLayers.value);
+      state.lmStudioContextLimit = normalizeLmStudioContextLimit(lmStudioContextLimit.value);
+      state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(lmStudioOutputTokenLimit.value);
       builtinPanel.style.display = runner.value === "builtin" ? "flex" : "none";
       lmPanel.style.display = runner.value === "lm_studio" ? "flex" : "none";
       apiPanel.style.display = runner.value === "llm_api" ? "flex" : "none";
@@ -45388,6 +45743,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.lmStudioBaseUrl = baseUrl.value || "http://127.0.0.1:1234/v1";
       state.lmStudioModel = model.value || "";
       state.lmStudioApiKey = lmStudioApiKey.value || "";
+      state.lmStudioContextLimit = normalizeLmStudioContextLimit(lmStudioContextLimit.value);
+      state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(lmStudioOutputTokenLimit.value);
       let progress = null;
       try {
         progress = createProgressWindow("Testing LM Studio");
@@ -45398,7 +45755,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           reference_type: "location",
           source_text: "small empty test room",
           style_theme: "",
-          max_new_tokens: 120,
+          max_new_tokens: Math.min(120, normalizeOutputTokenLimit(state.lmStudioOutputTokenLimit)),
         }, 60000);
         progress.set(`LM Studio responded successfully:\n${data.prompt}`, 100);
         progress.close(4000);
@@ -45422,10 +45779,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     save.onclick = async () => {
       state.textGemmaRunner = runner.value || "builtin";
       state.gemmaContextLimit = normalizeGemmaContextLimit(gemmaContextLimit.value);
+      state.gemmaOutputTokenLimit = normalizeOutputTokenLimit(gemmaOutputTokenLimit.value);
       state.gemmaGpuLayers = normalizeGemmaGpuLayers(gemmaGpuLayers.value);
       state.lmStudioBaseUrl = baseUrl.value || "http://127.0.0.1:1234/v1";
       state.lmStudioModel = model.value || "";
       state.lmStudioApiKey = lmStudioApiKey.value || "";
+      state.lmStudioContextLimit = normalizeLmStudioContextLimit(lmStudioContextLimit.value);
+      state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(lmStudioOutputTokenLimit.value);
       state.llmApiProvider = apiProvider.value || "openai";
       state.llmApiModel = apiModel.value || "";
       state.llmApiKey = runner.value === "llm_api" ? llmApiKey.value || "" : state.llmApiKey || "";
@@ -46581,22 +46941,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         toast(String(error?.message || error), true);
         return { mapped: 0, error: String(error?.message || error) };
       }
-    };
-    chooseProjectRootButton.onclick = async () => {
-      const path = await pickPath("project_root", projectRootInput);
-      if (path) projectRootInput.value = path;
-    };
-    saveProjectRootButton.onclick = () => {
-      const root = setPreferredProjectRoot(projectRootInput.value);
-      projectRootInput.value = root;
-      toast(root
-        ? `New projects will be created under:\n${root}`
-        : "New projects will use the ComfyUI output folder.");
-    };
-    clearProjectRootButton.onclick = () => {
-      projectRootInput.value = "";
-      setPreferredProjectRoot("");
-      toast("New projects will use the ComfyUI output folder.");
     };
     const applyWizardSceneDefaultSettingsToState = (settings = {}) => {
       const cameraSpeed = Math.max(0, Math.min(10, Number(settings.cameraMotionSpeed ?? settings.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed ?? 4)));
@@ -48130,7 +48474,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   loadSessionButton.onclick = loadSession;
   loadLastProjectButton.onclick = loadLastProject;
   promptCreatorButton.onclick = confirmOpenLegacyPromptCreator;
-  wizardButton.onclick = openWizardFromBuilder;
+  wizardButton.onclick = () => {
+    try {
+      openWizardFromBuilder();
+    } catch (error) {
+      console.error("VRGDG Video Wizard failed to open", error);
+      toast(`Video Wizard failed to open:\n${String(error?.message || error)}`, true);
+    }
+  };
   storyboardBuilderButton.onclick = () => {
     try {
       openStoryboardBuilderFromProject();
@@ -49058,6 +49409,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (!ltxIngredientsLoraPicker.input.value) ltxIngredientsLoraPicker.input.value = REQUIRED_LTX_INGREDIENTS_LORA;
     ltxIdLoraPicker.options = loras;
     if (!ltxIdLoraPicker.input.value) ltxIdLoraPicker.input.value = REQUIRED_LTX_ID_LORA;
+    miniMaxTurboLoraPicker.options = loras;
+    if (!miniMaxTurboLoraPicker.input.value) {
+      miniMaxTurboLoraPicker.input.value = DEFAULT_MINIMAX_H3_SETTINGS.turbo_lora_name;
+    }
   }
 
   async function confirmAndRunFullFLFBuild() {
@@ -49261,6 +49616,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     wireSearchablePicker(picker, saveMiniMaxH3SettingsFromPanel);
     picker.input.addEventListener("change", persistMiniMaxSettings);
   }
+  wireSearchablePicker(miniMaxTurboLoraPicker, saveMiniMaxH3SettingsFromPanel);
+  miniMaxTurboLoraPicker.input.addEventListener("change", persistMiniMaxSettings);
   for (const control of [
     miniMaxAspectRatio,
     miniMaxAudioMode,
@@ -49280,10 +49637,34 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     miniMaxEasyCacheVerbose.input,
     miniMaxSageAttention,
     miniMaxFp16Accumulation.input,
+    miniMaxTurboLoraStrength,
   ]) {
     control.addEventListener("input", saveMiniMaxH3SettingsFromPanel);
     control.addEventListener("change", persistMiniMaxSettings);
   }
+  miniMaxUseTurboLora.input.addEventListener("change", () => {
+    const segment = activeSegment();
+    const currentSettings = miniMaxH3SettingsForSegment(segment);
+    if (miniMaxUseTurboLora.input.checked) {
+      currentSettings.steps_before_turbo = Math.max(1, Math.trunc(Number(miniMaxSteps.value) || DEFAULT_MINIMAX_H3_SETTINGS.steps));
+      currentSettings.easy_cache_bypass_before_turbo = miniMaxEasyCacheBypass.input.checked;
+      miniMaxSteps.value = "6";
+      miniMaxEasyCacheBypass.input.checked = true;
+    } else {
+      miniMaxSteps.value = String(currentSettings.steps_before_turbo || DEFAULT_MINIMAX_H3_SETTINGS.steps);
+      miniMaxEasyCacheBypass.input.checked = Boolean(currentSettings.easy_cache_bypass_before_turbo);
+    }
+    const settings = saveMiniMaxH3SettingsFromPanel();
+    settings.steps_before_turbo = currentSettings.steps_before_turbo;
+    settings.easy_cache_bypass_before_turbo = currentSettings.easy_cache_bypass_before_turbo;
+    if (segment?.use_scene_minimax_h3_settings) {
+      segment.minimax_h3_settings = settings;
+    } else {
+      state.miniMaxH3Settings = settings;
+    }
+    syncMiniMaxH3Panel();
+    autoSaveSessionQuiet("MiniMax H3 Turbo setting").catch(() => null);
+  });
   for (const button of miniMaxModeButtons) {
     button.onclick = async () => {
       const segment = requireActiveSegment();
@@ -49300,13 +49681,19 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const continuityMode = normalizeMiniMaxH3ContinuityMode(miniMaxContinuityMode.value);
     const affectedSegments = segment?.use_scene_minimax_h3_settings
       ? [segment]
-      : allEditableSegments().filter((item) => miniMaxH3ContinuityModeForSegment(item) === "exact_start_frame");
+      : allEditableSegments().filter((item) => (
+        !item?.use_scene_minimax_h3_settings
+        && miniMaxH3ContinuityModeForSegment(item) === "exact_start_frame"
+      ));
     const clearedStartFrames = continuityMode === "exact_start_frame"
       ? affectedSegments.filter((item) => item?.minimax_h3_use_scene_image_as_start_frame)
       : [];
-    for (const item of clearedStartFrames) item.minimax_h3_use_scene_image_as_start_frame = false;
+    for (const item of clearedStartFrames) {
+      item.minimax_h3_use_scene_image_as_start_frame = false;
+      item.minimax_h3_scene_image_use = "off";
+    }
     if (clearedStartFrames.length) {
-      miniMaxUseSceneImageAsStartFrame.input.checked = false;
+      miniMaxSceneImageUse.value = "off";
       toast(`Previous-frame exact continuation is now the sole exact start frame. Turned off the scene-image exact start-frame option for ${clearedStartFrames.length} scene${clearedStartFrames.length === 1 ? "" : "s"}.`);
     }
     syncMiniMaxH3Panel();
@@ -49332,22 +49719,96 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   };
   miniMaxPrompt.addEventListener("input", saveMiniMaxSceneInputsFromPanel);
   miniMaxPrompt.addEventListener("change", () => autoSaveSessionQuiet("MiniMax H3 scene prompt").catch(() => null));
-  miniMaxUseSceneImageAsStartFrame.input.addEventListener("change", async () => {
+  miniMaxSceneImageUse.addEventListener("change", async () => {
     const segment = requireActiveSegment();
     if (!segment) return;
-    if (miniMaxUseSceneImageAsStartFrame.input.checked
-      && normalizeMiniMaxH3ContinuityMode(miniMaxH3SettingsForSegment(segment).continuity_mode) === "exact_start_frame") {
-      miniMaxUseSceneImageAsStartFrame.input.checked = false;
-      toast("Choose either the scene image as the exact start frame or the previous rendered final frame as the exact start frame—not both.", true);
+    const sceneImageUse = normalizeMiniMaxH3SceneImageUse(miniMaxSceneImageUse.value);
+    const exactStartFrame = sceneImageUse === "exact_start_frame";
+    const usesSceneImage = sceneImageUse !== "off";
+    const characterInfluence = normalizeMiniMaxH3StartFrameCharacterInfluence(
+      miniMaxStartFrameCharacterInfluence.value,
+    );
+    const sceneLocked = Boolean(segment.use_scene_minimax_h3_settings);
+    const candidates = (sceneLocked ? [segment] : allEditableSegments()).filter((item) => (
+      segmentTrack(item) !== "overlay"
+      && miniMaxH3ModeForSegment(item) === "reference_to_video"
+      && (sceneLocked || !item.use_scene_minimax_h3_settings)
+    ));
+    const blocked = exactStartFrame
+      ? candidates.filter((item) => miniMaxH3ContinuityModeForSegment(item) === "exact_start_frame")
+      : [];
+    const targets = exactStartFrame
+      ? candidates.filter((item) => miniMaxH3ContinuityModeForSegment(item) !== "exact_start_frame")
+      : candidates;
+    if (!targets.length) {
+      miniMaxSceneImageUse.value = miniMaxH3SceneImageUseForSegment(segment);
+      toast(blocked.length
+        ? "Every Reference-to-Video scene is using the previous rendered frame as its exact start, so the scene-image start frame could not be enabled."
+        : "There are no eligible Reference-to-Video scenes to update.", true);
       return;
     }
     pushHistory();
-    saveMiniMaxSceneInputsFromPanel();
+    for (const item of targets) {
+      item.minimax_h3_scene_image_use = sceneImageUse;
+      item.minimax_h3_use_scene_image_as_start_frame = exactStartFrame;
+      item.minimax_h3_start_frame_character_influence = characterInfluence;
+    }
+    const missingSceneImages = usesSceneImage
+      ? targets.filter((item) => !Boolean(segmentImageSource(item)?.path || segmentImageSource(item)?.data))
+      : [];
+    syncMiniMaxH3Panel();
     syncMiniMaxReferenceButtons();
-    await autoSaveSessionQuiet("MiniMax H3 start frame reference");
-    toast(miniMaxUseSceneImageAsStartFrame.input.checked
-      ? "The scene image will be sent as Image 1 and the exact MiniMax start frame."
-      : "The scene image will no longer be forced as the MiniMax start frame.");
+    await autoSaveSessionQuiet("MiniMax H3 scene image use");
+    if (usesSceneImage) {
+      const scopeLabel = sceneLocked
+        ? "this locked Reference-to-Video scene"
+        : `${targets.length} unlocked Reference-to-Video scene${targets.length === 1 ? "" : "s"}`;
+      const action = exactStartFrame
+        ? "Uses each scene image as MiniMax Image 1 and the exact start frame"
+        : sceneImageUse === "environment_inspiration"
+          ? "Uses each scene image only as environment inspiration for the prompt-writing LLM; framing and all character details are ignored, and MiniMax never receives the image"
+          : "Uses each scene image only as environment and framing inspiration for the prompt-writing LLM; all character details are ignored, and MiniMax never receives the image";
+      const details = [
+        `${action} for ${scopeLabel}.`,
+        blocked.length ? `Skipped ${blocked.length} scene${blocked.length === 1 ? "" : "s"} using previous-frame exact continuity.` : "",
+        missingSceneImages.length ? `${missingSceneImages.length} enabled scene${missingSceneImages.length === 1 ? " still needs" : "s still need"} a timeline image before prompting or rendering.` : "",
+        "Regenerate existing MiniMax prompts to apply this setup.",
+      ].filter(Boolean);
+      toast(details.join("\n"), Boolean(missingSceneImages.length));
+    } else {
+      toast(sceneLocked
+        ? "The scene image will not be used for this locked Reference-to-Video scene."
+        : `Turned off scene-image use for all ${targets.length} unlocked Reference-to-Video scene${targets.length === 1 ? "" : "s"}.`);
+    }
+  });
+  miniMaxStartFrameCharacterInfluence.addEventListener("change", async () => {
+    const segment = requireActiveSegment();
+    if (!segment) return;
+    const characterInfluence = normalizeMiniMaxH3StartFrameCharacterInfluence(
+      miniMaxStartFrameCharacterInfluence.value,
+    );
+    const sceneLocked = Boolean(segment.use_scene_minimax_h3_settings);
+    const targets = (sceneLocked ? [segment] : allEditableSegments()).filter((item) => (
+      segmentTrack(item) !== "overlay"
+      && miniMaxH3ModeForSegment(item) === "reference_to_video"
+      && (sceneLocked || !item.use_scene_minimax_h3_settings)
+    ));
+    if (!targets.length) {
+      toast("There are no eligible Reference-to-Video scenes to update.", true);
+      return;
+    }
+    pushHistory();
+    for (const item of targets) {
+      item.minimax_h3_start_frame_character_influence = characterInfluence;
+    }
+    syncMiniMaxH3Panel();
+    await autoSaveSessionQuiet("MiniMax H3 global start-frame character influence");
+    const scopeLabel = sceneLocked
+      ? "this locked Reference-to-Video scene"
+      : `all ${targets.length} unlocked Reference-to-Video scene${targets.length === 1 ? "" : "s"}`;
+    toast(miniMaxStartFrameCharacterInfluence.value === "face_hair_only"
+      ? `Character references will supply only face and hair for ${scopeLabel}. Regenerate existing MiniMax prompts to apply the new priority.`
+      : `Character references may supply the full character identity for ${scopeLabel}. Regenerate existing MiniMax prompts to apply the new priority.`);
   });
   for (const row of miniMaxVideoReferenceRows) {
     for (const control of [row.path, row.start, row.duration, row.purpose, row.useAudio.input]) {

--- a/web/VRGDG_MusicVideoPromptCreatorUI.js
+++ b/web/VRGDG_MusicVideoPromptCreatorUI.js
@@ -585,9 +585,13 @@ function buildPayload(controls, modelSelect) {
     srt_text: controls.srtText.value,
     output_srt_path: controls.srtOutput.value,
     text_runner: controls.textGemmaRunner || "builtin",
+    gemma_context_limit: controls.gemmaContextLimit || 8000,
+    gemma_output_token_limit: controls.gemmaOutputTokenLimit || 8192,
     lmstudio_base_url: controls.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
     lmstudio_model: controls.lmStudioModel || "",
     lmstudio_api_key: controls.lmStudioApiKey || "",
+    lmstudio_context_limit: controls.lmStudioContextLimit || 32768,
+    lmstudio_output_token_limit: controls.lmStudioOutputTokenLimit || 8192,
     llm_api_provider: controls.llmApiProvider || "openai",
     llm_api_model: controls.llmApiModel || "",
     llm_api_key: controls.llmApiKey || "",
@@ -595,6 +599,8 @@ function buildPayload(controls, modelSelect) {
     lm_studio_base_url: controls.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
     lm_studio_model: controls.lmStudioModel || "",
     lm_studio_api_key: controls.lmStudioApiKey || "",
+    lm_studio_context_limit: controls.lmStudioContextLimit || 32768,
+    lm_studio_output_token_limit: controls.lmStudioOutputTokenLimit || 8192,
   };
 }
 
@@ -672,9 +678,13 @@ function openPromptCreator(options = {}) {
     i2vMotionNotes: {},
     extractedSubject: "",
     textGemmaRunner: "builtin",
+    gemmaContextLimit: 8000,
+    gemmaOutputTokenLimit: 8192,
     lmStudioBaseUrl: "http://127.0.0.1:1234/v1",
     lmStudioModel: "",
     lmStudioApiKey: "",
+    lmStudioContextLimit: 32768,
+    lmStudioOutputTokenLimit: 8192,
     llmApiProvider: "openai",
     llmApiModel: "",
     llmApiKey: "",
@@ -923,9 +933,13 @@ function openPromptCreator(options = {}) {
 
   function syncRunnerControls() {
     controls.textGemmaRunner = state.textGemmaRunner;
+    controls.gemmaContextLimit = state.gemmaContextLimit;
+    controls.gemmaOutputTokenLimit = state.gemmaOutputTokenLimit;
     controls.lmStudioBaseUrl = state.lmStudioBaseUrl;
     controls.lmStudioModel = state.lmStudioModel;
     controls.lmStudioApiKey = state.lmStudioApiKey;
+    controls.lmStudioContextLimit = state.lmStudioContextLimit;
+    controls.lmStudioOutputTokenLimit = state.lmStudioOutputTokenLimit;
     controls.llmApiProvider = state.llmApiProvider;
     controls.llmApiModel = state.llmApiModel;
     controls.llmApiKey = state.llmApiKey;
@@ -1508,9 +1522,13 @@ function openPromptCreator(options = {}) {
     state.i2vMotionNotes = parseJsonSafe(i2vMotionOutput.value, {});
     state.extractedSubject = subjectOutput.value || "";
     state.textGemmaRunner = draft.text_gemma_runner || draft.text_runner || draft.textGemmaRunner || state.textGemmaRunner || "builtin";
+    state.gemmaContextLimit = Number(draft.gemma_context_limit || draft.n_ctx || draft.llm_max_tokens || draft.llmMaxTokens || state.gemmaContextLimit || 8000);
+    state.gemmaOutputTokenLimit = Number(draft.gemma_output_token_limit || draft.llm_max_tokens || draft.llmMaxTokens || state.gemmaOutputTokenLimit || 8192);
     state.lmStudioBaseUrl = draft.lm_studio_base_url || draft.lmstudio_base_url || draft.lmStudioBaseUrl || state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1";
     state.lmStudioModel = draft.lm_studio_model || draft.lmstudio_model || draft.lmStudioModel || state.lmStudioModel || "";
     state.lmStudioApiKey = draft.lm_studio_api_key || draft.lmstudio_api_key || draft.lmStudioApiKey || state.lmStudioApiKey || "";
+    state.lmStudioContextLimit = Number(draft.lm_studio_context_limit || draft.lmstudio_context_limit || state.lmStudioContextLimit || 32768);
+    state.lmStudioOutputTokenLimit = Number(draft.lm_studio_output_token_limit || draft.lmstudio_output_token_limit || draft.llm_max_tokens || draft.llmMaxTokens || state.lmStudioOutputTokenLimit || 8192);
     state.llmApiProvider = draft.llm_api_provider || draft.llmApiProvider || state.llmApiProvider || "openai";
     state.llmApiModel = draft.llm_api_model || draft.llmApiModel || state.llmApiModel || "";
     syncRunnerControls();
@@ -1645,9 +1663,13 @@ function openPromptCreator(options = {}) {
       temperature: 0.75,
       top_p: 0.95,
       text_runner: state.textGemmaRunner || "builtin",
+      gemma_context_limit: state.gemmaContextLimit || 8000,
+      gemma_output_token_limit: state.gemmaOutputTokenLimit || 8192,
       lmstudio_base_url: state.lmStudioBaseUrl || "http://127.0.0.1:1234/v1",
       lmstudio_model: state.lmStudioModel || "",
       lmstudio_api_key: state.lmStudioApiKey || "",
+      lmstudio_context_limit: state.lmStudioContextLimit || 32768,
+      lmstudio_output_token_limit: state.lmStudioOutputTokenLimit || 8192,
       llm_api_provider: state.llmApiProvider || "openai",
       llm_api_model: state.llmApiModel || "",
       llm_api_key: state.llmApiKey || "",

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -2406,6 +2406,54 @@ function storyboardSpeedValue(value, fallback = 4) {
   return Number.isFinite(number) ? Math.max(0, Math.min(10, number)) : fallback;
 }
 
+export function storyboardCutFrequencyValue(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.min(10, Math.round(number))) : fallback;
+}
+
+export function storyboardCutFrequencyLabel(value) {
+  const frequency = storyboardCutFrequencyValue(value);
+  if (frequency <= 0) return "0 / continuous shot";
+  if (frequency >= 10) return "10 / cut every second";
+  if (frequency <= 3) return `${frequency} / occasional cuts`;
+  if (frequency <= 6) return `${frequency} / moderate cuts`;
+  return `${frequency} / frequent cuts`;
+}
+
+export function storyboardCutPlanForDuration(durationValue, frequencyValue) {
+  const duration = Math.max(0, Number(durationValue) || 0);
+  const frequency = storyboardCutFrequencyValue(frequencyValue);
+  const maximumCuts = Math.max(0, Math.ceil(Math.max(0, duration - 0.000001)) - 1);
+  const nonMaximumCutLimit = Math.max(1, maximumCuts - 1);
+  const cutCount = frequency <= 0 || maximumCuts <= 0
+    ? 0
+    : frequency >= 10
+      ? maximumCuts
+      : Math.min(nonMaximumCutLimit, Math.max(1, Math.round(maximumCuts * frequency / 10)));
+  let cutTimes = [];
+  if (cutCount > 0) {
+    cutTimes = cutCount === maximumCuts
+      ? Array.from({ length: cutCount }, (_, index) => index + 1)
+      : Array.from({ length: cutCount }, (_, index) => duration * (index + 1) / (cutCount + 1));
+    cutTimes = cutTimes.map((time) => Number(time.toFixed(3)));
+  }
+  const exactDuration = Number(duration.toFixed(3));
+  const timingText = cutTimes.map((time) => `${time}s`).join(", ");
+  const instruction = cutCount > 0
+    ? `EDITING / CUT PLAN — MANDATORY: Cut frequency ${frequency}/10 for this exact ${exactDuration}-second segment requires exactly ${cutCount} hard CUT TO transition${cutCount === 1 ? "" : "s"}, at approximately ${timingText}, creating ${cutCount + 1} coherent shots. Begin with shot 1 at 0s. At every listed time, write an explicit new timestamp block beginning with CUT TO: and change to a clearly different but continuity-preserving angle, framing, or story detail within the same scene and ongoing action. Preserve identity, wardrobe, location, lighting, props, spatial direction, and action continuity. Do not add extra cuts, montage beats, dissolves, scene changes, or transitions outside this schedule.`
+    : `EDITING / CUT PLAN — MANDATORY: Use one smooth, continuous, uninterrupted shot for the full ${exactDuration}-second segment. Use no CUT TO, hard cut, angle reset, montage, dissolve, scene change, or transition. Camera and character movement may develop inside the same continuous take.`;
+  return {
+    frequency,
+    exact_duration_seconds: exactDuration,
+    maximum_one_per_second_cuts: maximumCuts,
+    cut_count: cutCount,
+    shot_count: cutCount + 1,
+    cut_times_seconds: cutTimes,
+    continuous_shot: cutCount === 0,
+    instruction,
+  };
+}
+
 function storyboardSpeedLabel(value, kind = "motion") {
   const speed = storyboardSpeedValue(value);
   if (speed <= 0) return kind === "camera" ? "0 / static camera" : "0 / still subject";
@@ -2526,6 +2574,7 @@ function slimStoryboardForRequest(state) {
     global_consistency_phrase: state.globalConsistencyPhrase || "",
     camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
     character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
+    minimax_h3_cut_frequency: storyboardCutFrequencyValue(state.cutFrequency),
     performance_style_default: state.performanceStyle || "",
     facial_performance_default: state.facialPerformance || "",
     facial_performance_custom_default: state.facialPerformanceCustom || "",
@@ -2655,6 +2704,15 @@ function storyboardScenesForGpt(state) {
       && normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine) === "minimax_h3"
       ? storyboardTemporalWorldEffectForScene(normalized, state)
       : null;
+    const miniMaxVideoScene = !imageMode
+      && normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine) === "minimax_h3";
+    const exactSceneDuration = Math.max(
+      0,
+      Number(normalized.exact_duration || 0) || Number(normalized.timeline_end || 0) - Number(normalized.timeline_start || 0),
+    );
+    const cutPlan = miniMaxVideoScene
+      ? storyboardCutPlanForDuration(exactSceneDuration, state.cutFrequency)
+      : null;
     const instrumental = Boolean(normalized.lyric_instrumental);
     const noLipSync = Boolean(normalized.lyric_no_lip_sync || performanceMode === "no_lip_sync");
     const noCharacterPresent = Boolean(normalized.no_character_present);
@@ -2691,6 +2749,10 @@ function storyboardScenesForGpt(state) {
       prompt_type: imageMode ? "text to image" : storyboardVideoPromptTypeLabel(normalized.video_prompt_type),
       project_video_engine: normalizeStoryboardProjectVideoEngine(normalized.project_video_engine || state.projectVideoEngine),
       minimax_h3_mode: normalizeStoryboardMiniMaxH3Mode(normalized.minimax_h3_mode),
+      ...(cutPlan ? {
+        minimax_h3_cut_frequency: cutPlan.frequency,
+        cut_plan: cutPlan,
+      } : {}),
       exact_duration: Number(normalized.exact_duration || 0),
       timeline_start: Number(normalized.timeline_start || 0),
       timeline_end: Number(normalized.timeline_end || 0),
@@ -2878,7 +2940,7 @@ export function storyboardGptPayload(state, scenesOverride = null) {
         },
       }
       : {
-        task_instruction: "Create detailed image-to-video prompts for Video Prep using a strict source hierarchy. The mapped location_ref is the required physical set for each scene: do not replace it with a location from story_layer, scene_story_beat, song_story_brief, user_story_arc, lyrics, or previous/next scene context. If story context mentions another place, translate only its emotion, tension, symbolism, or action into the mapped location_ref environment. The first_frame_visual_inventory field is only a first-frame inventory: visible subject identity, wardrobe, hair, makeup, props, setting, lighting, color palette, framing, and composition. Do not use first_frame_visual_inventory or any image prompt wording for body action, camera motion, performance energy, facial performance, lyric action, story action, or animation pacing. Follow camera_flow_guidance as a hard framing constraint for the entire shot, every camera move, and the ending composition. When starting_shot.required is true, the first sentence must explicitly state that the video begins with starting_shot.selected_starting_shot; do not merely imply that framing or use it later. For an eyes shot, explicitly say the video begins with an extreme close-up of the subject's eyes. The selected camera motion begins from that opening framing. Then build the rest of the video prompt in this order: 1) subject and vocal/performance sentence from vocal_status, performance_direction, and facial_performance_direction; 2) character movement sentence from character_motion, character_motion_guidance, character_motion_speed, and scene_story_beat; 3) camera movement sentence from camera_motion, camera_guidance, and camera_motion_speed_guidance; 4) environment/lighting sentence from first_frame_visual_inventory and location_ref; 5) final mood/style sentence from story_layer and image aesthetic only where visual. Each sentence has one job and must add new information. Do not repeat the same mood, trait, motion, authority/defiance language, setting adjective, or descriptive phrase across multiple sentences. If an idea appears in the face sentence, do not repeat it in the body, camera, environment, or atmosphere sentence; use a different concrete visual detail instead. Do not duplicate adjacent words such as 'tall, tall'. The motion priority is character_motion_guidance + camera_motion_speed_guidance + camera_guidance + performance_direction + vocal_status + scene_story_beat above story_layer, and all of those above first_frame_visual_inventory. At camera speed 7-8, do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera wording; use energetic active movement. At camera speed 9-10, use multiple coordinated readable camera moves. At character speed 4 or higher, include at least one clear physical body action, gesture, step, or set interaction; facial movement alone does not count.",
+        task_instruction: "Create detailed image-to-video prompts for Video Prep using a strict source hierarchy. The mapped location_ref is the required physical set for each scene: do not replace it with a location from story_layer, scene_story_beat, song_story_brief, user_story_arc, lyrics, or previous/next scene context. If story context mentions another place, translate only its emotion, tension, symbolism, or action into the mapped location_ref environment. The first_frame_visual_inventory field is only a first-frame inventory: visible subject identity, wardrobe, hair, makeup, props, setting, lighting, color palette, framing, and composition. Do not use first_frame_visual_inventory or any image prompt wording for body action, camera motion, performance energy, facial performance, lyric action, story action, or animation pacing. Follow camera_flow_guidance as a hard framing constraint for the entire shot, every camera move, and the ending composition. For MiniMax scenes, follow cut_plan.instruction exactly: a zero/effectively-zero plan is one continuous take with no cuts, while an active plan requires the exact listed number and timing of explicit CUT TO transitions. When starting_shot.required is true, the first sentence must explicitly state that the video begins with starting_shot.selected_starting_shot; do not merely imply that framing or use it later. For an eyes shot, explicitly say the video begins with an extreme close-up of the subject's eyes. The selected camera motion begins from that opening framing. Then build the rest of the video prompt in this order: 1) subject and vocal/performance sentence from vocal_status, performance_direction, and facial_performance_direction; 2) character movement sentence from character_motion, character_motion_guidance, character_motion_speed, and scene_story_beat; 3) camera movement sentence from camera_motion, camera_guidance, and camera_motion_speed_guidance; 4) environment/lighting sentence from first_frame_visual_inventory and location_ref; 5) final mood/style sentence from story_layer and image aesthetic only where visual. Each sentence has one job and must add new information. Do not repeat the same mood, trait, motion, authority/defiance language, setting adjective, or descriptive phrase across multiple sentences. If an idea appears in the face sentence, do not repeat it in the body, camera, environment, or atmosphere sentence; use a different concrete visual detail instead. Do not duplicate adjacent words such as 'tall, tall'. The motion priority is character_motion_guidance + camera_motion_speed_guidance + camera_guidance + performance_direction + vocal_status + scene_story_beat above story_layer, and all of those above first_frame_visual_inventory. At camera speed 7-8, do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera wording; use energetic active movement. At camera speed 9-10, use multiple coordinated readable camera moves. At character speed 4 or higher, include at least one clear physical body action, gesture, step, or set interaction; facial movement alone does not count.",
       }),
     story_layer: normalizeStoryLayer(state.storyLayer),
     scenes: storyboardScenesForGpt(payloadState),
@@ -2969,6 +3031,7 @@ function openStoryboardBuilder(payload = {}) {
     facialPerformanceCustom: String(payload.facialPerformanceCustom || payload.facial_performance_custom || payload.facial_performance_custom_default || ""),
     cameraMotionSpeed: storyboardSpeedValue(payload.cameraMotionSpeed ?? payload.camera_motion_speed ?? payload.motion_defaults?.camera_motion_speed, 4),
     characterMotionSpeed: storyboardSpeedValue(payload.characterMotionSpeed ?? payload.character_motion_speed ?? payload.motion_defaults?.character_motion_speed, 4),
+    cutFrequency: storyboardCutFrequencyValue(payload.cutFrequency ?? payload.minimax_h3_cut_frequency ?? payload.builderStoryboardDefaults?.minimax_h3_cut_frequency ?? payload.builder_storyboard_defaults?.minimax_h3_cut_frequency),
     performanceMode: payloadPerformanceMode,
     shortFilmPlanningMode: normalizeStoryboardShortFilmPlanningMode(
       payload.shortFilmPlanningMode
@@ -3007,6 +3070,7 @@ function openStoryboardBuilder(payload = {}) {
       global_consistency_phrase: String(state.globalConsistencyPhrase || "").trim(),
       camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
       character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
+      minimax_h3_cut_frequency: storyboardCutFrequencyValue(state.cutFrequency),
       camera_guidance: storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
       character_guidance: storyboardSpeedGuidance(state.characterMotionSpeed, "character"),
       performance_style: String(state.performanceStyle || ""),
@@ -3038,6 +3102,7 @@ function openStoryboardBuilder(payload = {}) {
     temporal_protected_custom: String(state.temporalProtectedCustom || "").trim(),
     camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
     character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
+    minimax_h3_cut_frequency: storyboardCutFrequencyValue(state.cutFrequency),
     motion_defaults: {
       camera_motion_speed: storyboardSpeedValue(state.cameraMotionSpeed, 4),
       character_motion_speed: storyboardSpeedValue(state.characterMotionSpeed, 4),
@@ -3373,6 +3438,25 @@ function openStoryboardBuilder(payload = {}) {
   cameraSpeedControls.append(cameraSpeedLabel, cameraSpeedInput, cameraSpeedValue, cameraSpeedHint);
   const cameraSpeedInfo = document.createElement("div");
   cameraSpeedInfo.style.cssText = "color:#94a3b8;line-height:1.35;";
+  const cutFrequencyControls = document.createElement("div");
+  cutFrequencyControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
+  const cutFrequencyLabel = document.createElement("div");
+  cutFrequencyLabel.style.cssText = "font-weight:900;color:#cffafe;white-space:nowrap;text-align:right;min-width:160px;";
+  cutFrequencyLabel.textContent = "Cut frequency";
+  const cutFrequencyInput = makeInput(String(storyboardCutFrequencyValue(state.cutFrequency)));
+  cutFrequencyInput.type = "range";
+  cutFrequencyInput.min = "0";
+  cutFrequencyInput.max = "10";
+  cutFrequencyInput.step = "1";
+  cutFrequencyInput.style.minWidth = "360px";
+  cutFrequencyInput.style.accentColor = "#22d3ee";
+  const cutFrequencyValue = document.createElement("div");
+  cutFrequencyValue.style.cssText = "font-size:12px;color:#cffafe;font-weight:900;min-width:150px;";
+  const cutFrequencyHint = makeButton("Hint");
+  cutFrequencyHint.title = "Explain MiniMax cut frequency.";
+  cutFrequencyControls.append(cutFrequencyLabel, cutFrequencyInput, cutFrequencyValue, cutFrequencyHint);
+  const cutFrequencyInfo = document.createElement("div");
+  cutFrequencyInfo.style.cssText = "color:#94a3b8;line-height:1.35;";
   const performanceControls = document.createElement("div");
   performanceControls.style.cssText = "display:flex;gap:8px;align-items:center;white-space:nowrap;";
   const performanceLabel = document.createElement("div");
@@ -3473,6 +3557,7 @@ function openStoryboardBuilder(payload = {}) {
     consistencyControls,
     cameraFlowControls,
     cameraSpeedControls,
+    cutFrequencyControls,
     performanceControls,
     characterSpeedControls,
     facialControls,
@@ -3499,6 +3584,7 @@ function openStoryboardBuilder(payload = {}) {
     consistencyInput,
     cameraFlowSelect,
     cameraSpeedInput,
+    cutFrequencyInput,
     performanceSelect,
     characterSpeedInput,
     facialSelect,
@@ -3508,7 +3594,7 @@ function openStoryboardBuilder(payload = {}) {
     control.style.minWidth = "0";
     control.style.maxWidth = "100%";
   }
-  for (const control of [videoStyleCustomInput, temporalEffectCustomInput, temporalProtectedCustomInput, imageCustomStyleInput, consistencyInput, cameraSpeedInput, characterSpeedInput, facialCustomInput]) {
+  for (const control of [videoStyleCustomInput, temporalEffectCustomInput, temporalProtectedCustomInput, imageCustomStyleInput, consistencyInput, cameraSpeedInput, cutFrequencyInput, characterSpeedInput, facialCustomInput]) {
     control.style.flex = "1 1 280px";
     control.style.width = "100%";
   }
@@ -3522,6 +3608,7 @@ function openStoryboardBuilder(payload = {}) {
     consistencyInfo,
     cameraFlowInfo,
     cameraSpeedInfo,
+    cutFrequencyInfo,
     performanceInfo,
     characterSpeedInfo,
     facialInfo,
@@ -3532,7 +3619,7 @@ function openStoryboardBuilder(payload = {}) {
     info.style.maxWidth = "100%";
     info.style.overflowWrap = "anywhere";
   }
-  cameraFlowBar.append(imageShotControls, imageShotInfo, imageAestheticControls, imageAestheticInfo, videoStyleControls, videoStyleCustomControls, videoStyleInfo, temporalEffectControls, temporalEffectCustomControls, temporalEffectOptions, temporalProtectedCustomControls, temporalEffectInfo, imageWorldStyleControls, imageWorldStyleInfo, imageCustomStyleControls, imageCustomStyleInfo, consistencyControls, consistencyInfo, cameraFlowControls, cameraFlowInfo, cameraSpeedControls, cameraSpeedInfo, performanceControls, performanceInfo, characterSpeedControls, characterSpeedInfo, facialControls, facialInfo, facialCustomControls, facialCustomInfo);
+  cameraFlowBar.append(imageShotControls, imageShotInfo, imageAestheticControls, imageAestheticInfo, videoStyleControls, videoStyleCustomControls, videoStyleInfo, temporalEffectControls, temporalEffectCustomControls, temporalEffectOptions, temporalProtectedCustomControls, temporalEffectInfo, imageWorldStyleControls, imageWorldStyleInfo, imageCustomStyleControls, imageCustomStyleInfo, consistencyControls, consistencyInfo, cameraFlowControls, cameraFlowInfo, cameraSpeedControls, cameraSpeedInfo, cutFrequencyControls, cutFrequencyInfo, performanceControls, performanceInfo, characterSpeedControls, characterSpeedInfo, facialControls, facialInfo, facialCustomControls, facialCustomInfo);
 
   const storyLayerBar = document.createElement("div");
   storyLayerBar.className = "vrgdg-storyboard-story-grid";
@@ -3753,6 +3840,9 @@ function openStoryboardBuilder(payload = {}) {
     cameraFlowInfo.style.display = isVideoPrepMode ? "" : "none";
     cameraSpeedControls.style.display = isVideoPrepMode ? "flex" : "none";
     cameraSpeedInfo.style.display = isVideoPrepMode ? "" : "none";
+    const cutFrequencyEligible = isVideoPrepMode && state.projectVideoEngine === "minimax_h3";
+    cutFrequencyControls.style.display = cutFrequencyEligible ? "flex" : "none";
+    cutFrequencyInfo.style.display = cutFrequencyEligible ? "" : "none";
     characterSpeedControls.style.display = isVideoPrepMode ? "flex" : "none";
     characterSpeedInfo.style.display = isVideoPrepMode ? "" : "none";
     refreshConsistencyInfo();
@@ -3803,7 +3893,7 @@ function openStoryboardBuilder(payload = {}) {
     const performancePreset = performancePresetForMode(state.performanceStyle);
     const facialPreset = facialPresetForMode(state.facialPerformance);
     sceneDefaultsPanel.setSummary(state.mode === "image_to_video_prep"
-      ? `${cameraPreset.label || "Camera flow"}${state.videoStyle ? ` · ${videoStylePreset.label}` : ""}${state.temporalWorldEffect ? ` · ${temporalEffectPreset.label}` : ""} · camera ${storyboardSpeedValue(state.cameraMotionSpeed, 4)}/10 · character ${storyboardSpeedValue(state.characterMotionSpeed, 4)}/10 · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`
+      ? `${cameraPreset.label || "Camera flow"}${state.videoStyle ? ` · ${videoStylePreset.label}` : ""}${state.temporalWorldEffect ? ` · ${temporalEffectPreset.label}` : ""} · camera ${storyboardSpeedValue(state.cameraMotionSpeed, 4)}/10${state.projectVideoEngine === "minimax_h3" ? ` · cuts ${storyboardCutFrequencyValue(state.cutFrequency)}/10` : ""} · character ${storyboardSpeedValue(state.characterMotionSpeed, 4)}/10 · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`
       : `${imageShotPreset.label || "Still shot flow"} · ${imageAestheticPreset.label || "Image aesthetic"} · ${performancePreset.label || "Performance style"} · ${facialPreset.label || "Facial performance"}${state.globalConsistencyPhrase ? " · consistency phrase" : ""}`);
     const beatCount = state.scenes.filter((scene) => String(scene.story_beat || "").trim()).length;
     const sectionCount = state.scenes.filter((scene) => String(scene.lyric_section || "").trim()).length;
@@ -3872,6 +3962,17 @@ function openStoryboardBuilder(payload = {}) {
   const refreshCameraSpeedInfo = () => {
     cameraSpeedValue.textContent = storyboardSpeedLabel(state.cameraMotionSpeed, "camera");
     cameraSpeedInfo.textContent = storyboardSpeedGuidance(state.cameraMotionSpeed, "camera");
+    refreshSetupPanelSummaries();
+  };
+
+  const refreshCutFrequencyInfo = () => {
+    const frequency = storyboardCutFrequencyValue(state.cutFrequency);
+    cutFrequencyValue.textContent = storyboardCutFrequencyLabel(frequency);
+    cutFrequencyInfo.textContent = frequency <= 0
+      ? "MiniMax prompts use one smooth, continuous shot for every segment. Existing prompts are not changed until regenerated."
+      : frequency >= 10
+        ? "Maximum MiniMax editing: each segment cuts at every whole second inside its exact duration. A 5-second segment gets cuts at 1s, 2s, 3s, and 4s."
+        : `MiniMax scales this ${frequency}/10 editing intensity to each segment's exact duration, spacing the resulting CUT TO transitions evenly. Existing prompts are not changed until regenerated.`;
     refreshSetupPanelSummaries();
   };
 
@@ -6408,8 +6509,10 @@ function openStoryboardBuilder(payload = {}) {
       facialCustomInput.value = state.facialPerformanceCustom;
       state.cameraMotionSpeed = storyboardSpeedValue(saved.camera_motion_speed ?? saved.motion_defaults?.camera_motion_speed ?? state.cameraMotionSpeed, 4);
       state.characterMotionSpeed = storyboardSpeedValue(saved.character_motion_speed ?? saved.motion_defaults?.character_motion_speed ?? state.characterMotionSpeed, 4);
+      state.cutFrequency = storyboardCutFrequencyValue(saved.minimax_h3_cut_frequency ?? saved.cut_frequency ?? state.cutFrequency);
       cameraSpeedInput.value = String(state.cameraMotionSpeed);
       characterSpeedInput.value = String(state.characterMotionSpeed);
+      cutFrequencyInput.value = String(state.cutFrequency);
       state.storyLayer = normalizeStoryLayer(saved.story_layer || saved.storyLayer || {});
       state.scriptImport = normalizeStoryboardScriptImportState(saved.script_import || saved.scriptImport || state.scriptImport || {});
       storyLayerEnabledInput.checked = state.storyLayer.enabled !== false;
@@ -6425,6 +6528,7 @@ function openStoryboardBuilder(payload = {}) {
       refreshTemporalEffectInfo();
       refreshConsistencyInfo();
       refreshCameraSpeedInfo();
+      refreshCutFrequencyInfo();
       refreshPerformanceInfo();
       refreshCharacterSpeedInfo();
       refreshFacialInfo();
@@ -7053,6 +7157,26 @@ function openStoryboardBuilder(payload = {}) {
       "9-10: fast action camera language; multiple coordinated moves can happen in one scene while keeping the subject readable.",
     ].join("\n"));
   };
+  cutFrequencyInput.addEventListener("input", () => {
+    state.cutFrequency = storyboardCutFrequencyValue(cutFrequencyInput.value);
+    cutFrequencyInput.value = String(state.cutFrequency);
+    refreshCutFrequencyInfo();
+  });
+  cutFrequencyInput.addEventListener("change", notifyStoryboardDefaultsChanged);
+  cutFrequencyHint.onclick = () => {
+    window.alert([
+      "Cut Frequency controls MiniMax H3 editing inside each timeline segment.",
+      "",
+      "0: one smooth continuous take with no cuts.",
+      "1-3: occasional cuts, scaled to the segment's exact duration.",
+      "4-6: a moderate number of evenly spaced cuts.",
+      "7-9: frequent cuts with short coherent coverage shots.",
+      "10: maximum frequency — CUT TO a new continuity-preserving angle every second.",
+      "",
+      "Example: a 5-second segment at 10 starts with shot 1, then cuts at 1s, 2s, 3s, and 4s.",
+      "Changing this setting affects newly generated MiniMax prompts; it does not rewrite existing prompts automatically.",
+    ].join("\n"));
+  };
   cameraFlowApply.onclick = () => applyCameraFlow({ overwrite: false });
   cameraFlowReplace.onclick = () => applyCameraFlow({ overwrite: true });
   imageShotApply.onclick = () => applyImageShotFlow({ overwrite: false });
@@ -7175,6 +7299,7 @@ function openStoryboardBuilder(payload = {}) {
   refreshImageWorldStyleInfo();
   refreshConsistencyInfo();
   refreshCameraSpeedInfo();
+  refreshCutFrequencyInfo();
   refreshPerformanceInfo();
   refreshCharacterSpeedInfo();
   refreshFacialInfo();


### PR DESCRIPTION
## Summary

- adds MiniMax scene-default cut frequency with exact duration-aware cut plans and matching LLM instructions
- adds scope-aware Reference-to-Video scene-image modes, including prompt-only environment inspiration and exact-start Face + hair only priority
- adds MiniMax-H3 Turbo LoRA workflow injection with the dedicated sampler, reference-audio compatibility adapter, 6-step activation default, and automatic EasyCache bypass/restoration
- adds persistent Gemma Local and LM Studio input/output token limits across Builder, Storyboard, Wizard, vision, and Prompt Creator paths, including PR #114 legacy-setting migration
- fixes global-versus-locked MiniMax setting propagation, the Video Wizard launch, runner labels, and character subject-count authority
- renames the status surface to AI Video Builder, adds the live LTX/MiniMax engine badge, and publishes a distinct anchored What's New release

## Why

MiniMax projects needed explicit control over edit density, clearer separation between prompt inspiration and renderer references, and a safe way to combine an exact start composition with a different reference face and hair. Turbo acceleration also needed reliable hidden-workflow wiring for pruned reference-audio models and sensible low-step defaults. Local LLM runners were still constrained by small hardcoded output limits, and several global/locked-scene and Wizard paths were not honoring their intended scope.

## User impact

Users can now choose continuous MiniMax takes or scheduled cuts, control exactly how scene images influence prompts and rendering, enable Turbo without manually reconfiguring steps or EasyCache, and generate substantially longer prompts with configurable local-runner limits. Existing projects retain LTX by default, locked MiniMax scenes remain independent, and legacy settings are migrated.

## Validation

- `python -B -m unittest discover -s tests` — 92 passed, 4 skipped
- Python compilation passed for all four changed Python modules
- JavaScript module syntax checks passed for Builder, Prompt Creator, and Storyboard UI files
- `update_notes.json` parsed successfully
- `git diff --check` passed
