### PR TITLE
Add Auto Build and MiniMax singer cue workflow

### DIFF
--- a/VRGDG_MiniMaxH3PromptInstructions.py
+++ b/VRGDG_MiniMaxH3PromptInstructions.py
@@ -6,172 +6,50 @@ which contract is active and the two paths must never be mixed.
 """
 
 
-MINIMAX_H3_PROMPT_DIRECTOR_CORE = """You are the MiniMax H3 Prompt Director for the Video Builder. Convert the supplied scene context into one polished MiniMax H3 video prompt.
+MINIMAX_H3_PROMPT_DIRECTOR_CORE = """You write only the creative shot descriptions for a MiniMax H3 video prompt.
 
-The input context will identify the exact scene duration, aspect ratio, visual idea, lyrics or dialogue when available, scene notes, ordered speaker assignments, selected audio mode, and any ordered reference media. Treat the supplied duration, speaker order, audio mode, and media assignments as authoritative.
+The Builder will assemble the final MiniMax prompt after you answer. The Builder adds all fixed MiniMax sections, reference definitions, audio blocks, continuity blocks, safety blocks, shot labels, and cut times.
 
-CORE WORKFLOW
-1. Use the exact duration supplied for the scene. Never round it, shorten it, or extend it.
-2. Begin exactly with: Generate a [duration]-second [aspect ratio] [visual style] video.
-3. Replace every bracketed placeholder with concrete values. Never leave placeholder text in the result.
-4. Use the exact sectioned layout described under OUTPUT FORMAT. Preserve every required blank line and line break.
-5. Obey any supplied `EDITING / CUT PLAN — MANDATORY` contract before applying general timeline-density or shot-planning guidance.
-6. Follow the media assignments with a timestamped visual schedule covering the entire duration.
-7. Every timestamp must connect precisely, with no gaps or overlaps.
-8. Expand the idea into an exciting but physically readable sequence while preserving the user's subject, location, story intent, and requested ending.
-9. Make reasonable creative decisions from the supplied context without asking questions.
+Return plain valid JSON only:
+{"shots":[{"description":"..."},{"description":"..."}]}
 
-TIMELINE DENSITY
-- These ranges are fallback guidance only when the scene context does not supply an `EDITING / CUT PLAN — MANDATORY` contract.
-- 4-5 seconds: 2-3 clear visual beats.
-- 6-8 seconds: 3-5 clear visual beats.
-- 9-12 seconds: 4-6 clear visual beats.
-- 13-15 seconds: 5-8 clear visual beats.
-- For other durations, use the fewest beats needed to make the requested action clear and achievable.
-
-Format timestamps like:
-[0s-2s]
-[2s-4.5s]
-[4.5s-8s]
-
-EDITING / CUT PLAN AUTHORITY
-- When the scene context supplies an `EDITING / CUT PLAN — MANDATORY` contract, treat its continuous-shot choice, cut count, shot count, and cut times as authoritative. It overrides TIMELINE DENSITY and any general preference for more or fewer visual beats, shots, cutaways, or transitions.
-- A continuous-shot plan means one uninterrupted take for the entire duration. Timestamp blocks may describe chronological phases of that same take, but they must not create a new shot, angle reset, cutaway, montage beat, dissolve, match cut, hard cut, scene change, or transition. Change framing only through explicitly continuous camera movement, and never write `CUT TO:`.
-- An active cut plan requires exactly the supplied number of hard cuts and exactly one more shot than cuts. Begin shot 1 at 0 seconds. Start every later shot at the supplied cut time, and begin its visual description with the literal words `CUT TO:` immediately after the timestamp header.
-- Do not omit, merge, add, or shift a scheduled cut. Do not add any transition at an unscheduled time. The final timestamp must still end at the exact scene duration with no gaps or overlaps.
-- Every post-cut shot must be meaningfully different coverage—such as a new wide, medium, close-up, extreme close-up, reaction, object detail, profile, low angle, or high angle—while remaining inside the same scene and ongoing action unless the user's scene material explicitly requests a location or time change.
-- Across cuts, preserve subject identity, face, hairstyle, body proportions, wardrobe, props, location, lighting, screen direction, spatial relationships, dialogue order, vocal timing, and action continuity. Never use a cut as permission to clone a subject, reset the scene, or invent unrelated action.
-
-VISUAL DIRECTION
-- Describe visible actions literally and chronologically.
-- Include the subject and relevant appearance, environment, physical action, camera framing and movement, lighting and atmosphere, important facial expression, object interaction, and physical consequences.
-- Prioritize visible action over decorative adjectives. Describe exactly what transforms, moves, breaks, appears, disappears, or changes.
-- Give each timestamp one main readable event, especially in fast sequences.
-- Do not overload one moment with incompatible camera movements.
-- Use clear camera language such as wide establishing shot, extreme close-up, low-angle tracking shot, fast push-in, orbiting camera, handheld chase shot, rapid pullback, continuous unbroken shot, hard cut, or match cut.
-- When no mandatory cut plan is supplied, multi-shot sequences may connect meaningfully different shots with a hard cut, match cut, motivated transition, or continuous movement. When a mandatory cut plan is supplied, follow only its permitted transition type, count, and timing.
-- Do not fill time with slow motion unless the user requests it.
-- Treat supplied camera-motion speed and character-motion speed as hard requirements, not suggestions. Concrete scene-card motion wording must agree with them.
-- At camera speed 7-8, use energetic, visibly active camera movement and do not use slow, gentle, subtle, restrained, locked-off, static, or hold camera language. At camera speed 9-10, use two or more coordinated readable camera actions when practical.
-- At character speed 4 or higher, include at least one clear physical body action, gesture, step, or interaction with the set. Facial expression, blinking, breathing, and mouth movement alone do not satisfy character motion.
-- If the scene notes contain a `TEMPORAL / WORLD EFFECT` contract, copy that full contract word-for-word into the finished prompt after the media/audio assignments and before the first timestamp. Never bury it inside a timestamp or append it after Continuity. Obey it as a hard layered-time rule. Protected mapped/reference characters, their identities, faces, performances, voices, and lip sync remain natural, singular, stable, and correctly synchronized. Apply the effect only to the contract's unprotected extras or environment, and infer anonymous location-appropriate extras only when the contract explicitly permits them.
-- A temporal/world contract must be visibly staged, not merely repeated. Every timestamp block must contain the required number of concrete visible background/world actions appropriate to the mapped location and selected effect. At intensity 7 or higher, subtle flicker, ambience, drifting particles, or a vague reference to time passage alone fails the requirement.
-- If the temporal/world contract permits anonymous extras, a phrase such as “no people” in a location reference describes only that source image. It does not prohibit generated anonymous background extras. Continuity may prohibit additional named, principal, mapped, or referenced characters, but must explicitly retain allowed anonymous unreferenced extras and apply the selected effect to them.
-
-AUDIO MODE AND VOCAL CONTRACT
-- The scene context identifies exactly one audio mode: Input Audio or Built-in MiniMax Audio. Never mix their terminology or requirements.
-- Always place the selected mode's audio assignment before the timestamped timeline. Always include an Audio: section after the timestamped timeline.
-- INPUT AUDIO: label the supplied custom/project audio as Audio 1. Use it unchanged as the primary and only audio track and as the authoritative music, voice, vocal, timing, rhythm, phrasing, tone, duration, performance, movement, and lip-sync reference. Never generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects.
-- BUILT-IN MINIMAX AUDIO: label the assignment Native audio. MiniMax must generate the requested dialogue, singing, ambience, and sound effects. There is no Audio 1, supplied vocal track, or unchanged primary track in this mode. Never use the phrases “Audio 1,” “use unchanged,” “preserve supplied audio,” or “replacement audio” in a Built-in MiniMax Audio prompt.
-- When exact spoken speaker assignments are supplied, preserve every cue verbatim and in exact order. Only the assigned character speaks each cue. Every other visible character remains silent with their mouth closed and reacts naturally until assigned their own cue.
-- For Built-in MiniMax Audio dialogue, put the exact quoted dialogue script only once in the entire finished prompt: inside the Native audio assignment. Timestamp blocks must refer to the assigned cue without quoting it again, and the final Audio section must not repeat the script.
-- Generate speech only in the same language used by the exact supplied dialogue. Never translate it, switch languages, invent foreign-language speech, or add phonetic substitutions, babble, gibberish, invented syllables, filler, repeated phrases, or extra vocalizations.
-- Begin the first spoken cue within the first 0.15 seconds, pace the supplied words naturally across the available clip, and land the final spoken word approximately 0.15-0.30 seconds before the clip ends. Never finish early and then invent speech; never restart a cue or repeat its opening words to fill time.
-- Never turn the list of characters who speak somewhere in the scene into a direction for all of them to say the complete combined dialogue. Never repeat the complete dialogue in every timestamp.
-- Each speaking timestamp must name only its assigned speaker and refer to that speaker's assigned cue without quoting the words again. Do not merge, overlap, transfer, reorder, rewrite, repeat, improvise, omit, or add words.
-- When an exact sung lyric is supplied, require the assigned visible singer to perform it with precise lip, mouth-shape, jaw, facial-muscle, and breathing synchronization to the selected audio mode.
-- For Input Audio singing, quote the exact lyric only once in the Audio 1 assignment. Timestamp blocks must say the singer begins, continues, or completes the currently audible portion of the assigned lyric without quoting the lyric again. Never paste the entire lyric or a generic full-line lip-sync paragraph into every timestamp.
-- For Input Audio, describe singing only during the portion of each timestamp where the vocal is actually audible in Audio 1. Never stretch, restart, or repeat the full lyric across every timestamp. After the supplied vocal ends, close or relax the mouth naturally and fill remaining time with physical action or reaction, not invented vocals.
-- When the scene is explicitly visual-only, instrumental, no-lip-sync, or has no visible character, do not invent visible singing or speaking. In Input Audio mode, Audio 1 remains unchanged as the primary and only audio track; preserve all of it exactly, use the instrumental/no-lip-sync marker only to keep visible mouths naturally relaxed or closed, and never add ambience or sound effects. In Built-in MiniMax Audio mode, generate only the requested ambience and sound effects.
-- In the final Audio: section, restate only the active audio contract. For Input Audio, preserve Audio 1 unchanged as the primary and only audio track and prohibit all generated or added audio. For Built-in MiniMax Audio, generate the ordered dialogue or lyric with the assigned voices and add only subtle requested ambience or sound effects underneath.
-
-CONTINUITY
-- Add a Continuity: section only when identity, clothing, objects, locations, or spatial relationships must remain consistent.
-- Preserve the same face, hairstyle, clothing, age, body proportions, accessories, and held objects across beats unless the user explicitly requests a visible change.
-- Track important objects and spatial positions coherently across cuts.
-
-TEXT ON SCREEN
-- Include visible text only when the user explicitly requests it.
-- Put the exact requested text in quotation marks, require exact spelling, say it appears only once, and do not invent captions, logos, subtitles, credits, or other text.
-
-OUTPUT FORMAT
-Return the finished prompt in this exact visual structure, with real line breaks rather than one continuous paragraph:
-
-Generate a [duration]-second [aspect ratio] [visual style] video.
-
-[One separate Image N: or Video N: assignment paragraph for each supplied visual reference. Omit this block only for text-to-video.]
-
-[Input Audio only] Audio 1: [exact supplied-audio assignment and lip-sync contract.]
-[Built-in MiniMax Audio only] Native audio: [exact generated dialogue/lyric speaker order, voice, silence, and lip-sync contract.]
-
-[When supplied] TEMPORAL / WORLD EFFECT — [copy the complete exact contract here before the first timestamp.]
-
-[0s–...s]
-[Visible action, performance, camera, and environment for this interval.]
-
-[next timestamp]
-[Visible action, performance, camera, and environment for this interval.]
-
-Audio: [the selected mode's final audio contract; never combine Input Audio and Built-in MiniMax Audio wording.]
-
-Continuity: [identity, clothing, environment, spatial, and no-new-elements requirements.]
-
-- Put each timestamp header on its own line.
-- Put a blank line before every media assignment, timestamp block, Audio: section, and Continuity: section.
-- Never collapse the result into one paragraph.
-- Refer to visual media naturally as Image 1, Image 2, and Video 1. Use Audio 1 only for Input Audio. Use Native audio only for Built-in MiniMax Audio. Do not print angle-bracket media tags in the finished prompt.
-
-SILENT QUALITY CHECK
-Before answering, verify that the timeline starts at 0 seconds, ends at the exact requested duration, contains no gaps or overlaps, gives every action and dialogue cue enough time, follows only the selected audio mode, preserves required continuity, assigns every exact cue only to its named speaker, keeps non-speaking characters silent, and ends with a deliberate payoff rather than stopping randomly.
-
-OUTPUT RULES
-- Return only the finished MiniMax H3 prompt as plain text.
-- Do not use a markdown code fence.
-- Keep the required paragraph breaks and timestamp line breaks exactly as specified.
-- Do not explain the prompt, provide alternatives, add a negative prompt, repeat the request, mention these instructions, or mention Builder metadata.
+Rules:
+- Return exactly the requested number of shot descriptions.
+- Each description is one complete prose string describing only the visible shot action.
+- Do not output markdown, analysis, bullets, plans, notes, or explanations.
+- Do not output section headings such as Audio, Continuity, detailed_description, subject_definitions, summary, retention_analysis, overall_soundscape, or non_diegetic_music.
+- Do not write [Shot N] labels, timestamps, time ranges, or cut times. The Builder writes those.
+- Do not add keys other than shots and description.
+- Use the supplied subject, location, lyrics/dialogue, camera speed, character speed, and scene notes.
+- Preserve the same subject identity, outfit, location, lighting, and spatial continuity across shots.
+- If a lyric/dialogue line is supplied and the scene is not visual-only, stage the visible singer/speaker performing it naturally. Put exact performed words inside <d>[English] ...</d> only when useful.
+- If the scene context supplies a vocal cue map, obey it exactly. Only the assigned <Subject N> (SN) performs each cue; all other visible subjects remain silent, mouth closed, or naturally reacting until assigned their own cue. Do not merge, swap, repeat, omit, translate, or transfer cues between subjects.
+- If the cue map supplies instrumental or no-vocal intervals, no visible subject sings, speaks, or lip-syncs during those intervals. Subjects may still act, dance, walk, interact, or react with mouths closed or naturally relaxed.
+- In multi-subject vocal scenes, use the supplied <Subject N> (SN) labels and <Audio 1> label in the shot descriptions when they are provided. Describe assigned cues as precise lip-sync to <Audio 1>, with the performed words inside <d>[English] ...</d>.
+- If the scene is visual-only, instrumental, or no-character-present, do not invent singing or speaking.
+- Make each shot meaningfully different coverage while staying in the same scene unless the user explicitly requested a scene change.
+- Do not begin any description with "The camera cuts to" or "The camera...". Start with the resulting shot framing or subject action instead, such as "A panning medium shot shows..." or "<Subject 2> (S2) steps forward...".
+- After the closing JSON brace, output nothing else.
 """
 
 
 _MINIMAX_H3_TEXT_TO_VIDEO_MODE = """MODE: TEXT TO VIDEO
-- Build the complete visible scene from the user's idea, scene notes, story context, and exact duration.
-- Do not claim that an image or video reference exists and do not use Image N or Video N labels.
-- Preserve named subjects, wardrobe, setting, mood, and story requirements from the input.
-- Infer only missing visual and camera details needed to make the scene complete.
-- Use only the audio label required by the selected audio mode.
+Use only the supplied text context. Do not mention picture or video labels unless the context supplies them.
 """
 
 
 _MINIMAX_H3_IMAGE_TO_VIDEO_MODE = """MODE: IMAGE TO VIDEO
-- Image 1 is the supplied opening image and the authoritative starting composition.
-- Explicitly identify Image 1 as the exact start frame and the subject-identity, clothing, setting, lighting, and composition anchor.
-- Start from Image 1 exactly, then animate the subject, camera, lighting, and environment naturally.
-- Preserve the visible subject's face, hairstyle, age, body proportions, clothing, accessories, location, and major composition details unless the user explicitly requests a visible transformation.
-- Do not treat Image 1 as a cutaway, a later insert, or a loose style suggestion.
-- Do not invent additional image or video labels.
-- Follow only the selected audio-mode and vocal contract.
+Use <Picture 1> as the starting visual anchor when supplied. Animate it naturally without writing the standalone picture definition.
 """
 
 
 _MINIMAX_H3_REFERENCE_TO_VIDEO_MODE = """MODE: REFERENCE TO VIDEO
-- The input context will list the connected images in their exact workflow order and state the intended purpose of each one. Refer to them as Image 1 through Image 9 only when they are actually supplied.
-- The context may separately identify an attached picture as `PROMPT-ONLY SCENE-IMAGE INSPIRATION`. That picture is visible only to the prompt-writing LLM and is never supplied to the MiniMax renderer. Never assign it an Image N label, never count it as a renderer reference, and never mention the picture, inspiration process, source imagery, or visual analysis in the finished prompt.
-- For environment-only inspiration, extract only location/environment, atmosphere/mood, lighting/weather, colors/materials/background details, and relevant objects or environmental activity. Explicitly ignore framing, shot distance, camera angle, lens, composition, and every character's identity, face, hair, body, clothing, accessories, pose, placement, and activity.
-- For environment-plus-framing inspiration, the same environmental properties are allowed and framing, shot distance, angle, lens, and composition may be optional inspiration that can be changed freely. Still ignore every character property, pose, placement, and activity.
-- Under either prompt-only inspiration mode, assigned character-reference images are the sole visual authority for the rendered character's complete identity and appearance. Convert permitted environmental observations into direct scene description, and use only the renderer Image N labels and mapping supplied by the context.
-- Clearly assign every renderer picture its stated purpose in the finished prompt. Purposes may include character identity and clothing, location, visual style, prop, start frame, end frame, or storyboard guidance. The separately identified prompt-only inspiration picture is excluded from this requirement and must never receive an Image N assignment.
-- Never assume a fixed purpose from slot number. The supplied ordered assignments are authoritative.
-- Preserve character and location identity from the pictures assigned to those purposes without copying an unwanted pose, crop, camera angle, panel layout, or collage.
-- When a picture is identified as a storyboard grid, interpret its panels as ordered visual beats and composition guidance. Do not generate the grid, borders, panels, labels, or a collage as the output video.
-- A character/person picture may be a multi-view character sheet, turnaround sheet, or contact sheet. All portraits and body views inside that one reference picture depict the same single person. Extract only the character properties granted by its ordered assignment and the supplied start-frame priority contract; never assume that clothing or body proportions are authoritative when the assignment grants only face and hair.
-- Render exactly one on-screen instance of each distinct named subject. Never interpret alternate views in a character sheet as additional people, and never duplicate, clone, twin, multiply, or add background copies of a referenced subject unless the user explicitly requests duplicates.
-- When start and end pictures are assigned, begin from the start picture and arrive coherently at the end picture. Follow the user's requested transition behavior, including surreal morph, cinematic non-morphing continuation, or longer action between the endpoints.
-- When Image 1 is assigned as the exact start frame and later images are character references, obey the supplied `START-FRAME / CHARACTER-REFERENCE PRIORITY — MANDATORY` contract exactly.
-- Under `Face + hair only`, Image 1 remains authoritative for pose, body and body proportions, clothing, wardrobe styling, accessories, framing, composition, camera angle, environment, props, lighting, colors, and every other visible detail. Character-reference images are authoritative ONLY for face identity, facial features, and hair. The first generated frame must already show that face and hair in Image 1's otherwise unchanged visual setup. Describe the intended character as directly present from frame one; do not use temporal comparison language such as `now featuring`, `becomes`, `changes into`, or `replaced by`. Never describe or depict a face swap, replacement process, morph, transition, or transformation, and never import the character reference's clothing, body, pose, accessories, framing, lighting, or background.
-- Under `Full character identity`, Image 1 controls the opening composition, pose, camera angle, environment, and lighting, while character-reference images control face, hair, clothing, body proportions, and identity details that are hidden in Image 1.
-- If no start-frame character-influence contract is supplied, use `Full character identity` for backward compatibility.
-- Do not mention any image label that was not supplied.
-- Follow only the selected audio-mode and vocal contract.
+Use supplied <Subject N> and <Picture N> labels only if they are listed in the scene context. The Builder writes the standalone reference definitions, so do not output them.
 """
 
 
 _MINIMAX_H3_VIDEO_TO_VIDEO_MODE = """MODE: VIDEO TO VIDEO
-- The input context will list connected videos in exact workflow order, with a purpose for each. Refer to them as Video 1 through Video 3 only when they are actually supplied.
-- Explicitly assign every supplied video its stated role, such as continuation source, movement guide, camera guide, edit/rhythm guide, transformation source, or visual-style guide.
-- Follow only the intended property of each reference video. Do not copy an unwanted subject identity, clothing, location, text, watermark, or unrelated content from a motion or camera reference.
-- For continuation or extension, begin coherently from the supplied video's ending state and preserve identity, clothing, location, object positions, movement direction, and camera logic unless the user requests a transition.
-- If ordered image references are also supplied, use their exact Image N labels and stated purposes without overriding the assigned role of the video references.
-- Do not mention image or video labels that were not supplied.
-- Follow only the selected audio-mode contract. Do not treat audio embedded in a reference video as the soundtrack unless the input context explicitly assigns that audio a purpose.
+Use supplied <Video N>, <Picture N>, and <Subject N> labels only if they are listed in the scene context. The Builder writes the standalone reference definitions, so do not output them.
 """
 
 

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -2514,7 +2514,7 @@ def _patch_minimax_h3_turbo(prompt, payload):
             "Download the LoRA, refresh/restart ComfyUI, and select it in MiniMax Video Settings."
         )
     strength = _float_payload(payload, "turbo_lora_strength", 1.0, -10.0, 10.0)
-    turbo_steps = _int_payload(payload, "steps", 6, 4, 1000)
+    turbo_steps = _int_payload(payload, "steps", 4, 1, 1000)
 
     scheduler_id = _api_node_id_by_class(prompt, "BasicScheduler", fallback="124")
     guider_id = _api_node_id_by_class(prompt, "BasicGuider", fallback="126")

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -680,6 +680,54 @@ def _trim_minimax_h3_audio_context(source_path, project_folder, scene_number, ti
     }
 
 
+def _prepare_scene_audio_clip(payload):
+    source_path = os.path.abspath(str(payload.get("audio_path", "") or "").strip().strip('"'))
+    project_folder = os.path.abspath(str(payload.get("project_folder", "") or "").strip().strip('"'))
+    if not source_path:
+        raise ValueError("Audio file path is empty.")
+    if not os.path.isfile(source_path):
+        raise FileNotFoundError(f"Audio file was not found: {source_path}")
+    if not project_folder:
+        raise ValueError("Create or load a project before preparing scene audio.")
+    os.makedirs(project_folder, exist_ok=True)
+    scene_number = int(_float_payload(payload, "scene_number", 1, minimum=1, maximum=9999))
+    start = _float_payload(payload, "start_seconds", 0.0, minimum=0.0, maximum=24 * 60 * 60)
+    duration = _float_payload(payload, "duration_seconds", 8.0, minimum=0.05, maximum=120.0)
+    target_dir = os.path.join(project_folder, "minimax_h3_scene_audio")
+    os.makedirs(target_dir, exist_ok=True)
+    target_path = os.path.join(target_dir, f"scene_audio_{scene_number:04d}.wav")
+    ffmpeg_path = _find_ffmpeg_path()
+    cmd = [
+        ffmpeg_path,
+        "-y",
+        "-ss",
+        f"{start:.9f}",
+        "-i",
+        source_path,
+        "-t",
+        f"{duration:.9f}",
+        "-vn",
+        "-ac",
+        "2",
+        "-ar",
+        "44100",
+        "-c:a",
+        "pcm_s16le",
+        target_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if result.returncode != 0 or not os.path.isfile(target_path):
+        raise RuntimeError((result.stderr or result.stdout or "FFmpeg failed to prepare scene audio.").strip())
+    actual_duration = _probe_media_duration_seconds(target_path)
+    return {
+        "audio_path": target_path,
+        "start": start,
+        "duration": actual_duration,
+        "requested_duration": duration,
+        "format": "pcm_s16le_wav",
+    }
+
+
 def _minimax_h3_output_location(project_folder, scene_number):
     project_name = re.sub(
         r"[^A-Za-z0-9_-]+",
@@ -4376,6 +4424,18 @@ def _ensure_workflow_runner_routes():
             return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
         try:
             result = _build_timestamped_transcribe_api_prompt(payload)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        return web.json_response({"ok": True, **result})
+
+    @server_instance.routes.post("/vrgdg/workflow_runner/prepare_scene_audio_clip")
+    async def vrgdg_workflow_runner_prepare_scene_audio_clip(request):
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
+        try:
+            result = _prepare_scene_audio_clip(payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -123,7 +123,7 @@ These are the newest user-facing changes covered throughout this guide:
 | MiniMax H3 B-roll safety | Scenes marked B-roll/no-lip-sync now suppress lyric, singer, speaker, and native-voice inputs during prompt generation, remove singing directions from H3 timestamp blocks, and reapply a visual-only safety contract when rendering an existing prompt. |
 | MiniMax short films | Storyboard Builder can plan Guided Film scene cards, import and validate `speaker: dialogue` scripts, map every speaker to a Reference Builder character, preserve exact dialogue, and create the real timeline only after review. |
 | Project storage and memory control | Settings can choose a default folder for newly created projects and can enable or disable automatic RAM/VRAM cleanup. Existing projects and temporary ComfyUI outputs are not moved. |
-| International lyric alignment and longer waits | Lyric matching now preserves Unicode words such as Cyrillic instead of stripping them, and an individual scene render may wait up to two hours before the Builder reports a timeout. |
+| International lyric alignment and longer waits | Lyric matching preserves Unicode words such as Cyrillic instead of stripping them, and Settings can keep an individual scene render waiting from 1–24 hours before the Builder reports a timeout. |
 | Reference lyrics and Story Arc reliability | `Transcribe Existing Scenes` now requires reference lyrics, preserves their exact line order, corrects held or missed boundary words, and no longer inserts pipe delimiters. Beat mode automatically transcribes its finished beat scenes. Story Arc keeps a complete valid heading structure when Gemma only appends invented trailing sections. |
 | Faster scene selection and Ingredients panels | `Select Multi` now supports direct timeline clicks and typed scene lists with ranges and shortcuts. The Ingredients Reference Builder correctly mounts its Sheets, Mapping, and Locations panels. |
 | Timeline and Storyboard prompt controls | `+ Segment` can end at the scrubber, Space toggles playback, `S` adds a segment, Left/Right navigate scenes, Storyboard Video Prep exposes Motion Notes inline, and all-scenes Gemma runs can fill only missing prompts or redo every visible scene. |
@@ -149,9 +149,9 @@ https://github.com/vrgamegirl19/comfyui-vrgamedevgirl
 4. Use the default `main` branch if Manager asks you to choose a branch.
 5. Install, restart ComfyUI, then hard refresh the browser page.
 
-The current ComfyUI Registry release is `9.1.0`. ComfyUI Manager installs a registry package rather than necessarily creating a Git checkout, so `git pull` and the Builder's Git self-updater may not work inside a Manager-installed folder. Use Manager's `Update` or reinstall action for that kind of installation.
+The current ComfyUI Registry release is `9.1.1`. ComfyUI Manager installs a registry package rather than necessarily creating a Git checkout, so `git pull` and the Builder's Git self-updater may not work inside a Manager-installed folder. Use Manager's `Update` or reinstall action for that kind of installation.
 
-If many VRGDG nodes appear but `VRGDG AI Video Builder UI` does not, check the installed version in Manager or the `[VRGDG]` line printed in the ComfyUI terminal during startup. A version older than `9.1.0` predates the current Builder/H3 registry package. Refresh Manager's node data, update or reinstall `comfyui-vrgamedevgirl`, restart ComfyUI, and hard refresh the browser. If Manager still offers the older package, remove only this custom-node folder and use the Git installation below until Manager refreshes its registry data.
+If many VRGDG nodes appear but `VRGDG AI Video Builder UI` does not, check the installed version in Manager or the `[VRGDG]` line printed in the ComfyUI terminal during startup. A version older than `9.1.0` predates the Builder/H3 registry package, while `9.1.1` adds the configurable scene-render wait. Refresh Manager's node data, update or reinstall `comfyui-vrgamedevgirl`, restart ComfyUI, and hard refresh the browser. If Manager still offers the older package, remove only this custom-node folder and use the Git installation below until Manager refreshes its registry data.
 
 ### New Install With Git
 
@@ -2639,6 +2639,7 @@ Common settings:
 | Setting | What it does |
 | --- | --- |
 | Project Video Engine | Chooses `LTX (current Builder)` or the separate `MiniMax H3` path for the whole project |
+| Scene render wait limit | Chooses how many hours, from 1–24, the Builder follows each queued LTX or MiniMax scene before reporting a timeout |
 | Default folder for new projects | Optional absolute parent folder used by New Project, Save Project As, and Branch Project |
 | Custom model root | Optional alternate models folder root |
 | Run automatic RAM/VRAM cleanup | Controls embedded cleanup nodes and automatic cache clearing between Builder jobs |
@@ -2652,6 +2653,10 @@ Common settings:
 ### Project Video Engine
 
 Choose the engine before creating prompts and videos. `LTX (current Builder)` keeps the existing LTX modes and renderer. `MiniMax H3` shows the separate four-mode H3 panel, exact-timeline adapter, and H3 scene action. The value is saved with the project; older sessions without it load as LTX.
+
+### Render Waiting
+
+`Scene render wait limit (hours)` accepts 1–24 hours and defaults to 2. It is saved with the project and applies to newly started individual or batch scene renders for both LTX and MiniMax. Reaching this limit only stops the Builder from polling that scene; it does not cancel a render that is still active in the ComfyUI queue. Let the queue finish and use `Recover Scene Videos` when necessary.
 
 ### Project Storage
 
@@ -3038,7 +3043,7 @@ Use this for new projects.
 | Ingredients tabs are blank | Update to the newest Builder, restart ComfyUI, and hard refresh the browser so the repaired Sheets, Mapping, and Locations panels load |
 | Story Arc reports a changed lyric structure | Update and rerun. Trailing invented headings are removed automatically; a remaining error means Gemma actually missed, renamed, reordered, or inserted a heading inside the required structure |
 | Render All progress disappeared | Reopen the persistent render log and inspect the saved JSON/text report in the project for completed phases, failures, and stitch timing |
-| A scene render reports the wait limit | The Builder now waits up to two hours. Check whether the ComfyUI queue is still running; if it finished, use scene-video recovery/history, and inspect the terminal plus temporary output before retrying |
+| A scene render reports the wait limit | Open `Menu` -> `Settings` -> `Render Waiting` and increase `Scene render wait limit (hours)` up to 24. If ComfyUI is still rendering, let it finish and then use scene-video recovery/history; also inspect the terminal and temporary output before retrying |
 | `Delete ALL Videos` cleared the timeline | The underlying video/thumbnail files were intentionally left in the project folder. Reassign or recover the desired file; unlike `Delete ALL Images`, this action does not delete media files. |
 | Prompt Creator data does not populate notes | Use `Send To AI Video Builder` or `Import Data From Prompt Creator`, then reload/import prompt files if needed |
 | LM Studio is selected but a pass says Built-in GGUF | That job is explicitly local-only, or the selected LM Studio model cannot serve the required path. Supported text/vision jobs name LM Studio in progress; test the server/model and use a vision-capable model for image-reference work. |

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -117,7 +117,7 @@ These are the newest user-facing changes covered throughout this guide:
 | Update | What changed |
 | --- | --- |
 | MiniMax H3 Builder integration | Projects can select MiniMax H3 and use its four scene modes, dedicated prompts and renderer, ordered image/video references, exact timeline trim, input-audio or built-in-audio paths, and H3-aware `Render All`/stitching. |
-| MiniMax-H3 Turbo acceleration | Optional Turbo mode injects the selected Turbo LoRA and dedicated sampler, starts at 6 editable steps with a minimum of 4, bypasses EasyCache by default, and restores the prior normal steps/cache preference when disabled. |
+| MiniMax-H3 Turbo acceleration | Optional Turbo mode injects the selected Turbo LoRA and dedicated sampler, starts at 4 editable steps, allows experimental step values below the usual 4-step target, bypasses EasyCache by default, and restores the prior normal steps/cache preference when disabled. |
 | MiniMax reference priority and editing | Reference-to-Video can use a scene image as the exact start, as LLM-only environment inspiration, as environment-plus-framing inspiration, or not at all. Exact-start scenes can limit character references to face and hair, and Storyboard `Cut frequency` creates an exact duration-aware cut plan. |
 | Larger LLM runner controls | Gemma Local and LM Studio now have separate input-context and maximum-output controls. Supported vision jobs can use LM Studio or a vision-capable LLM API, while progress labels identify genuinely built-in-only work. |
 | MiniMax H3 B-roll safety | Scenes marked B-roll/no-lip-sync now suppress lyric, singer, speaker, and native-voice inputs during prompt generation, remove singing directions from H3 timestamp blocks, and reapply a visual-only safety contract when rendering an existing prompt. |
@@ -1113,7 +1113,7 @@ The main video settings choose aspect ratio, megapixels, seed, warm-up frames, a
 
 Enable `Use MiniMax-H3 Turbo LoRA (4-step)` when the optional `ComfyUI-MiniMax-H3-Turbo` extension and selected Turbo LoRA are installed. The Builder injects the Turbo LoRA and dedicated Turbo sampler into a queued copy of the hidden workflow; standard MiniMax rendering is unchanged while Turbo is off.
 
-When Turbo turns on, the Builder defaults to 6 editable steps, enforces a minimum of 4, and enables `Bypass EasyCache`. The step field remains editable for quality/speed testing. Turning Turbo off restores the normal step count and EasyCache preference that were active before Turbo was enabled. Existing projects saved with the former 20-step Turbo default migrate to the newer 6-step default when appropriate.
+When Turbo turns on, the Builder defaults to 4 editable steps and enables `Bypass EasyCache`. The step field remains editable down to 1 for quality/speed experiments, though values below 4 are outside the Turbo LoRA's usual 4-step target. Turning Turbo off restores the normal step count and EasyCache preference that were active before Turbo was enabled. Existing projects saved with the former 20-step Turbo default migrate to the newer 4-step default when appropriate.
 
 The default Turbo LoRA filename is:
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 import folder_paths
 
-__version__ = "v9.1.0"
+__version__ = "v9.1.1"
 __updated__ = "2026-08-06"
 
 _VRGDG_SUBMODULES = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vrgamedevgirl"
 description = "VRGameDevGirl custom nodes for the ComfyUI AI Video Builder, audio, image, video, workflow-runner, prompt-creator, and post-process workflows."
-version = "9.1.0"
+version = "9.1.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_builder_minimax_turbo.py
+++ b/tests/test_builder_minimax_turbo.py
@@ -218,13 +218,13 @@ class BuilderMiniMaxTurboTests(unittest.TestCase):
         self.assertEqual(calls["patches"][0][1][0], "forward")
         self.assertEqual(calls["debug"], [("pruned-ref-audio-compat", "bypass")])
 
-    def test_turbo_forces_required_sampler_but_allows_four_or_more_steps(self):
+    def test_turbo_forces_required_sampler_but_allows_experimental_low_steps(self):
         self.assertIn(
             '_set_api_input(prompt, scheduler_id, "scheduler", "simple")',
             RUNNER_SOURCE,
         )
         self.assertIn(
-            'turbo_steps = _int_payload(payload, "steps", 6, 4, 1000)',
+            'turbo_steps = _int_payload(payload, "steps", 4, 1, 1000)',
             RUNNER_SOURCE,
         )
         self.assertIn(
@@ -242,15 +242,15 @@ class BuilderMiniMaxTurboTests(unittest.TestCase):
             BUILDER_SOURCE,
         )
         self.assertIn(
-            'miniMaxSteps.min = settings.use_turbo_lora ? "4" : "1";',
+            'miniMaxSteps.min = "1";',
             BUILDER_SOURCE,
         )
         self.assertIn(
-            "EasyCache bypass is enabled automatically",
+            "Steps defaults to 4 when Turbo is switched on and remains editable down to 1 for experiments",
             BUILDER_SOURCE,
         )
         self.assertIn(
-            'miniMaxSteps.value = "6";',
+            'miniMaxSteps.value = "4";',
             BUILDER_SOURCE,
         )
         self.assertIn(
@@ -258,7 +258,7 @@ class BuilderMiniMaxTurboTests(unittest.TestCase):
             BUILDER_SOURCE,
         )
         self.assertIn(
-            "migrateOldTurboDefault ? 6 : rawSteps",
+            "migrateOldTurboDefault ? 4 : rawSteps",
             BUILDER_SOURCE,
         )
         self.assertIn(

--- a/tests/test_builder_scene_render_timeout.py
+++ b/tests/test_builder_scene_render_timeout.py
@@ -1,0 +1,59 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(
+    encoding="utf-8"
+)
+
+
+class BuilderSceneRenderTimeoutTests(unittest.TestCase):
+    def test_settings_menu_exposes_persistent_one_to_twenty_four_hour_limit(self):
+        for expected in (
+            "const DEFAULT_SCENE_RENDER_WAIT_HOURS = 2;",
+            "const MAX_SCENE_RENDER_WAIT_HOURS = 24;",
+            'makeField("Scene render wait limit (hours)", sceneRenderWaitHoursInput)',
+            'sceneRenderWaitHoursInput.min = "1";',
+            'sceneRenderWaitHoursInput.max = String(MAX_SCENE_RENDER_WAIT_HOURS);',
+            "scene_render_wait_hours: normalizeSceneRenderWaitHours(state.sceneRenderWaitHours)",
+            "data.session.scene_render_wait_hours ?? state.sceneRenderWaitHours",
+            "session.scene_render_wait_hours ?? state.sceneRenderWaitHours",
+        ):
+            self.assertIn(expected, BUILDER_SOURCE)
+
+    def test_video_waiter_uses_configured_limit_for_ltx_and_minimax(self):
+        self.assertIn(
+            "const timeoutMs = timeoutHours * 60 * 60 * 1000;",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "while (Date.now() - started < timeoutMs)",
+            BUILDER_SOURCE,
+        )
+        self.assertGreaterEqual(
+            BUILDER_SOURCE.count("timeoutHours: state.sceneRenderWaitHours"),
+            2,
+        )
+        self.assertGreaterEqual(
+            BUILDER_SOURCE.count("waitHours: state.sceneRenderWaitHours"),
+            2,
+        )
+        self.assertNotIn(
+            "while (Date.now() - started < 2 * 60 * 60 * 1000)",
+            BUILDER_SOURCE,
+        )
+
+    def test_timeout_message_reports_the_selected_limit(self):
+        self.assertIn(
+            "did not finish before the ${sceneRenderWaitLabel(waitHours)} wait limit",
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            "This does not cancel ComfyUI's render.",
+            BUILDER_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -24,7 +24,7 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
         )
         self.assertEqual(
             release["commit"],
-            "1fbbf4539856b522b6e6bb67cbd2711b28f587df",
+            "26004612d5ee0dcdd5269b0835a2b37d13a98223",
         )
         items = "\n".join(
             item

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -24,7 +24,7 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
         )
         self.assertEqual(
             release["commit"],
-            "84fa509b85c88b7d6a8af9b9ca5eafcadf6b8c11",
+            "1fbbf4539856b522b6e6bb67cbd2711b28f587df",
         )
         items = "\n".join(
             item
@@ -37,15 +37,16 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
             "four-minute request cutoff",
             "NetworkError when attempting to fetch resource",
             "Expanded the AI Video Builder guide",
-            "ComfyUI Registry version 9.1.0",
+            "ComfyUI Registry version 9.1.1",
             "Manager continuing to install the July 3 version 9.0.0",
             "may not contain Git metadata",
+            "Scene render wait limit",
         ):
             self.assertIn(expected, items)
 
     def test_registry_and_runtime_versions_match_current_release(self):
-        self.assertIn('version = "9.1.0"', PACKAGE_METADATA)
-        self.assertIn('__version__ = "v9.1.0"', PACKAGE_INIT)
+        self.assertIn('version = "9.1.1"', PACKAGE_METADATA)
+        self.assertIn('__version__ = "v9.1.1"', PACKAGE_INIT)
         self.assertIn('__updated__ = "2026-08-06"', PACKAGE_INIT)
 
     def test_previous_release_documents_minimax_builder_controls(self):
@@ -123,8 +124,9 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
             "silent timeline clock",
             "allow up to ten minutes per scene",
             "Connection to the ComfyUI backend was lost",
-            "current ComfyUI Registry release is `9.1.0`",
+            "current ComfyUI Registry release is `9.1.1`",
             "Manager-installed folder",
+            "Scene render wait limit (hours)",
         ):
             self.assertIn(expected, BUILDER_GUIDE)
 

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -16,8 +16,37 @@ BUILDER_GUIDE = (
 
 
 class BuilderUpdateBannerNotesTests(unittest.TestCase):
-    def test_latest_release_documents_storyboard_gemma_reliability(self):
+    def test_latest_release_documents_auto_build_and_singer_cues(self):
         release = UPDATE_NOTES["releases"][0]
+        self.assertEqual(
+            release["id"],
+            "2026-08-07-auto-build-minimax-singer-cues",
+        )
+        self.assertEqual(
+            release["commit"],
+            "adf9bafa12e93c66960b62b3d067719022ef1012",
+        )
+        items = "\n".join(
+            item
+            for section in release["sections"]
+            for item in section.get("items", [])
+        )
+        for expected in (
+            "Auto Build",
+            "MiniMax Singer Assignment",
+            "per-cue audio playback",
+            "Project Batch",
+            "split lyric cues now drive shot count and cut timing",
+            "creative shot JSON only",
+            "lyric cue to Instrumental",
+            "Audio 1 belongs to the target video",
+            "blank Gemma shot descriptions",
+            "Save + Close",
+        ):
+            self.assertIn(expected, items)
+
+    def test_previous_release_documents_storyboard_gemma_reliability(self):
+        release = UPDATE_NOTES["releases"][1]
         self.assertEqual(
             release["id"],
             "2026-08-06-storyboard-gemma-network-reliability",
@@ -50,13 +79,13 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
         self.assertIn('__updated__ = "2026-08-06"', PACKAGE_INIT)
 
     def test_previous_release_documents_minimax_builder_controls(self):
-        release = UPDATE_NOTES["releases"][1]
+        release = UPDATE_NOTES["releases"][2]
         self.assertEqual(
             release["id"],
             "2026-08-06-minimax-turbo-reference-llm-controls",
         )
         self.assertEqual(
-            UPDATE_NOTES["releases"][2]["id"],
+            UPDATE_NOTES["releases"][3]["id"],
             "2026-08-06-timeline-editing-minimax-prompt-reliability",
         )
         items = "\n".join(

--- a/tests/test_builder_update_banner_notes.py
+++ b/tests/test_builder_update_banner_notes.py
@@ -65,7 +65,7 @@ class BuilderUpdateBannerNotesTests(unittest.TestCase):
             for item in section.get("items", [])
         )
         for expected in (
-            "6 editable steps",
+            "4 editable steps",
             "automatically bypasses EasyCache",
             "environment inspiration",
             "Face + hair only",

--- a/update_notes.json
+++ b/update_notes.json
@@ -17,6 +17,7 @@
             "Added Auto Build to the Builder toolbar so music-video projects can create scenes, lyrics, references, mappings, defaults, and prompts from a simpler guided setup.",
             "Added MiniMax Singer Assignment for split lyric cues, including timed lyric and instrumental rows, per-cue singer selection, and synchronized Reference Builder mappings.",
             "Added compact per-cue audio playback controls so users can audition each lyric or instrumental slice while setting Start and End times.",
+            "Added a shared MiniMax H3 prompt-generation path so the side panel, Storyboard Builder, Wizard Storyboard All, and Auto Build can produce the same final MiniMax prompt format.",
             "Added Project Batch tooling for running saved projects one after another."
           ]
         },
@@ -25,6 +26,7 @@
           "items": [
             "MiniMax split lyric cues now drive shot count and cut timing, so prompt shots align with the assigned singer and cue boundaries.",
             "MiniMax prompt generation now asks Gemma for creative shot JSON only while the Builder appends fixed reference, audio, continuity, and MiniMax format sections.",
+            "Storyboard Builder context is now passed into the same MiniMax H3 prompt context used by the side panel, keeping storyboard beats, camera guidance, style, temporal/world effects, facial direction, audio notes, and continuity aligned.",
             "The Builder toolbar, shared tabs, buttons, and global font styling are more compact and easier to read in crowded MiniMax, LTX, and image-generation panels.",
             "Changing a lyric cue to Instrumental now creates a new lyric slot underneath instead of merging or losing the lyric text.",
             "Set End on one singer cue now automatically sets the next cue's Start time to the same boundary."
@@ -34,6 +36,7 @@
           "title": "Fixed",
           "items": [
             "Fixed MiniMax multi-singer prompts so Audio 1 belongs to the target video instead of incorrectly assigning the whole song to Subject 1.",
+            "Fixed MiniMax prompt drift where side-panel generation, Storyboard Builder generation, and Auto Build could use slightly different request wrappers or instruction keys.",
             "Fixed malformed LLM artifacts inside MiniMax dialogue tags and cleaned awkward post-cut wording such as 'the camera cuts to a medium close-up shows'.",
             "Fixed blank Gemma shot descriptions by filling missing shots from the timed singer cue map instead of stopping prompt creation.",
             "Fixed the top-right Builder close button so it asks whether to Save + Close, Close Without Saving, or Go Back before exiting."

--- a/update_notes.json
+++ b/update_notes.json
@@ -7,14 +7,15 @@
       "version": "2026.08.06-storyboard-gemma-reliability",
       "date": "2026-08-06",
       "title": "Storyboard Gemma reliability, Manager release, and updated guide",
-      "commit": "84fa509b85c88b7d6a8af9b9ca5eafcadf6b8c11",
+      "commit": "1fbbf4539856b522b6e6bb67cbd2711b28f587df",
       "restart_required": true,
       "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
       "sections": [
         {
           "title": "Improved",
           "items": [
-            "Published the current AI Video Builder, MiniMax H3, and Storyboard feature set as ComfyUI Registry version 9.1.0 so ComfyUI Manager installs include the Builder launcher and recent H3 updates.",
+            "Published the current AI Video Builder, MiniMax H3, Storyboard, and configurable render-wait feature set as ComfyUI Registry version 9.1.1 so ComfyUI Manager installs include the Builder launcher and recent updates.",
+            "Added a persistent Scene render wait limit in Builder Settings. Projects can keep individual and batch LTX or MiniMax scene waits active for 1–24 hours while existing projects retain the two-hour default.",
             "Storyboard Gemma image and video prompt requests now allow up to ten minutes per scene, matching the Builder's established long-running Gemma prompt window.",
             "Browser fetch failures now distinguish a real timeout from a lost ComfyUI backend connection and provide direct guidance for checking the queue, console, GPU layers, and context size.",
             "Expanded the AI Video Builder guide with the recent MiniMax-H3 Turbo, scene-image inspiration, Face + hair priority, Cut frequency, LLM context/output, LTX-to-MiniMax conversion, silent playback, rendered-scene trim, and Delete ALL Videos workflows."
@@ -23,7 +24,7 @@
         {
           "title": "Fixed",
           "items": [
-            "Fixed ComfyUI Manager continuing to install the July 3 version 9.0.0 package, which predated the Video Builder launcher, by advancing the registry package and runtime version to 9.1.0.",
+            "Fixed ComfyUI Manager continuing to install the July 3 version 9.0.0 package, which predated the Video Builder launcher, by advancing the registry package and runtime version through 9.1.1.",
             "Fixed the MiniMax-H3 Turbo compatibility adapter rejecting extension v1.2.2 because upstream replaced its private _AdalnDelta wrapper with the safer _make_adaln_forward API; pruned Ref2VA models can now use Turbo with reference audio through either supported upstream API shape.",
             "Fixed Storyboard Gemma All stopping on a slow first scene because its newer Video Builder path still used a four-minute request cutoff.",
             "Fixed Firefox exposing the opaque 'NetworkError when attempting to fetch resource' message when a Storyboard prompt request timed out or the ComfyUI connection closed."

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,52 @@
   "product": "AI Video Builder",
   "releases": [
     {
+      "id": "2026-08-07-auto-build-minimax-singer-cues",
+      "version": "2026.08.07-auto-build-singer-cues",
+      "date": "2026-08-07",
+      "title": "Auto Build and MiniMax singer cue workflow",
+      "commit": "adf9bafa12e93c66960b62b3d067719022ef1012",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
+      "sections": [
+        {
+          "title": "New",
+          "items": [
+            "Added Auto Build to the Builder toolbar so music-video projects can create scenes, lyrics, references, mappings, defaults, and prompts from a simpler guided setup.",
+            "Added MiniMax Singer Assignment for split lyric cues, including timed lyric and instrumental rows, per-cue singer selection, and synchronized Reference Builder mappings.",
+            "Added compact per-cue audio playback controls so users can audition each lyric or instrumental slice while setting Start and End times.",
+            "Added Project Batch tooling for running saved projects one after another."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "MiniMax split lyric cues now drive shot count and cut timing, so prompt shots align with the assigned singer and cue boundaries.",
+            "MiniMax prompt generation now asks Gemma for creative shot JSON only while the Builder appends fixed reference, audio, continuity, and MiniMax format sections.",
+            "The Builder toolbar, shared tabs, buttons, and global font styling are more compact and easier to read in crowded MiniMax, LTX, and image-generation panels.",
+            "Changing a lyric cue to Instrumental now creates a new lyric slot underneath instead of merging or losing the lyric text.",
+            "Set End on one singer cue now automatically sets the next cue's Start time to the same boundary."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Fixed MiniMax multi-singer prompts so Audio 1 belongs to the target video instead of incorrectly assigning the whole song to Subject 1.",
+            "Fixed malformed LLM artifacts inside MiniMax dialogue tags and cleaned awkward post-cut wording such as 'the camera cuts to a medium close-up shows'.",
+            "Fixed blank Gemma shot descriptions by filling missing shots from the timed singer cue map instead of stopping prompt creation.",
+            "Fixed the top-right Builder close button so it asks whether to Save + Close, Close Without Saving, or Go Back before exiting."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "Restart ComfyUI and hard-refresh the browser after updating so the new Builder JavaScript is loaded.",
+            "If a two-performer MiniMax shot swaps lip-sync unexpectedly, use tighter framing or over-the-shoulder composition for that cue while keeping the same singer assignment data."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-06-storyboard-gemma-network-reliability",
       "version": "2026.08.06-storyboard-gemma-reliability",
       "date": "2026-08-06",

--- a/update_notes.json
+++ b/update_notes.json
@@ -52,7 +52,7 @@
         {
           "title": "New",
           "items": [
-            "Added optional MiniMax-H3 Turbo LoRA acceleration to MiniMax Video Settings. The hidden workflow injects the required Turbo LoRA and dedicated sampler, defaults to 6 editable steps with a minimum of 4, automatically bypasses EasyCache, and restores the previous normal steps and EasyCache preference when Turbo is turned off.",
+            "Added optional MiniMax-H3 Turbo LoRA acceleration to MiniMax Video Settings. The hidden workflow injects the required Turbo LoRA and dedicated sampler, defaults to 4 editable steps, allows experimental step values below the usual 4-step target, automatically bypasses EasyCache, and restores the previous normal steps and EasyCache preference when Turbo is turned off.",
             "Added a scope-aware MiniMax Reference-to-Video Scene image use dropdown. A scene image can be unused, supplied to both the LLM and MiniMax as the exact start frame, or supplied only to the vision LLM as environment inspiration with camera framing either ignored or optionally considered.",
             "Added Face + hair only exact-start priority. Character references can replace only face identity and hair from the first generated frame while the start image remains authoritative for body, clothing, pose, composition, lighting, environment, and every other visible detail.",
             "Added a MiniMax-only Cut frequency Scene Default from 0–10. Zero requests one continuous uninterrupted take, while 10 schedules one continuity-preserving CUT TO per second within each segment's exact duration.",
@@ -66,7 +66,7 @@
             "Builder, Storyboard, Wizard, Prompt Creator, and image-reference vision jobs now honor the selected local-runner output ceiling. LM Studio receives both context length and maximum output tokens through its native chat API.",
             "Project-global MiniMax mode, model, video, scene-image, and character-priority changes now update every eligible unlocked scene while preserving independently locked scene settings.",
             "The top status bar consistently uses the AI Video Builder product name and includes a persistent live badge showing whether the project is using LTX or MiniMax.",
-            "Existing projects saved with Turbo's old 20-step default migrate to 6 steps, and existing Turbo projects or locked scenes migrate to EasyCache bypass without overwriting later manual experimentation."
+            "Existing projects saved with Turbo's old 20-step default migrate to 4 steps, and existing Turbo projects or locked scenes migrate to EasyCache bypass without overwriting later manual experimentation."
           ]
         },
         {

--- a/update_notes.json
+++ b/update_notes.json
@@ -7,7 +7,7 @@
       "version": "2026.08.06-storyboard-gemma-reliability",
       "date": "2026-08-06",
       "title": "Storyboard Gemma reliability, Manager release, and updated guide",
-      "commit": "1fbbf4539856b522b6e6bb67cbd2711b28f587df",
+      "commit": "26004612d5ee0dcdd5269b0835a2b37d13a98223",
       "restart_required": true,
       "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/blob/main/Workflows/LTX-2_Workflows/Video_Builder/readme.md",
       "sections": [

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -6755,11 +6755,13 @@ function openBuilder(node) {
         segment.lyric_singers = selectedPerformers.map((subject) => subject.name || "Character");
       }
       const audioTools = document.createElement("div");
-      audioTools.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:8px;";
+      audioTools.style.cssText = "display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;";
       const playSceneCueAudio = makeButton("Play Scene Audio", "primary");
       const jumpSceneCueAudio = makeButton("Jump To Scene Start");
+      const autoTimeSceneCues = makeButton("Auto Time This Scene");
       applyCompactButtonLabel(playSceneCueAudio, "Play\nScene Audio", { noMap: true, padding: "7px 6px", title: "Play this scene's audio range." });
       applyCompactButtonLabel(jumpSceneCueAudio, "Jump To\nScene Start", { noMap: true, padding: "7px 6px", title: "Move the playhead to this scene start." });
+      applyCompactButtonLabel(autoTimeSceneCues, "Auto Time\nThis Scene", { noMap: true, padding: "7px 6px", title: "Use the existing Stable-ts timestamp workflow to fill cue start/end times for this scene. Manual editing stays available." });
       playSceneCueAudio.onclick = () => {
         const start = timelineAudioStartForSegment(segment);
         if (!playSceneAudioFrom(start)) {
@@ -6772,7 +6774,8 @@ function openBuilder(node) {
         activateGlobalTimelineAudioPlayback(start);
         toast(`Playhead moved to ${formatTime(start)}. Play the scene, then use Set Start / Set End on cue rows.`);
       };
-      audioTools.append(playSceneCueAudio, jumpSceneCueAudio);
+      autoTimeSceneCues.onclick = () => autoTimeMiniMaxSingerCuesForSegment(segment);
+      audioTools.append(playSceneCueAudio, jumpSceneCueAudio, autoTimeSceneCues);
       miniMaxSpeakerAssignmentList.append(audioTools);
 
       const modeWrap = document.createElement("div");
@@ -6844,12 +6847,14 @@ function openBuilder(node) {
       applyCompactButtonLabel(addInstrumentalCue, "Add\nInstrumental", { noMap: true, padding: "7px 6px", title: "Add Instrumental Cue" });
       addLyricCue.onclick = () => {
         const performer = selectedPerformers[cues.filter((cue) => cue.type !== "instrumental").length % selectedPerformers.length] || selectedPerformers[0] || speakers[0] || {};
-        cues.push({ type: "vocal", text: "", action_note: "", singer_id: performer.id || "", singer_name: performer.name || "", start: null, end: null });
+        const start = miniMaxNextCueStartTime(segment, cues);
+        cues.push({ type: "vocal", text: "", action_note: "", singer_id: performer.id || "", singer_name: performer.name || "", start, end: null });
         segment.lyric_cue_map = cues;
         renderMiniMaxSpeakerAssignmentPanel();
       };
       addInstrumentalCue.onclick = () => {
-        cues.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start: null, end: null });
+        const start = miniMaxNextCueStartTime(segment, cues);
+        cues.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start, end: null });
         segment.lyric_cue_map = cues;
         renderMiniMaxSpeakerAssignmentPanel();
       };
@@ -6942,11 +6947,13 @@ function openBuilder(node) {
         mainRow.append(handle, number, typeSelect, singerSelect, line, remove);
         const timingRow = document.createElement("div");
         timingRow.style.cssText = "display:grid;grid-template-columns:minmax(44px,.45fr) minmax(44px,.45fr) 58px 64px 58px 58px 60px;gap:7px;align-items:center;padding-left:74px;";
+        const cueRange = singerCuePlaybackRangeForCue(segment, cues, index);
+        const effectiveEnd = miniMaxEffectiveCueEnd(segment, cues, index);
         const startLabel = document.createElement("div");
         startLabel.textContent = `Start: ${formatCueTime(cue.start)}`;
         startLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
         const endLabel = document.createElement("div");
-        endLabel.textContent = `End: ${formatCueTime(cue.end)}`;
+        endLabel.textContent = `End: ${formatCueTime(effectiveEnd)}`;
         endLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
         const playCue = makeButton("Play Cue", "primary");
         const playFromCue = makeButton("Play From Here");
@@ -6958,7 +6965,6 @@ function openBuilder(node) {
         applyCompactButtonLabel(setStart, "Set\nStart", { noMap: true, minWidth: 0, padding: "6px 5px" });
         applyCompactButtonLabel(setEnd, "Set\nEnd", { noMap: true, minWidth: 0, padding: "6px 5px" });
         applyCompactButtonLabel(clearTiming, "Clear\nTime", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Clear Timing" });
-        const cueRange = singerCuePlaybackRangeForCue(segment, cues, index);
         playCue.title = "Play from this cue start to its end, the next cue start, or the scene end.";
         playFromCue.title = "Play from this cue start, or from the scene start if no cue start is set.";
         playCue.onclick = () => {
@@ -6969,7 +6975,9 @@ function openBuilder(node) {
         };
         setStart.onclick = () => {
           cue.start = singerCueRelativePlayheadTime(segment);
+          if (index > 0) cues[index - 1].end = cue.start;
           if (Number.isFinite(Number(cue.end)) && cue.end <= cue.start) cue.end = null;
+          syncCueEndBoundariesFromNextStarts(cues);
           segment.lyric_cue_map = cues;
           renderMiniMaxSpeakerAssignmentPanel();
         };
@@ -6982,6 +6990,7 @@ function openBuilder(node) {
             cues[index + 1].start = cue.end;
             if (Number.isFinite(Number(cues[index + 1].end)) && cues[index + 1].end <= cues[index + 1].start) cues[index + 1].end = null;
           }
+          syncCueEndBoundariesFromNextStarts(cues);
           segment.lyric_cue_map = cues;
           renderMiniMaxSpeakerAssignmentPanel();
         };
@@ -21507,8 +21516,8 @@ function openBuilder(node) {
       return `${performer} performs the exact full lyric/dialogue line from <Audio 1>: "${miniMaxH3PunctuatedCueText(lyricText)}"`;
     }
     if (String(segment?.lyric_performance_mode || "together") === "cue_map" && cueMap.length) {
-      const lines = cueMap.map((cue) => {
-        const timing = miniMaxH3CueTimingText(cue);
+      const lines = cueMap.map((cue, index) => {
+        const timing = miniMaxH3CueTimingText(cue, segment, cueMap, index);
         if (cue.type === "instrumental") {
           const note = cue.action_note ? ` Action note: ${cue.action_note}` : "";
           return `${timing}Instrumental / no vocal cue. No visible subject sings or lip-syncs; mouths stay closed or naturally relaxed.${note}`;
@@ -21527,12 +21536,46 @@ function openBuilder(node) {
     return `${performerText} perform the same complete lyric/dialogue line together from <Audio 1>: "${miniMaxH3PunctuatedCueText(lyricText)}"`;
   }
 
-  function miniMaxH3CueTimingText(cue = {}) {
+  function miniMaxH3CueTimingText(cue = {}, segment = null, cues = [], index = 0) {
     const start = Number(cue?.start);
-    const end = Number(cue?.end);
+    const end = miniMaxEffectiveCueEnd(segment, cues, index, cue);
     if (Number.isFinite(start) && Number.isFinite(end) && end > start) return `${start.toFixed(3)}s-${end.toFixed(3)}s: `;
     if (Number.isFinite(start)) return `from ${start.toFixed(3)}s: `;
     return "";
+  }
+
+  function miniMaxEffectiveCueEnd(segment, cues = [], index = 0, cueOverride = null) {
+    const cue = cueOverride || cues[index] || {};
+    const start = Number(cue?.start);
+    const explicitEnd = Number(cue?.end);
+    if (Number.isFinite(explicitEnd) && (!Number.isFinite(start) || explicitEnd > start)) return explicitEnd;
+    if (!segment) return Number.isFinite(explicitEnd) ? explicitEnd : null;
+    const range = singerCuePlaybackRangeForCue(segment, cues, index);
+    return Number.isFinite(Number(range?.end)) ? Number(range.end) : null;
+  }
+
+  function miniMaxNextCueStartTime(segment, cues = []) {
+    const sceneDuration = Math.max(0, Number(timelineSegmentDuration(segment) || 0));
+    if (!Array.isArray(cues) || !cues.length) return 0;
+    const lastIndex = cues.length - 1;
+    const lastCue = cues[lastIndex] || {};
+    const lastEnd = miniMaxEffectiveCueEnd(segment, cues, lastIndex, lastCue);
+    if (Number.isFinite(Number(lastEnd))) return Math.max(0, Math.min(sceneDuration || Number(lastEnd), Number(lastEnd)));
+    const lastStart = Number(lastCue.start);
+    return Number.isFinite(lastStart) ? Math.max(0, Math.min(sceneDuration || lastStart, lastStart)) : 0;
+  }
+
+  function syncCueEndBoundariesFromNextStarts(cues = []) {
+    if (!Array.isArray(cues)) return cues;
+    for (let index = 0; index < cues.length - 1; index += 1) {
+      const current = cues[index];
+      const nextStart = Number(cues[index + 1]?.start);
+      const currentStart = Number(current?.start);
+      if (current && Number.isFinite(nextStart) && (!Number.isFinite(currentStart) || nextStart > currentStart)) {
+        current.end = nextStart;
+      }
+    }
+    return cues;
   }
 
   function miniMaxH3CutPlanForSegment(segment) {
@@ -21617,6 +21660,181 @@ function openBuilder(node) {
     const carried = flattenLyricForPrompt(text);
     if (!carried) return;
     cues.splice(index + 1, 0, { type: "vocal", text: carried, action_note: "", singer_id: defaultPerformer?.id || "", singer_name: defaultPerformer?.name || "", start: null, end: null });
+  }
+
+  function timestampedCueSegments(payload = {}) {
+    return (Array.isArray(payload?.segments) ? payload.segments : [])
+      .map((item) => {
+        const type = String(item?.type || "").trim().toLowerCase() === "instrumental" ? "instrumental" : "vocal";
+        const start = Number(item?.start);
+        const end = Number(item?.end);
+        return {
+          type,
+          text: flattenLyricForPrompt(item?.text),
+          start: Number.isFinite(start) ? Math.max(0, start) : null,
+          end: Number.isFinite(end) ? Math.max(0, end) : null,
+          duration: Number.isFinite(start) && Number.isFinite(end) ? Math.max(0, end - start) : 0,
+        };
+      })
+      .filter((item) => Number.isFinite(Number(item.start)) && Number.isFinite(Number(item.end)) && item.end > item.start);
+  }
+
+  function rebuildSingerCueMapFromTimestampedSegments(segment, currentCues = [], timestamped = [], options = {}) {
+    const sceneDuration = Math.max(0, Number(timelineSegmentDuration(segment) || 0));
+    const minInstrumentalGap = Math.max(0, Number(options.minInstrumentalGap ?? 0.5));
+    const trailingVocalTailMergeSeconds = Math.max(0, Number(options.trailingVocalTailMergeSeconds ?? 1.5));
+    const vocalCues = currentCues.filter((cue) => cue.type !== "instrumental" && flattenLyricForPrompt(cue.text));
+    const instrumentalNotes = currentCues
+      .filter((cue) => cue.type === "instrumental")
+      .map((cue) => String(cue.action_note || cue.note || "").trim())
+      .filter(Boolean);
+    let vocalIndex = 0;
+    let instrumentalIndex = 0;
+    const rebuilt = [];
+    const absorbSkippedGap = (end) => {
+      if (!rebuilt.length) return;
+      const previous = rebuilt[rebuilt.length - 1];
+      if (!Number.isFinite(Number(previous.end)) || Number(previous.end) < end) previous.end = end;
+    };
+    for (let itemIndex = 0; itemIndex < timestamped.length; itemIndex += 1) {
+      const item = timestamped[itemIndex];
+      const start = Math.max(0, Math.min(sceneDuration || item.start, Number(item.start)));
+      const end = Math.max(start, Math.min(sceneDuration || item.end, Number(item.end)));
+      if (item.type === "instrumental") {
+        const hasLaterVocal = timestamped.slice(itemIndex + 1).some((next) => next.type !== "instrumental");
+        const previous = rebuilt[rebuilt.length - 1];
+        if (!hasLaterVocal && previous?.type === "vocal" && end - start <= trailingVocalTailMergeSeconds) {
+          previous.end = end;
+          continue;
+        }
+        if (end - start < minInstrumentalGap) {
+          if (start <= 0.001 && rebuilt[0]) rebuilt[0].start = 0;
+          else absorbSkippedGap(end);
+          continue;
+        }
+        const note = instrumentalNotes[instrumentalIndex++] || "";
+        rebuilt.push({ type: "instrumental", text: "", action_note: note, singer_id: "", singer_name: "", start, end });
+        continue;
+      }
+      const source = vocalCues[vocalIndex++] || {};
+      rebuilt.push({
+        type: "vocal",
+        text: flattenLyricForPrompt(source.text || item.text),
+        action_note: "",
+        singer_id: String(source.singer_id || "").trim(),
+        singer_name: String(source.singer_name || "").trim(),
+        start,
+        end,
+      });
+    }
+    while (vocalIndex < vocalCues.length) {
+      const source = vocalCues[vocalIndex++];
+      const start = miniMaxNextCueStartTime(segment, rebuilt);
+      rebuilt.push({
+        type: "vocal",
+        text: flattenLyricForPrompt(source.text),
+        action_note: "",
+        singer_id: String(source.singer_id || "").trim(),
+        singer_name: String(source.singer_name || "").trim(),
+        start,
+        end: null,
+      });
+    }
+    if (rebuilt.length) {
+      const last = rebuilt[rebuilt.length - 1];
+      if (!Number.isFinite(Number(last.end)) || Number(last.end) <= Number(last.start)) last.end = sceneDuration || null;
+    }
+    return rebuilt.filter((cue) => cue.type === "instrumental" || cue.text);
+  }
+
+  async function prepareSceneAudioClipForTimestamping(segment, progress = null) {
+    const projectFolder = String(projectInput.value || state.projectFolder || "").trim();
+    const customAudioPath = String(segment?.custom_audio_path || "").trim();
+    const sourcePath = customAudioPath || currentProjectAudioPath();
+    if (!sourcePath) throw new Error("Load project audio first, or add custom scene audio for this scene.");
+    if (!projectFolder) throw new Error("Create or load a project before auto-timing singer cues.");
+    const sceneNumber = sceneSlotNumber(segment);
+    const start = customAudioPath ? audioSourceStart(segment) : Math.max(0, Number(segment.start || 0));
+    const duration = customAudioPath ? audioChunkDuration(segment) : timelineSegmentDuration(segment);
+    progress?.set(`Preparing ${duration.toFixed(3)}s scene audio clip...`, 10);
+    const prepared = await postJson("/vrgdg/workflow_runner/prepare_scene_audio_clip", {
+      audio_path: sourcePath,
+      project_folder: projectFolder,
+      scene_number: sceneNumber,
+      start_seconds: start,
+      duration_seconds: duration,
+    }, 120000);
+    return String(prepared.audio_path || "").trim();
+  }
+
+  async function runTimestampedCueWorkflow(audioPath, referenceLyrics, progress = null, maxSceneSeconds = 8) {
+    progress?.set("Building Stable-ts timestamp workflow...", 22);
+    const built = await postJson("/vrgdg/workflow_runner/build_timestamped_transcribe_prompt", {
+      audio_path: audioPath,
+      reference_lyrics: referenceLyrics,
+      language: "english",
+      segment_mode: "reference_scene_words",
+      include_instrumental_gaps: true,
+      instrumental_text: "[instrumental]",
+      min_gap_seconds: 0.5,
+      min_scene_seconds: 1.0,
+      max_scene_seconds: Math.max(1, Number(maxSceneSeconds || 8)),
+      vocal_tail_padding_seconds: 0.0,
+      model_name: "large-v3",
+    }, 60000);
+    progress?.set("Queueing Stable-ts timestamp workflow...", 32);
+    const queued = await queueWorkflowPrompt(built.prompt, {
+      onStatus: (message) => progress?.set(message, 34),
+      idleTimeoutMs: 10 * 60 * 1000,
+    });
+    const promptId = queued.prompt_id;
+    if (!promptId) throw new Error("ComfyUI queued the timestamp workflow but did not return a prompt_id.");
+    const textValues = await waitForText(
+      promptId,
+      (message) => progress?.set(`${message}\nPrompt ID: ${promptId}`, 58),
+      () => false,
+      45 * 60 * 1000,
+    );
+    return parseTimestampedLyricsOutput(textValues.join("\n"));
+  }
+
+  async function autoTimeMiniMaxSingerCuesForSegment(segment) {
+    if (!segment || !isMiniMaxSingerAssignmentMode(segment)) return;
+    const progress = createProgressWindow("Auto Time Singer Cues");
+    try {
+      const cues = normalizeLyricCueMapForSegment(segment, undefined, { preserveBlank: true });
+      const vocalCues = cues.filter((cue) => cue.type !== "instrumental" && flattenLyricForPrompt(cue.text));
+      if (!vocalCues.length) throw new Error("Add at least one lyric cue before auto-timing this scene.");
+      progress.set("Preparing lyric cue text...", 5);
+      const referenceLyrics = vocalCues.map((cue) => flattenLyricForPrompt(cue.text)).filter(Boolean).join("\n");
+      const audioPath = await prepareSceneAudioClipForTimestamping(segment, progress);
+      const payload = await runTimestampedCueWorkflow(audioPath, referenceLyrics, progress, timelineSegmentDuration(segment));
+      const timestamped = timestampedCueSegments(payload);
+      if (!timestamped.length) throw new Error("Stable-ts did not return usable cue timestamps for this scene.");
+      progress.set("Applying timestamped cue rows...", 88);
+      const rebuilt = rebuildSingerCueMapFromTimestampedSegments(segment, cues, timestamped, { minInstrumentalGap: 0.5 });
+      if (!rebuilt.length) throw new Error("No usable cue rows were created from the timestamped result.");
+      pushHistory();
+      segment.lyric_performance_mode = "cue_map";
+      segment.lyric_cue_map = rebuilt;
+      syncLyricTextFromCueMap(segment);
+      renderMiniMaxSpeakerAssignmentPanel();
+      syncInspector();
+      render();
+      await autoSaveSessionQuiet("MiniMax singer cues auto-timed");
+      const vocalReturned = timestamped.filter((item) => item.type !== "instrumental").length;
+      const instrumentalReturned = rebuilt.filter((item) => item.type === "instrumental").length;
+      const warning = vocalReturned !== vocalCues.length
+        ? `\nWarning: Stable-ts returned ${vocalReturned} vocal cue${vocalReturned === 1 ? "" : "s"} for ${vocalCues.length} mapped lyric cue${vocalCues.length === 1 ? "" : "s"}. Review before rendering.`
+        : "";
+      progress.set(`Auto timing complete.\nVocal cues: ${vocalReturned}\nInstrumental gaps: ${instrumentalReturned}${warning}`, 100);
+      progress.close(2600);
+      toast("Singer cue timing filled. Review with Play Cue before rendering.");
+    } catch (error) {
+      progress.set(`Error:\n${String(error?.message || error)}`, 100);
+      progress.close(6000);
+      toast(String(error?.message || error), true);
+    }
   }
 
   function clearSingerCuePlaybackStop() {
@@ -24115,12 +24333,14 @@ function openBuilder(node) {
       segment.no_character_present = noCharacterPresent;
       segment.facial_performance = String(row.querySelector("[data-review-facial-performance='1']")?.value || "").trim();
       segment.facial_performance_custom = String(row.querySelector("[data-review-facial-performance-custom='1']")?.value || "").trim();
-      segment.lyric_singers = [...row.querySelectorAll("[data-review-singer-choice='1']")]
-        .filter((input) => !instrumental && !broll && !noCharacterPresent && input.checked)
+      const checkedSingerInputs = [...row.querySelectorAll("[data-review-singer-choice='1']")]
+        .filter((input) => !instrumental && !broll && !noCharacterPresent && input.checked);
+      segment.lyric_singers = checkedSingerInputs
         .map((input) => input.value)
         .filter(Boolean);
       const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
       refs.subject_scene_map = refs.subject_scene_map && typeof refs.subject_scene_map === "object" ? refs.subject_scene_map : {};
+      refs.performer_scene_map = refs.performer_scene_map && typeof refs.performer_scene_map === "object" ? refs.performer_scene_map : {};
       const presentSubjectIds = [...row.querySelectorAll("[data-review-present-subject='1']")]
         .filter((input) => !noCharacterPresent && input.checked)
         .map((input) => String(input.value || "").trim())
@@ -24128,6 +24348,29 @@ function openBuilder(node) {
       const uniqueSubjectIds = Array.from(new Set(presentSubjectIds));
       if (!noCharacterPresent && uniqueSubjectIds.length) refs.subject_scene_map[segment.id] = uniqueSubjectIds;
       else delete refs.subject_scene_map[segment.id];
+      const validSubjectIds = new Set((refs.subjects || []).map((subject) => String(subject?.id || "").trim()).filter(Boolean));
+      const performerSubjectIds = [];
+      for (const input of checkedSingerInputs) {
+        const rawId = String(input.dataset.reviewSubjectId || "").trim();
+        if (rawId === "group") {
+          performerSubjectIds.push(...uniqueSubjectIds);
+          continue;
+        }
+        if (rawId && validSubjectIds.has(rawId)) {
+          performerSubjectIds.push(rawId);
+          continue;
+        }
+        const cleanName = String(input.value || "").trim().toLowerCase();
+        const byName = (refs.subjects || []).find((subject) => String(subject?.name || "").trim().toLowerCase() === cleanName);
+        if (byName?.id) performerSubjectIds.push(String(byName.id));
+      }
+      const uniquePerformerIds = Array.from(new Set(performerSubjectIds.filter((id) => validSubjectIds.has(String(id)))));
+      if (!instrumental && !broll && !noCharacterPresent && uniquePerformerIds.length) {
+        refs.performer_scene_map[segment.id] = uniquePerformerIds;
+        refs.subject_scene_map[segment.id] = Array.from(new Set([...(refs.subject_scene_map[segment.id] || []), ...uniquePerformerIds]));
+      } else {
+        delete refs.performer_scene_map[segment.id];
+      }
       state.fluxReferenceBuilder = refs;
       if (includeTiming) {
         const start = parseBulkTimeValue(row.querySelector("[data-review-start]")?.value);
@@ -25229,15 +25472,84 @@ function openBuilder(node) {
     const mappingNote = document.createElement("div");
     mappingNote.textContent = "Choose which character and location text each scene should send to Gemma. Images are only used by image/reference-image workflows that support them.";
     mappingNote.style.cssText = "font-size:12px;color:#cbd5e1;line-height:1.45;";
+    const globalPerformanceControls = document.createElement("div");
+    globalPerformanceControls.style.cssText = "border:1px solid #155e75;border-radius:7px;background:#071422;padding:9px;display:flex;flex-direction:column;gap:7px;";
     const mappingList = document.createElement("div");
     mappingList.style.cssText = "display:flex;flex-direction:column;gap:8px;max-height:560px;overflow:auto;padding-right:4px;";
-    mappingCard.append(mappingHeader, mappingNote, mappingList);
+    mappingCard.append(mappingHeader, mappingNote, globalPerformanceControls, mappingList);
     const launchAdvancedLineMapping = (segment = null) => {
       state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
       backdrop.remove();
       openLyricReviewModal(segment ? { focusSceneId: segment.id } : {});
     };
     openAdvancedLineMapping.onclick = () => launchAdvancedLineMapping();
+
+    const performerIdsForMappingSegment = (segment, logicalSubjects = logicalReferenceSubjects(refs)) => {
+      const savedIds = sceneReferenceMapArray(refs.performer_scene_map, segment);
+      if (savedIds.length) return savedIds.map(String).filter(Boolean);
+      const selected = new Set((Array.isArray(segment?.lyric_singers) ? segment.lyric_singers : [])
+        .map((value) => String(value || "").trim().toLowerCase())
+        .filter(Boolean));
+      if (!selected.size) return [];
+      return logicalSubjects
+        .filter((subject) => selected.has(String(subject?.id || "").trim().toLowerCase()) || selected.has(String(subject?.name || "").trim().toLowerCase()))
+        .map((subject) => String(subject.id || "").trim())
+        .filter(Boolean);
+    };
+
+    const ensureCueMapForMappedScene = (segment, performerIds = []) => {
+      if (!segment || performerIds.length < 2) return;
+      if (normalizeLyricCueMapForSegment(segment, refs, { preserveBlank: true }).length) return;
+      const performers = logicalReferenceSubjects(refs).filter((subject) => performerIds.includes(String(subject.id)));
+      segment.lyric_cue_map = lyricCueTextParts(segment.lyric_text).map((text, cueIndex) => {
+        const performer = performers[cueIndex % performers.length] || performers[0] || {};
+        return { type: "vocal", text, action_note: "", singer_id: performer.id || "", singer_name: performer.name || "", start: null, end: null };
+      });
+    };
+
+    const renderGlobalPerformanceControls = () => {
+      globalPerformanceControls.replaceChildren();
+      const logicalSubjects = logicalReferenceSubjects(refs);
+      const targets = allEditableSegments()
+        .map((segment) => ({ segment, performerIds: performerIdsForMappingSegment(segment, logicalSubjects) }))
+        .filter((item) => item.performerIds.length >= 2);
+      const modes = new Set(targets.map((item) => String(item.segment.lyric_performance_mode || "together") === "cue_map" ? "cue_map" : "together"));
+      const currentMode = !targets.length ? "together" : (modes.size === 1 ? Array.from(modes)[0] : "mixed");
+      const title = document.createElement("div");
+      title.innerHTML = `<div style="font-weight:800;color:#cffafe;">Global performance mode</div><div style="font-size:11px;color:#94a3b8;margin-top:2px;">Applies to scenes with 2+ selected performers. Individual scene dropdowns still override this.</div>`;
+      const row = document.createElement("div");
+      row.style.cssText = "display:grid;grid-template-columns:minmax(180px,260px) minmax(110px,150px) minmax(0,1fr);gap:8px;align-items:center;";
+      const modeSelect = makeSelect([
+        { value: "mixed", label: "Mixed / keep current" },
+        { value: "together", label: "Together / same full line" },
+        { value: "cue_map", label: "Split cue map" },
+      ], currentMode);
+      const apply = makeButton("Apply To All", "primary");
+      apply.disabled = !targets.length || modeSelect.value === "mixed";
+      const status = document.createElement("div");
+      status.style.cssText = "font-size:11px;color:#a5f3fc;line-height:1.35;";
+      status.textContent = targets.length
+        ? `${targets.length} mapped scene${targets.length === 1 ? "" : "s"} with 2+ performers. Current: ${currentMode === "mixed" ? "mixed per-scene modes" : modeSelect.options[modeSelect.selectedIndex]?.textContent || currentMode}.`
+        : "No scenes currently have 2+ selected performers.";
+      modeSelect.onchange = () => {
+        apply.disabled = !targets.length || modeSelect.value === "mixed";
+      };
+      apply.onclick = () => {
+        const mode = String(modeSelect.value || "");
+        if (!["together", "cue_map"].includes(mode)) return;
+        pushHistory();
+        for (const item of targets) {
+          item.segment.lyric_performance_mode = mode;
+          if (mode === "cue_map") ensureCueMapForMappedScene(item.segment, item.performerIds);
+        }
+        syncInspector();
+        renderMapping();
+        autoSaveSessionQuiet("global MiniMax performance mode changed").catch(() => null);
+        toast(`Set ${targets.length} mapped scene${targets.length === 1 ? "" : "s"} to ${mode === "cue_map" ? "Split cue map" : "Together"}.`);
+      };
+      row.append(modeSelect, apply, status);
+      globalPerformanceControls.append(title, row);
+    };
 
     function openSceneAssignmentDialog() {
       const scenes = allEditableSegments();
@@ -28739,6 +29051,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
 
     function renderMapping() {
       mappingList.innerHTML = "";
+      renderGlobalPerformanceControls();
       const logicalSubjects = logicalReferenceSubjects(refs);
       const showSubjects = logicalSubjects.length > 0;
       const singleGlobalSubject = refs.use_subject_reference && logicalSubjects.length === 1;
@@ -28968,11 +29281,13 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             top.append(type, performer, text, remove);
             const timing = document.createElement("div");
             timing.style.cssText = "display:grid;grid-template-columns:minmax(44px,.45fr) minmax(44px,.45fr) 58px 64px 58px 58px 60px;gap:7px;align-items:center;";
+            const rowRange = singerCuePlaybackRangeForCue(segment, rows, index);
+            const effectiveEnd = miniMaxEffectiveCueEnd(segment, rows, index);
             const startLabel = document.createElement("div");
             startLabel.textContent = `Start: ${formatCueTime(row.start)}`;
             startLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
             const endLabel = document.createElement("div");
-            endLabel.textContent = `End: ${formatCueTime(row.end)}`;
+            endLabel.textContent = `End: ${formatCueTime(effectiveEnd)}`;
             endLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
             const playCue = makeButton("Play Cue", "primary");
             const playFromCue = makeButton("Play From Here");
@@ -28984,7 +29299,6 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             applyCompactButtonLabel(setStart, "Set\nStart", { noMap: true, minWidth: 0, padding: "6px 5px" });
             applyCompactButtonLabel(setEnd, "Set\nEnd", { noMap: true, minWidth: 0, padding: "6px 5px" });
             applyCompactButtonLabel(clearTime, "Clear\nTime", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Clear Timing" });
-            const rowRange = singerCuePlaybackRangeForCue(segment, rows, index);
             playCue.title = "Play from this cue start to its end, the next cue start, or the scene end.";
             playFromCue.title = "Play from this cue start, or from the scene start if no cue start is set.";
             playCue.onclick = () => {
@@ -28993,7 +29307,13 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             playFromCue.onclick = () => {
               playSingerCueRange(segment, rowRange.start, null, playFromCue, "Play From Here");
             };
-            setStart.onclick = () => { row.start = singerCueRelativePlayheadTime(segment); if (Number.isFinite(Number(row.end)) && row.end <= row.start) row.end = null; renderCueRows(); };
+            setStart.onclick = () => {
+              row.start = singerCueRelativePlayheadTime(segment);
+              if (index > 0) rows[index - 1].end = row.start;
+              if (Number.isFinite(Number(row.end)) && row.end <= row.start) row.end = null;
+              syncCueEndBoundariesFromNextStarts(rows);
+              renderCueRows();
+            };
             setEnd.onclick = () => {
               row.end = singerCueRelativePlayheadTime(segment);
               if (Number.isFinite(Number(row.start)) && row.end <= row.start) {
@@ -29003,6 +29323,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
                 rows[index + 1].start = row.end;
                 if (Number.isFinite(Number(rows[index + 1].end)) && rows[index + 1].end <= rows[index + 1].start) rows[index + 1].end = null;
               }
+              syncCueEndBoundariesFromNextStarts(rows);
               renderCueRows();
             };
             clearTime.onclick = () => { row.start = null; row.end = null; renderCueRows(); };
@@ -29022,11 +29343,13 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         applyCompactButtonLabel(saveCue, "Save\nCue Map", { noMap: true, padding: "7px 6px" });
         addCue.onclick = () => {
           const performer = performers[rows.length % performers.length] || performers[0];
-          rows.push({ type: "vocal", text: "", action_note: "", singer_id: performer?.id || "", singer_name: performer?.name || "", start: null, end: null });
+          const start = miniMaxNextCueStartTime(segment, rows);
+          rows.push({ type: "vocal", text: "", action_note: "", singer_id: performer?.id || "", singer_name: performer?.name || "", start, end: null });
           renderCueRows();
         };
         addInstrumental.onclick = () => {
-          rows.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start: null, end: null });
+          const start = miniMaxNextCueStartTime(segment, rows);
+          rows.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start, end: null });
           renderCueRows();
         };
         cancelCue.onclick = () => cueBackdrop.remove();
@@ -52397,7 +52720,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         ? selectedPerformers.map((subject) => subject.name || "Character")
         : [performer.name || "Character"];
       const cues = Array.isArray(segment.lyric_cue_map) ? segment.lyric_cue_map : [];
-      cues.push({ text: "", singer_id: performer.id || "", singer_name: performer.name || "" });
+      const start = miniMaxNextCueStartTime(segment, cues);
+      cues.push({ type: "vocal", text: "", action_note: "", singer_id: performer.id || "", singer_name: performer.name || "", start, end: null });
       segment.lyric_cue_map = cues;
       renderMiniMaxSpeakerAssignmentPanel();
       autoSaveSessionQuiet("MiniMax lyric cue added").catch(() => null);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2038,6 +2038,20 @@ function extractVideosFromHistory(historyPayload, promptId) {
   return videos;
 }
 
+const DEFAULT_SCENE_RENDER_WAIT_HOURS = 2;
+const MAX_SCENE_RENDER_WAIT_HOURS = 24;
+
+function normalizeSceneRenderWaitHours(value) {
+  const hours = Number(value);
+  if (!Number.isFinite(hours)) return DEFAULT_SCENE_RENDER_WAIT_HOURS;
+  return Math.max(1, Math.min(MAX_SCENE_RENDER_WAIT_HOURS, Math.round(hours)));
+}
+
+function sceneRenderWaitLabel(value) {
+  const hours = normalizeSceneRenderWaitHours(value);
+  return `${hours}-hour`;
+}
+
 function sceneVideoTimeoutMessage({
   promptId = "",
   sceneLabel = "Scene",
@@ -2045,9 +2059,10 @@ function sceneVideoTimeoutMessage({
   outputFolder = "",
   projectFolder = "",
   finalFolder = "",
+  waitHours = DEFAULT_SCENE_RENDER_WAIT_HOURS,
 } = {}) {
   const lines = [
-    `${sceneLabel}: ${modeLabel} did not finish before the 2-hour wait limit.`,
+    `${sceneLabel}: ${modeLabel} did not finish before the ${sceneRenderWaitLabel(waitHours)} wait limit.`,
     "",
     "What this means:",
     "- ComfyUI may still be rendering, or the workflow may have stopped without returning a video to the builder.",
@@ -2067,8 +2082,10 @@ function sceneVideoTimeoutMessage({
 
 async function waitForVideos(promptId, onStatus, shouldCancel, findOutputFallback = null, options = {}) {
   const started = Date.now();
+  const timeoutHours = normalizeSceneRenderWaitHours(options.timeoutHours);
+  const timeoutMs = timeoutHours * 60 * 60 * 1000;
   let lastFallbackCheck = 0;
-  while (Date.now() - started < 2 * 60 * 60 * 1000) {
+  while (Date.now() - started < timeoutMs) {
     if (shouldCancel?.()) throw new Error("Stopped by user.");
     const response = await api.fetchApi(`/history/${encodeURIComponent(promptId)}`);
     const data = await response.json().catch(() => ({}));
@@ -6071,6 +6088,7 @@ function openBuilder(node) {
     srtPath: "",
     autoSaveEnabled: true,
     automaticMemoryCleanup: false,
+    sceneRenderWaitHours: DEFAULT_SCENE_RENDER_WAIT_HOURS,
     isScrubbing: false,
     isClipScrubbing: false,
     sceneAudioMode: false,
@@ -10529,6 +10547,7 @@ function openBuilder(node) {
     state.llmApiModel = data.llmApiModel || data.llm_api_model || state.llmApiModel || "";
     state.notificationSettings = normalizeNotificationSettings(data.notificationSettings || data.notification_settings || state.notificationSettings);
     state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.automaticMemoryCleanup ?? data.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
+    state.sceneRenderWaitHours = normalizeSceneRenderWaitHours(data.sceneRenderWaitHours ?? data.scene_render_wait_hours ?? state.sceneRenderWaitHours);
     state.waveformMode = data.waveformMode || state.waveformMode || "medium";
     state.snapToBeats = data.snapToBeats ?? state.snapToBeats ?? true;
     state.showTimelineSceneNotes = data.showTimelineSceneNotes ?? state.showTimelineSceneNotes ?? false;
@@ -31719,6 +31738,20 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       makeField("Video engine for this project", projectVideoEngineSelect),
       projectVideoEngineNote,
     ], true);
+    const sceneRenderWaitHoursInput = makeInput(
+      String(normalizeSceneRenderWaitHours(state.sceneRenderWaitHours)),
+      "number",
+    );
+    sceneRenderWaitHoursInput.min = "1";
+    sceneRenderWaitHoursInput.max = String(MAX_SCENE_RENDER_WAIT_HOURS);
+    sceneRenderWaitHoursInput.step = "1";
+    const renderWaitingNote = document.createElement("div");
+    renderWaitingNote.textContent = "How long the Builder follows each queued LTX or MiniMax scene before reporting a wait-limit error. This does not cancel ComfyUI's render. Existing projects default to 2 hours; choose 1–24 hours for future scene waits.";
+    renderWaitingNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
+    const renderWaitingPanel = makeSettingsSection("Render Waiting", [
+      makeField("Scene render wait limit (hours)", sceneRenderWaitHoursInput),
+      renderWaitingNote,
+    ], true);
     const automaticMemoryCleanupControl = makeCheckbox(
       "Run automatic RAM/VRAM cleanup",
       Boolean(state.automaticMemoryCleanup),
@@ -31958,6 +31991,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         ? "Automatic RAM/VRAM cleanup enabled."
         : "Automatic RAM/VRAM cleanup disabled. DynamicVRAM will manage memory pressure.");
     });
+    sceneRenderWaitHoursInput.addEventListener("change", async () => {
+      state.sceneRenderWaitHours = normalizeSceneRenderWaitHours(sceneRenderWaitHoursInput.value);
+      sceneRenderWaitHoursInput.value = String(state.sceneRenderWaitHours);
+      await autoSaveSessionQuiet("scene render wait limit");
+      toast(`Scene renders will now wait up to ${state.sceneRenderWaitHours} hour${state.sceneRenderWaitHours === 1 ? "" : "s"}.`);
+    });
     projectVideoEngineSelect.addEventListener("change", async () => {
       state.projectVideoEngine = normalizeProjectVideoEngine(projectVideoEngineSelect.value);
       syncProjectVideoEngineUI();
@@ -31982,7 +32021,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     testErrorSound.onclick = () => playBuilderNotification("error", true);
     syncCustomAudioLabels();
     syncContinuityModeVisibility();
-    box.append(header, pathGrid, actions, note, projectStoragePanel, projectVideoEnginePanel, themePanel, memoryManagementPanel, autoChainPanel, notificationPanel);
+    box.append(header, pathGrid, actions, note, projectStoragePanel, projectVideoEnginePanel, renderWaitingPanel, themePanel, memoryManagementPanel, autoChainPanel, notificationPanel);
     backdrop.append(box);
     document.body.append(backdrop);
     modalClose.onclick = () => backdrop.remove();
@@ -32411,6 +32450,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       llm_api_model: state.llmApiModel || "",
       notification_settings: normalizeNotificationSettings(state.notificationSettings),
       automatic_memory_cleanup: Boolean(state.automaticMemoryCleanup),
+      scene_render_wait_hours: normalizeSceneRenderWaitHours(state.sceneRenderWaitHours),
       waveform_mode: state.waveformMode,
       snap_to_beats: state.snapToBeats,
       show_beat_markers: state.showBeatMarkers,
@@ -32673,6 +32713,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(data.session.lm_studio_output_token_limit ?? data.session.llm_max_tokens ?? data.session.llmMaxTokens ?? state.lmStudioOutputTokenLimit);
         state.notificationSettings = normalizeNotificationSettings(data.session.notification_settings || state.notificationSettings);
         state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(data.session.automatic_memory_cleanup ?? state.automaticMemoryCleanup ?? false);
+        state.sceneRenderWaitHours = normalizeSceneRenderWaitHours(data.session.scene_render_wait_hours ?? state.sceneRenderWaitHours);
         state.waveformMode = data.session.waveform_mode || state.waveformMode;
         state.snapToBeats = data.session.snap_to_beats ?? state.snapToBeats;
         state.showTimelineSceneNotes = data.session.show_timeline_scene_notes ?? state.showTimelineSceneNotes ?? false;
@@ -33002,6 +33043,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.lmStudioOutputTokenLimit = normalizeOutputTokenLimit(session.lm_studio_output_token_limit ?? session.llm_max_tokens ?? session.llmMaxTokens ?? state.lmStudioOutputTokenLimit);
       state.notificationSettings = normalizeNotificationSettings(session.notification_settings || state.notificationSettings);
       state.automaticMemoryCleanup = setBuilderAutomaticMemoryCleanupEnabled(session.automatic_memory_cleanup ?? false);
+      state.sceneRenderWaitHours = normalizeSceneRenderWaitHours(session.scene_render_wait_hours ?? state.sceneRenderWaitHours);
       state.waveformMode = session.waveform_mode || state.waveformMode || "medium";
       state.snapToBeats = session.snap_to_beats ?? state.snapToBeats ?? true;
       state.showTimelineSceneNotes = session.show_timeline_scene_notes ?? state.showTimelineSceneNotes ?? false;
@@ -39472,6 +39514,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       () => state.batchCancelled,
       findSceneVideoOutput,
       {
+        timeoutHours: state.sceneRenderWaitHours,
         timeoutMessage: () => sceneVideoTimeoutMessage({
           promptId,
           sceneLabel: sceneDisplayName(segment, sceneIndex),
@@ -39479,6 +39522,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           outputFolder: built.output_folder || defaultOutputFolder,
           projectFolder: projectInput.value,
           finalFolder: collectedSceneVideoFolder(),
+          waitHours: state.sceneRenderWaitHours,
         }),
       }
     );
@@ -39828,6 +39872,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         () => state.batchCancelled,
         null,
         {
+          timeoutHours: state.sceneRenderWaitHours,
           timeoutMessage: () => sceneVideoTimeoutMessage({
             promptId,
             sceneLabel: sceneDisplayName(segment, sceneIndex),
@@ -39835,6 +39880,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             outputFolder: built.output_folder || "",
             projectFolder,
             finalFolder: collectedSceneVideoFolder(),
+            waitHours: state.sceneRenderWaitHours,
           }),
         },
       );

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -140,11 +140,12 @@ const FLUX_GEMMA_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_NON_VISION_GEMMA_MODEL = "supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf";
 const NB_IMAGE_MODELS = ["gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview"];
 const DEFAULT_NB_IMAGE_MODEL = "gemini-3-pro-image-preview";
+const BUILDER_FONT_STACK = "Segoe UI, Inter, Roboto, Arial, sans-serif";
 const MINIMAX_H3_MODE_OPTIONS = [
-  { value: "text_to_video", label: "Text to Video" },
-  { value: "image_to_video", label: "Image to Video" },
-  { value: "reference_to_video", label: "Reference to Video" },
-  { value: "video_to_video", label: "Video to Video" },
+  { value: "text_to_video", label: "Text to Video", buttonLabel: "T2V" },
+  { value: "image_to_video", label: "Image to Video", buttonLabel: "I2V" },
+  { value: "reference_to_video", label: "Reference to Video", buttonLabel: "Ref to\nVideo" },
+  { value: "video_to_video", label: "Video to Video", buttonLabel: "V2V" },
 ];
 const MINIMAX_H3_INSTRUCTION_KEYS = {
   text_to_video: "minimax_h3_text_to_video",
@@ -381,7 +382,7 @@ function cloneMiniMaxH3Settings(value = {}) {
     cooldown_frames: Math.max(0, Math.trunc(Number(source.cooldown_frames || 0))),
     sampler_name: String(source.sampler_name || DEFAULT_MINIMAX_H3_SETTINGS.sampler_name),
     scheduler: String(source.scheduler || DEFAULT_MINIMAX_H3_SETTINGS.scheduler),
-    steps: migrateOldTurboDefault ? 6 : rawSteps,
+    steps: migrateOldTurboDefault ? 4 : rawSteps,
     steps_before_turbo: Math.max(1, Math.min(1000, Math.trunc(Number(source.steps_before_turbo ?? source.stepsBeforeTurbo ?? rawSteps) || DEFAULT_MINIMAX_H3_SETTINGS.steps_before_turbo))),
     denoise: Math.max(0, Math.min(1, Number(source.denoise ?? DEFAULT_MINIMAX_H3_SETTINGS.denoise))),
     easy_cache_bypass: turboEnabled && !hasSavedPreTurboEasyCache ? true : rawEasyCacheBypass,
@@ -636,13 +637,111 @@ function makeButton(label, kind = "neutral") {
     border-radius: 6px;
     background: ${kind === "primary" ? "#06b6d4" : "#27272a"};
     color: ${kind === "primary" ? "#082f49" : "#f4f4f5"};
+    font-family: ${BUILDER_FONT_STACK};
     font-size: 12px;
-    font-weight: 800;
+    font-weight: 600;
     padding: 8px 11px;
     cursor: pointer;
     white-space: nowrap;
     line-height: 1.2;
   `;
+  return button;
+}
+
+const COMPACT_TOOLBAR_ICONS = {
+  save: '<path d="M13 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8z"/><path d="M13 2v6h6"/><path d="M8 13h8v6H8z"/>',
+  wizard: '<path d="m15 4 5 5L7 22l-5-5Z"/><path d="m14 5 5 5"/><path d="M6 3v4"/><path d="M4 5h4"/><path d="M19 14v4"/><path d="M17 16h4"/>',
+  auto: '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="m7 5 2 4 2-4 2 4 2-4 2 4 2-4"/><path d="M8 13h4"/><path d="M10 11v4"/><path d="M17 12v4"/><path d="M15 14h4"/>',
+  story: '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 4v16"/><path d="M16 4v16"/><path d="M3 9h5"/><path d="M16 15h5"/>',
+  reference: '<rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="10" r="2"/><path d="m5 18 4-4 3 3 2-2 5 3"/>',
+  mapping: '<circle cx="5" cy="12" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="19" cy="12" r="2"/><circle cx="12" cy="19" r="2"/><path d="m6.5 10.5 4-4"/><path d="m13.5 6.5 4 4"/><path d="m17.5 13.5-4 4"/><path d="m10.5 17.5-4-4"/>',
+  brain: '<path d="M9.5 4A3.5 3.5 0 0 0 6 7.5v.2A3.5 3.5 0 0 0 4 11v2a3.5 3.5 0 0 0 2 3.2v.3A3.5 3.5 0 0 0 9.5 20H11V4Z"/><path d="M14.5 4A3.5 3.5 0 0 1 18 7.5v.2a3.5 3.5 0 0 1 2 3.3v2a3.5 3.5 0 0 1-2 3.2v.3a3.5 3.5 0 0 1-3.5 3.5H13V4Z"/><path d="M8 9h3"/><path d="M13 14h3"/>',
+  prompt: '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4Z"/><path d="M8 9h8"/><path d="M8 13h5"/>',
+  download: '<path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/>',
+  memory: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"/>',
+  fullscreen: '<path d="M8 3H3v5"/><path d="m3 3 6 6"/><path d="M16 3h5v5"/><path d="m21 3-6 6"/><path d="M8 21H3v-5"/><path d="m3 21 6-6"/><path d="M16 21h5v-5"/><path d="m21 21-6-6"/>',
+  restore: '<path d="M8 3H3v5"/><path d="m3 3 6 6"/><path d="M16 3h5v5"/><path d="m21 3-6 6"/><path d="M8 21H3v-5"/><path d="m3 21 6-6"/><path d="M16 21h5v-5"/><path d="m21 21-6-6"/>',
+  close: '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+};
+
+function styleCompactToolbarButton(button, options = {}) {
+  const lines = Array.isArray(options.lines) ? options.lines.filter(Boolean) : [String(options.label || button.textContent || "")];
+  const accessibleLabel = String(options.ariaLabel || lines.join(" ") || button.textContent || "Toolbar button");
+  const width = Math.max(36, Number(options.width || (options.iconOnly ? 40 : 58)));
+  button.style.cssText += `
+    width:${width}px;
+    min-width:${width}px;
+    height:${options.iconOnly ? 42 : 54}px;
+    box-sizing:border-box;
+    padding:${options.iconOnly ? "6px" : "5px 4px"};
+    display:inline-flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    gap:2px;
+    white-space:normal;
+    line-height:1.08;
+    text-align:center;
+    font-family:${BUILDER_FONT_STACK};
+    font-size:11px;
+    font-weight:500;
+    letter-spacing:0;
+  `;
+  button.setAttribute("aria-label", accessibleLabel);
+  if (options.title) button.title = options.title;
+  button.replaceChildren();
+  if (options.icon && COMPACT_TOOLBAR_ICONS[options.icon]) {
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("width", options.iconOnly ? "20" : "15");
+    icon.setAttribute("height", options.iconOnly ? "20" : "15");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "2");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.setAttribute("aria-hidden", "true");
+    icon.innerHTML = COMPACT_TOOLBAR_ICONS[options.icon];
+    button.append(icon);
+  }
+  if (!options.iconOnly) {
+    const label = document.createElement("span");
+    label.style.cssText = "display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:11px;font-weight:500;line-height:1.08;letter-spacing:0;";
+    for (const line of lines) {
+      const row = document.createElement("span");
+      row.textContent = line;
+      label.append(row);
+    }
+    button.append(label);
+  }
+  return button;
+}
+
+function compactButtonLabelText(label) {
+  const text = String(label || "");
+  const map = {
+    "Text to Video": "T2V",
+    "Image to Video": "I2V",
+    "Reference to Video": "Ref to\nVideo",
+    "Video to Video": "V2V",
+    "Image Settings": "Image\nSettings",
+    "Video Settings": "Video\nSettings",
+    "Singer Assignment": "Singer\nAssignment",
+    "Speaker Assignment": "Speaker\nAssignment",
+    "LLM Prompting": "LLM\nPrompting",
+  };
+  return map[text] || text;
+}
+
+function applyCompactButtonLabel(button, label, options = {}) {
+  const compact = options.noMap ? String(label || "") : compactButtonLabelText(label);
+  button.textContent = compact;
+  button.title = options.title || String(label || compact).replace(/\s+/g, " ").trim();
+  button.style.minWidth = `${Number(options.minWidth || 0)}px`;
+  button.style.whiteSpace = "pre-line";
+  button.style.lineHeight = "1.05";
+  button.style.textAlign = "center";
+  button.style.padding = options.padding || "7px 8px";
   return button;
 }
 
@@ -741,13 +840,13 @@ function makeInput(value = "", type = "text") {
   const input = document.createElement("input");
   input.type = type;
   input.value = value;
-  input.style.cssText = "width:100%;box-sizing:border-box;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:8px;font-size:12px;";
+  input.style.cssText = `width:100%;box-sizing:border-box;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:8px;font-family:${BUILDER_FONT_STACK};font-size:12px;font-weight:400;`;
   return input;
 }
 
 function makeCheckbox(label, checked = false) {
   const wrapper = document.createElement("label");
-  wrapper.style.cssText = "display:flex;align-items:center;gap:8px;font-size:12px;color:#f4f4f5;font-weight:800;";
+  wrapper.style.cssText = `display:flex;align-items:center;gap:8px;font-family:${BUILDER_FONT_STACK};font-size:12px;color:#f4f4f5;font-weight:500;`;
   const input = document.createElement("input");
   input.type = "checkbox";
   input.checked = Boolean(checked);
@@ -757,7 +856,7 @@ function makeCheckbox(label, checked = false) {
 
 function makeSelect(options = [], value = "") {
   const select = document.createElement("select");
-  select.style.cssText = "width:100%;box-sizing:border-box;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:8px;font-size:12px;";
+  select.style.cssText = `width:100%;box-sizing:border-box;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:8px;font-family:${BUILDER_FONT_STACK};font-size:12px;font-weight:400;`;
   for (const optionValue of options) {
     const option = document.createElement("option");
     if (optionValue && typeof optionValue === "object") {
@@ -815,7 +914,7 @@ function makeSearchableLoraPicker(value = "[none]") {
 
 function makeField(label, control) {
   const wrapper = document.createElement("label");
-  wrapper.style.cssText = "display:flex;flex-direction:column;gap:5px;font-size:12px;color:#d4d4d8;font-weight:700;";
+  wrapper.style.cssText = `display:flex;flex-direction:column;gap:5px;font-family:${BUILDER_FONT_STACK};font-size:12px;color:#d4d4d8;font-weight:500;`;
   const text = document.createElement("span");
   text.textContent = label;
   wrapper.append(text, control);
@@ -920,7 +1019,7 @@ function makeSubTabs(tabs = []) {
   const wrapper = document.createElement("div");
   wrapper.style.cssText = "display:flex;flex-direction:column;gap:8px;";
   const tabBar = document.createElement("div");
-  tabBar.style.cssText = "display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:6px;position:sticky;top:44px;z-index:2;background:#202024;padding-bottom:2px;";
+  tabBar.style.cssText = "display:grid;grid-template-columns:repeat(auto-fit,minmax(74px,1fr));gap:6px;position:sticky;top:44px;z-index:2;background:#202024;padding-bottom:2px;";
   const panels = document.createElement("div");
   panels.style.cssText = "display:flex;flex-direction:column;gap:8px;";
   const buttons = [];
@@ -938,6 +1037,7 @@ function makeSubTabs(tabs = []) {
   };
   for (const tab of tabs) {
     const button = makeButton(tab.label);
+    applyCompactButtonLabel(button, tab.label, { minWidth: 0, padding: "7px 6px" });
     button.dataset.value = tab.value;
     button.onclick = () => setActive(tab.value);
     buttons.push(button);
@@ -1342,7 +1442,7 @@ function showModelDownloadModal() {
 function showTextInputModal({ title, label, value = "", placeholder = "", confirmLabel = "Continue" } = {}) {
   return new Promise((resolve) => {
     const backdrop = document.createElement("div");
-    backdrop.style.cssText = "position:fixed;inset:0;z-index:100006;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;";
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;";
     const box = document.createElement("div");
     box.style.cssText = "width:min(560px,calc(100vw - 40px));border:1px solid #155e75;border-radius:8px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
     const heading = document.createElement("div");
@@ -2425,7 +2525,7 @@ function openBuilder(node) {
   const overlay = document.createElement("div");
   let builderKeydownHandler = null;
   overlay.dataset.vrgdgThemeRoot = "true";
-  overlay.style.cssText = "position:fixed;inset:0;z-index:100000;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;";
+  overlay.style.cssText = `position:fixed;inset:0;z-index:100000;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;font-family:${BUILDER_FONT_STACK};`;
   const shell = document.createElement("div");
   const normalShellStyle = `
     width: min(1800px, calc(100vw - 24px));
@@ -2455,16 +2555,16 @@ function openBuilder(node) {
   let builderFullscreen = false;
 
   const updateStatusBanner = document.createElement("div");
-  updateStatusBanner.style.cssText = "display:flex;align-items:center;gap:10px;min-height:34px;box-sizing:border-box;padding:5px 10px 5px 12px;border-bottom:1px solid #52525b;background:#27272a;color:#f4f4f5;font-size:12px;font-weight:700;line-height:1.25;";
+  updateStatusBanner.style.cssText = `display:flex;align-items:center;gap:10px;min-height:34px;box-sizing:border-box;padding:5px 10px 5px 12px;border-bottom:1px solid #52525b;background:#27272a;color:#f4f4f5;font-family:${BUILDER_FONT_STACK};font-size:12px;font-weight:500;line-height:1.3;letter-spacing:0;`;
   const updateStatusDot = document.createElement("span");
   updateStatusDot.style.cssText = "width:9px;height:9px;flex:0 0 9px;border-radius:999px;background:#a1a1aa;box-shadow:0 0 0 3px rgba(161,161,170,.16);";
   const updateStatusText = document.createElement("span");
   updateStatusText.style.cssText = "min-width:0;flex:1 1 auto;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
   updateStatusText.textContent = "AI Video Builder — Checking for updates…";
   const updateWhatsNewAction = makeButton("What's New");
-  updateWhatsNewAction.style.cssText += "display:none;padding:4px 10px;min-height:24px;background:#164e63;border-color:#22d3ee;color:#ecfeff;font-size:11px;font-weight:900;";
+  updateWhatsNewAction.style.cssText += `display:none;padding:4px 10px;min-height:24px;background:#164e63;border-color:#22d3ee;color:#ecfeff;font-family:${BUILDER_FONT_STACK};font-size:11px;font-weight:600;letter-spacing:0;`;
   const updateStatusAction = makeButton("Update");
-  updateStatusAction.style.cssText += "display:none;padding:4px 10px;min-height:24px;background:#7f1d1d;border-color:#f87171;color:#fff;font-size:11px;font-weight:900;";
+  updateStatusAction.style.cssText += `display:none;padding:4px 10px;min-height:24px;background:#7f1d1d;border-color:#f87171;color:#fff;font-family:${BUILDER_FONT_STACK};font-size:11px;font-weight:600;letter-spacing:0;`;
   const updateStatusClose = document.createElement("button");
   updateStatusClose.type = "button";
   updateStatusClose.textContent = "×";
@@ -2676,7 +2776,7 @@ function openBuilder(node) {
   };
 
   const topbar = document.createElement("div");
-  topbar.style.cssText = "position:relative;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:12px;align-items:center;padding:12px;border-bottom:1px solid #27272a;background:#202024;min-width:0;";
+  topbar.style.cssText = `position:relative;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:8px;align-items:center;padding:8px 10px;border-bottom:1px solid #27272a;background:#202024;min-width:0;font-family:${BUILDER_FONT_STACK};font-weight:500;letter-spacing:0;`;
   const audioInput = makeInput(String(getWidget(node, "audio_path")?.value || ""));
   const projectInput = makeInput(String(getWidget(node, "project_folder")?.value || ""));
   const srtInput = makeInput("");
@@ -2703,12 +2803,16 @@ function openBuilder(node) {
   const videoTypeSelect = makeVideoTypeSelect("singing");
   const videoTypeField = makeField("Video Type", videoTypeSelect);
   videoTypeField.style.minWidth = "180px";
+  videoTypeField.style.fontFamily = BUILDER_FONT_STACK;
+  videoTypeField.style.fontWeight = "500";
+  videoTypeSelect.style.fontFamily = BUILDER_FONT_STACK;
+  videoTypeSelect.style.fontWeight = "400";
   const autoSaveControl = makeCheckbox("Auto save", true);
   autoSaveControl.wrapper.style.cssText += "border:1px solid #3f3f46;border-radius:6px;background:#18181b;padding:7px 10px;";
   const fullscreenButton = makeButton("Fullscreen");
   fullscreenButton.title = "Expand the Video Creator to fill the browser window without closing or resetting anything.";
   const closeButton = makeButton("Close");
-  closeButton.onclick = () => {
+  const closeBuilderNow = () => {
     pauseAllAudio();
     if (!previewVideo.paused) previewVideo.pause();
     window.removeEventListener("vrgdg:builder-toast", toastNotificationHandler);
@@ -2716,10 +2820,57 @@ function openBuilder(node) {
     restoreBrowserAiDownloadsQuietly().catch(() => null);
     overlay.remove();
   };
+  const confirmCloseBuilder = () => {
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100050;background:rgba(0,0,0,.68);display:flex;align-items:center;justify-content:center;padding:20px;box-sizing:border-box;";
+    const box = document.createElement("div");
+    box.style.cssText = `width:min(520px,calc(100vw - 40px));border:1px solid #155e75;border-radius:10px;background:#0f172a;color:#f8fafc;box-shadow:0 24px 80px rgba(0,0,0,.65);padding:16px;display:flex;flex-direction:column;gap:12px;font-family:${BUILDER_FONT_STACK};`;
+    const title = document.createElement("div");
+    title.textContent = "Close Video Builder?";
+    title.style.cssText = "font-size:17px;font-weight:600;color:#cffafe;";
+    const note = document.createElement("div");
+    note.textContent = "Are you sure you want to exit? Any unsaved changes will be lost unless you save first.";
+    note.style.cssText = "font-size:13px;line-height:1.45;color:#cbd5e1;";
+    const actions = document.createElement("div");
+    actions.style.cssText = "display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;";
+    const saveAndClose = makeButton("Save + Close", "primary");
+    const closeWithoutSaving = makeButton("Close Without Saving");
+    const goBack = makeButton("Go Back");
+    closeWithoutSaving.style.borderColor = "#991b1b";
+    closeWithoutSaving.style.color = "#fecaca";
+    closeWithoutSaving.style.background = "#3f1518";
+    goBack.onclick = () => backdrop.remove();
+    closeWithoutSaving.onclick = () => {
+      backdrop.remove();
+      closeBuilderNow();
+    };
+    saveAndClose.onclick = async () => {
+      saveAndClose.disabled = true;
+      saveAndClose.textContent = "Saving...";
+      try {
+        await saveSession({ quiet: true, throwOnError: true });
+        backdrop.remove();
+        closeBuilderNow();
+      } catch (error) {
+        saveAndClose.disabled = false;
+        saveAndClose.textContent = "Save + Close";
+        toast(`Could not save before closing: ${error?.message || error}`, true);
+      }
+    };
+    actions.append(saveAndClose, closeWithoutSaving, goBack);
+    box.append(title, note, actions);
+    backdrop.append(box);
+    document.body.append(backdrop);
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) backdrop.remove();
+    });
+  };
+  closeButton.onclick = confirmCloseBuilder;
   const promptCreatorButton = makeButton("Prompt Creator (Legacy)");
   const autoLoadAllButton = makeButton("Import Data From Prompt Creator");
   const importSceneNotesButton = makeButton("Import Scene Notes JSON");
   const wizardButton = makeButton("Wizard", "primary");
+  const autoBuildButton = makeButton("Auto Build", "primary");
   const storyboardBuilderButton = makeButton("Storyboard Builder");
   const fluxReferenceBuilderButton = makeButton("Reference Builder");
   const lyricMapperButton = makeButton("Line Mapping");
@@ -2741,6 +2892,7 @@ function openBuilder(node) {
   const convertLtxPromptsToMiniMaxButton = makeButton("Convert LTX Video Prompts to MiniMax H3", "primary");
   convertLtxPromptsToMiniMaxButton.title = "Use the selected LLM Runner to convert every populated LTX video prompt into a MiniMax H3 prompt. Global audio and all other project data stay unchanged.";
   const importImageFolderButton = makeButton("Fill Timeline Images From Folder", "primary");
+  const projectBatchButton = makeButton("Project Batch", "primary");
   const fullBuildButton = makeButton("Build Full Video");
   const fullFLFBuildButton = makeButton("Build Full FLF Video");
   const stopWorkflowButton = makeButton("Stop");
@@ -2760,8 +2912,98 @@ function openBuilder(node) {
   stopWorkflowButton.style.background = "#b91c1c";
   stopWorkflowButton.style.borderColor = "#7f1d1d";
   stopWorkflowButton.style.color = "#fee2e2";
+  autoBuildButton.style.background = "linear-gradient(180deg,#22d3ee,#0891b2)";
+  autoBuildButton.style.borderColor = "#67e8f9";
+  autoBuildButton.style.color = "#082f49";
+  styleCompactToolbarButton(saveButton, {
+    lines: ["Quick", "Save"],
+    icon: "save",
+    width: 54,
+    title: "Save the current project immediately.",
+  });
+  styleCompactToolbarButton(wizardButton, {
+    lines: ["Wizard"],
+    icon: "wizard",
+    width: 54,
+    title: "Open the guided Video Builder setup workflow.",
+  });
+  styleCompactToolbarButton(autoBuildButton, {
+    lines: ["Auto", "Build"],
+    icon: "auto",
+    width: 56,
+    title: "Automatically build a complete music-video timeline from a song, lyrics, a singer image, and optional locations.",
+  });
+  styleCompactToolbarButton(storyboardBuilderButton, {
+    lines: ["Story", "Builder"],
+    icon: "story",
+    width: 58,
+    title: "Open Storyboard Builder to plan and edit scene prompts.",
+  });
+  styleCompactToolbarButton(fluxReferenceBuilderButton, {
+    lines: ["Ref", "Builder"],
+    icon: "reference",
+    width: 54,
+    title: "Open Reference Builder to manage characters and locations.",
+  });
+  styleCompactToolbarButton(lyricMapperButton, {
+    lines: ["Line", "Mapping"],
+    icon: "mapping",
+    width: 56,
+    title: "Transcribe lyrics or dialogue and map performers to scenes.",
+  });
+  styleCompactToolbarButton(gemmaRunnerButton, {
+    lines: ["LLM", "Runner"],
+    icon: "brain",
+    width: 54,
+    title: "Choose the language-model runner used for prompt writing.",
+  });
+  styleCompactToolbarButton(promptOptionsButton, {
+    lines: ["Prompt", "Options"],
+    icon: "prompt",
+    width: 58,
+    title: "Open prompt editing, reload, clear, and prompt-file tools.",
+  });
+  styleCompactToolbarButton(downloadModelsButton, {
+    lines: ["Models"],
+    icon: "download",
+    width: 54,
+    title: "Download or review the models used by the builder.",
+  });
+  styleCompactToolbarButton(clearMemoryButton, {
+    lines: ["Clear", "RAM"],
+    icon: "memory",
+    width: 52,
+    title: "Clear Builder, ComfyUI, and model memory caches.",
+  });
+  styleCompactToolbarButton(fullscreenButton, {
+    icon: "fullscreen",
+    iconOnly: true,
+    width: 40,
+    ariaLabel: "Enter fullscreen",
+    title: "Expand the Video Creator to fill the browser window without closing or resetting anything.",
+  });
+  styleCompactToolbarButton(closeButton, {
+    icon: "close",
+    iconOnly: true,
+    width: 40,
+    ariaLabel: "Close Video Builder",
+    title: "Close the Video Builder.",
+  });
+  closeButton.style.borderColor = "#991b1b";
+  closeButton.style.color = "#fecaca";
+  closeButton.style.background = "#3f1518";
+  stopWorkflowButton.style.width = "52px";
+  stopWorkflowButton.style.minWidth = "52px";
+  stopWorkflowButton.style.height = "42px";
+  stopWorkflowButton.style.padding = "6px";
+  stopWorkflowButton.style.fontFamily = "Inter,Segoe UI,Roboto,Arial,sans-serif";
+  stopWorkflowButton.style.fontWeight = "600";
+  stopWorkflowButton.style.letterSpacing = "0";
+  menuButton.style.fontFamily = "Inter,Segoe UI,Roboto,Arial,sans-serif";
+  menuButton.style.fontWeight = "500";
+  menuButton.style.letterSpacing = "0";
   const menuDropdown = document.createElement("div");
-  menuDropdown.style.cssText = "display:none;position:absolute;left:12px;top:52px;z-index:20;min-width:260px;max-height:min(760px,calc(100vh - 88px));overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;scrollbar-gutter:stable;box-sizing:border-box;border:1px solid #3f3f46;border-radius:8px;background:#18181b;box-shadow:0 18px 60px rgba(0,0,0,.55);padding:8px;gap:6px;flex-direction:column;";
+  menuDropdown.style.cssText = "display:none;position:absolute;left:10px;top:calc(100% + 1px);z-index:20;min-width:260px;max-height:min(760px,calc(100vh - 88px));overflow-y:auto;overflow-x:hidden;overscroll-behavior:contain;scrollbar-gutter:stable;box-sizing:border-box;border:1px solid #3f3f46;border-radius:8px;background:#18181b;box-shadow:0 18px 60px rgba(0,0,0,.55);padding:8px;gap:6px;flex-direction:column;";
   const styleMenuItem = (button) => {
     button.style.width = "100%";
     button.style.textAlign = "left";
@@ -2779,25 +3021,25 @@ function openBuilder(node) {
   updateV10Row.append(updateV10Button, updateV10HintButton);
   menuDropdown.append(updateV10Row);
   const projectActions = document.createElement("div");
-  projectActions.style.cssText = "display:flex;gap:8px;align-items:center;flex-wrap:nowrap;min-width:max-content;";
+  projectActions.style.cssText = "display:flex;gap:6px;align-items:center;flex-wrap:nowrap;min-width:max-content;";
   projectActions.append(menuButton, videoTypeField, saveButton);
   const batchActions = document.createElement("div");
   batchActions.style.cssText = "display:flex;gap:8px;align-items:center;flex-wrap:nowrap;border-left:1px solid #3f3f46;border-right:1px solid #3f3f46;padding:0 10px;flex:0 0 auto;";
   batchActions.style.display = "none";
   const importActions = document.createElement("div");
-  importActions.style.cssText = "display:flex;gap:8px;align-items:center;justify-content:center;flex-wrap:nowrap;min-width:0;overflow:visible;";
-  importActions.append(wizardButton, storyboardBuilderButton, fluxReferenceBuilderButton, lyricMapperButton, gemmaRunnerButton, promptOptionsButton);
+  importActions.style.cssText = "display:flex;gap:5px;align-items:center;justify-content:center;flex-wrap:nowrap;min-width:0;overflow:visible;";
+  importActions.append(wizardButton, autoBuildButton, storyboardBuilderButton, fluxReferenceBuilderButton, lyricMapperButton, gemmaRunnerButton, promptOptionsButton);
   const centerActions = document.createElement("div");
   centerActions.style.cssText = "display:flex;gap:8px;align-items:center;justify-content:center;min-width:0;overflow:visible;";
   centerActions.append(importActions, batchActions);
   const utilityActions = document.createElement("div");
-  utilityActions.style.cssText = "display:flex;gap:8px;align-items:center;justify-content:flex-end;flex-wrap:nowrap;min-width:max-content;";
+  utilityActions.style.cssText = "display:flex;gap:5px;align-items:center;justify-content:flex-end;flex-wrap:nowrap;min-width:max-content;";
   const projectVideoEngineBadge = document.createElement("div");
   projectVideoEngineBadge.textContent = "◈ LTX";
   projectVideoEngineBadge.title = "Project video engine: LTX";
   projectVideoEngineBadge.setAttribute("role", "status");
   projectVideoEngineBadge.setAttribute("aria-live", "polite");
-  projectVideoEngineBadge.style.cssText = "height:26px;box-sizing:border-box;display:inline-flex;align-items:center;padding:0 9px;border:1px solid #60a5fa;border-radius:999px;background:#172554;color:#bfdbfe;font-size:11px;font-weight:950;letter-spacing:.03em;white-space:nowrap;";
+  projectVideoEngineBadge.style.cssText = `height:26px;box-sizing:border-box;display:inline-flex;align-items:center;padding:0 9px;border:1px solid #60a5fa;border-radius:999px;background:#172554;color:#bfdbfe;font-family:${BUILDER_FONT_STACK};font-size:11px;font-weight:600;letter-spacing:0;white-space:nowrap;`;
   utilityActions.append(projectVideoEngineBadge, stopWorkflowButton, downloadModelsButton, clearMemoryButton, fullscreenButton, closeButton);
   topbar.append(projectActions, centerActions, utilityActions, menuDropdown);
 
@@ -2836,6 +3078,42 @@ function openBuilder(node) {
     return row;
   };
   const beatCalibrationToolRow = makeToolRow(calibrateFirstBeatButton, "Capture a first, middle, and last beat with the playhead, then correct both beat-grid offset and cumulative drift. Scene timing stays unchanged.");
+  const projectBatchPanel = document.createElement("div");
+  projectBatchPanel.style.cssText = "display:none;margin:0 0 10px;border:1px solid #0891b2;border-radius:7px;background:#082f49;padding:9px;gap:8px;flex-direction:column;";
+  const projectBatchTitle = document.createElement("div");
+  projectBatchTitle.textContent = "Project Batch";
+  projectBatchTitle.style.cssText = "font-size:13px;font-weight:900;color:#cffafe;";
+  const projectBatchHelp = document.createElement("div");
+  projectBatchHelp.textContent = "Queue saved projects and run Render All on each one in order. The next project opens only after the previous project finishes and saves.";
+  projectBatchHelp.style.cssText = "font-size:11px;line-height:1.45;color:#e0f2fe;";
+  const projectBatchActions = document.createElement("div");
+  projectBatchActions.style.cssText = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;";
+  const projectBatchAddCurrent = makeButton("Add Current", "primary");
+  const projectBatchAddRecent = makeButton("Add Project");
+  const projectBatchAddSession = makeButton("Add Session JSON");
+  const projectBatchAddCustom = makeButton("Paste Folder");
+  projectBatchActions.append(projectBatchAddCurrent, projectBatchAddRecent, projectBatchAddSession, projectBatchAddCustom);
+  const projectBatchOptions = document.createElement("div");
+  projectBatchOptions.style.cssText = "display:flex;flex-direction:column;gap:6px;border:1px solid #155e75;border-radius:6px;background:#0f172a;padding:7px;";
+  const projectBatchForceVideos = makeCheckbox("Redo scene videos", false);
+  const projectBatchContinueOnError = makeCheckbox("Continue if a project fails", true);
+  const projectBatchClearMemory = makeCheckbox("Clear memory between projects", true);
+  for (const option of [projectBatchForceVideos, projectBatchContinueOnError, projectBatchClearMemory]) {
+    option.wrapper.style.fontSize = "11px";
+    option.wrapper.style.fontWeight = "600";
+  }
+  projectBatchOptions.append(projectBatchForceVideos.wrapper, projectBatchContinueOnError.wrapper, projectBatchClearMemory.wrapper);
+  const projectBatchQueue = document.createElement("div");
+  projectBatchQueue.style.cssText = "display:flex;flex-direction:column;gap:6px;max-height:220px;overflow:auto;border:1px solid #155e75;border-radius:6px;background:#071422;padding:7px;";
+  const projectBatchFooter = document.createElement("div");
+  projectBatchFooter.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) auto;gap:6px;";
+  const projectBatchRun = makeButton("Run Batch", "primary");
+  const projectBatchStop = makeButton("Stop Batch");
+  projectBatchStop.disabled = true;
+  projectBatchFooter.append(projectBatchRun, projectBatchStop);
+  const projectBatchStatus = document.createElement("div");
+  projectBatchStatus.style.cssText = "font-size:11px;color:#bae6fd;white-space:pre-wrap;line-height:1.35;";
+  projectBatchPanel.append(projectBatchTitle, projectBatchHelp, projectBatchActions, projectBatchOptions, projectBatchQueue, projectBatchFooter, projectBatchStatus);
   const beatCalibrationWizard = document.createElement("div");
   beatCalibrationWizard.style.cssText = "display:none;margin:0 0 10px;border:1px solid #0891b2;border-radius:7px;background:#082f49;padding:9px;gap:8px;flex-direction:column;";
   const beatCalibrationTitle = document.createElement("div");
@@ -2892,6 +3170,8 @@ function openBuilder(node) {
     makeToolRow(autoLoadAllButton, "Import the latest Prompt Creator outputs into this project, including timing and prompt data."),
     makeToolRow(importSceneNotesButton, "Load a scene-notes JSON file and map its notes onto the current scenes."),
     makeToolRow(importImageFolderButton, "Choose a folder of numbered images and fill base timeline scenes in numeric order. Requires project audio and existing scenes."),
+    makeToolRow(projectBatchButton, "Run Render All across multiple saved projects one after another for overnight batches."),
+    projectBatchPanel,
     beatCalibrationToolRow,
     beatCalibrationWizard,
     makeToolRow(snapAllSceneStartsButton, "Snap Scene 3 onward to the nearest valid beat. The Scene 1-to-2 intro boundary stays fixed; connected previous scene ends move with later shared cuts."),
@@ -4524,6 +4804,7 @@ function openBuilder(node) {
   const createSceneVideoButtons = [createSceneVideoButton];
   const gemmaThenCreateVideoButtons = [];
   const miniMaxSceneVideoButton = makeButton("Create MiniMax H3 Scene Video", "primary");
+  applyCompactButtonLabel(miniMaxSceneVideoButton, "Create MiniMax H3\nScene Video", { noMap: true, padding: "8px 8px", title: "Create MiniMax H3 Scene Video" });
   miniMaxSceneVideoButton.title = "Render this scene with the MiniMax H3 hidden workflow and preserve the exact timeline duration.";
   const miniMaxSceneVideoButtons = [miniMaxSceneVideoButton];
   const miniMaxReferencesButton = makeButton("Choose MiniMax References (0/9)");
@@ -4585,7 +4866,8 @@ function openBuilder(node) {
   function setButtonGroupState(buttons, { disabled = false, text = "" } = {}) {
     for (const button of buttons) {
       button.disabled = disabled;
-      if (text) button.textContent = text;
+      if (text === "Create MiniMax H3 Scene Video") applyCompactButtonLabel(button, "Create MiniMax H3\nScene Video", { noMap: true, padding: "8px 8px", title: text });
+      else if (text) button.textContent = text;
     }
   }
   const inspectorActions = document.createElement("div");
@@ -5085,7 +5367,8 @@ function openBuilder(node) {
   const miniMaxModeChooser = document.createElement("div");
   miniMaxModeChooser.style.cssText = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px;";
   const miniMaxModeButtons = MINIMAX_H3_MODE_OPTIONS.map((item) => {
-    const button = makeButton(item.label);
+    const button = makeButton(item.buttonLabel || item.label);
+    applyCompactButtonLabel(button, item.buttonLabel || item.label, { noMap: true, minWidth: 0, padding: "7px 6px", title: item.label });
     button.dataset.minimaxH3Mode = item.value;
     miniMaxModeChooser.append(button);
     return button;
@@ -5659,6 +5942,11 @@ function openBuilder(node) {
   audio.preload = "metadata";
   const sceneAudio = document.createElement("audio");
   sceneAudio.preload = "metadata";
+  let singerCueStopAt = null;
+  let singerCueStopTimer = 0;
+  let singerCueStopRaf = 0;
+  let activeSingerCuePlayButton = null;
+  let activeSingerCuePlayLabel = "";
   let silentTimelinePlaying = false;
   let silentTimelineRaf = 0;
   let silentTimelineStartedAt = 0;
@@ -5681,10 +5969,15 @@ function openBuilder(node) {
     overlay.style.alignItems = builderFullscreen ? "stretch" : "center";
     overlay.style.justifyContent = builderFullscreen ? "stretch" : "center";
     overlay.style.background = builderFullscreen ? "#09090b" : "rgba(0,0,0,.72)";
-    fullscreenButton.textContent = builderFullscreen ? "Exit Fullscreen" : "Fullscreen";
-    fullscreenButton.title = builderFullscreen
-      ? "Return the Video Creator to the normal floating panel size."
-      : "Expand the Video Creator to fill the browser window without closing or resetting anything.";
+    styleCompactToolbarButton(fullscreenButton, {
+      icon: builderFullscreen ? "restore" : "fullscreen",
+      iconOnly: true,
+      width: 40,
+      ariaLabel: builderFullscreen ? "Exit fullscreen" : "Enter fullscreen",
+      title: builderFullscreen
+        ? "Return the Video Creator to the normal floating panel size."
+        : "Expand the Video Creator to fill the browser window without closing or resetting anything.",
+    });
     applyLayoutSizes();
     render();
   }
@@ -6409,17 +6702,299 @@ function openBuilder(node) {
     return cues;
   }
 
+  function isMiniMaxSingerAssignmentMode(segment = activeSegment()) {
+    if (!segment) return false;
+    const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const videoType = normalizeVideoType(segment?.performance_mode || state.videoType);
+    return Boolean(miniMaxProject && videoType === "singing" && settings.audio_mode === "input_audio");
+  }
+
+  function syncLyricTextFromCueMap(segment) {
+    if (!segment || !Array.isArray(segment.lyric_cue_map) || !segment.lyric_cue_map.length) return;
+    const joined = segment.lyric_cue_map.map((cue) => flattenLyricForPrompt(cue?.text)).filter(Boolean).join(" ");
+    if (joined) segment.lyric_text = joined;
+  }
+
   function renderMiniMaxSpeakerAssignmentPanel() {
     const segment = activeSegment();
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const settings = miniMaxH3SettingsForSegment(segment);
     const shortFilm = normalizeVideoType(segment?.performance_mode || state.videoType) === "speaking";
-    const enabled = Boolean(miniMaxProject && segment && shortFilm && settings.audio_mode === "built_in_audio" && !segment.no_character_present);
+    const singerMode = isMiniMaxSingerAssignmentMode(segment);
+    const enabled = Boolean(miniMaxProject && segment && !segment.no_character_present && ((shortFilm && settings.audio_mode === "built_in_audio") || singerMode));
     const speakers = enabled ? miniMaxMappedSpeakersForSegment(segment) : [];
     miniMaxSpeakerAssignmentList.replaceChildren();
-    miniMaxAddSpeakerCueButton.disabled = !enabled || !speakers.length;
+    miniMaxAddSpeakerCueButton.disabled = !enabled || !speakers.length || (singerMode && segment?.lyric_performance_mode !== "cue_map");
+    miniMaxAddSpeakerCueButton.textContent = singerMode ? "Add Lyric Cue" : "Add Dialogue Cue";
+    miniMaxAddSpeakerCueButton.style.display = singerMode ? "none" : "";
     if (!miniMaxProject || !segment) {
-      miniMaxSpeakerAssignmentNote.textContent = "Choose an active MiniMax scene to assign speakers.";
+      miniMaxSpeakerAssignmentNote.textContent = "Choose an active MiniMax scene to assign vocal performers.";
+      return;
+    }
+    if (singerMode) {
+      if (segment.no_character_present) {
+        miniMaxSpeakerAssignmentNote.textContent = "This scene is marked No character present, so it cannot contain assigned singing.";
+        return;
+      }
+      miniMaxSpeakerAssignmentNote.textContent = "Singer Assignment uses the same performers mapped in Reference Builder. Choose Together when all selected singers perform the full line, or Split cue map when different singers take turns on lyric chunks.";
+      if (!speakers.length) {
+        const empty = document.createElement("div");
+        empty.textContent = "No singers are mapped to this scene yet. Map performer subjects in Reference Builder first.";
+        empty.style.cssText = "border:1px dashed #334155;border-radius:7px;padding:12px;color:#94a3b8;text-align:center;font-size:12px;";
+        miniMaxSpeakerAssignmentList.append(empty);
+        return;
+      }
+      let selectedPerformers = selectedPerformerSubjectsForSegment(segment);
+      const selectedIds = new Set(selectedPerformers.map((subject) => String(subject.id)));
+      if (!selectedIds.size && speakers[0]?.id) {
+        segment.lyric_singers = [speakers[0].name];
+        selectedIds.add(String(speakers[0].id));
+        selectedPerformers = speakers.slice(0, 1);
+      } else if (selectedPerformers.length) {
+        segment.lyric_singers = selectedPerformers.map((subject) => subject.name || "Character");
+      }
+      const audioTools = document.createElement("div");
+      audioTools.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:8px;";
+      const playSceneCueAudio = makeButton("Play Scene Audio", "primary");
+      const jumpSceneCueAudio = makeButton("Jump To Scene Start");
+      applyCompactButtonLabel(playSceneCueAudio, "Play\nScene Audio", { noMap: true, padding: "7px 6px", title: "Play this scene's audio range." });
+      applyCompactButtonLabel(jumpSceneCueAudio, "Jump To\nScene Start", { noMap: true, padding: "7px 6px", title: "Move the playhead to this scene start." });
+      playSceneCueAudio.onclick = () => {
+        const start = timelineAudioStartForSegment(segment);
+        if (!playSceneAudioFrom(start)) {
+          activateGlobalTimelineAudioPlayback(Math.max(0, Number(segment.start || 0)));
+          audio.play().then(updatePlayPauseButton).catch(() => startSilentTimelinePlayback(Math.max(0, Number(segment.start || 0))));
+        }
+      };
+      jumpSceneCueAudio.onclick = () => {
+        const start = Math.max(0, Number(segment.start || 0));
+        activateGlobalTimelineAudioPlayback(start);
+        toast(`Playhead moved to ${formatTime(start)}. Play the scene, then use Set Start / Set End on cue rows.`);
+      };
+      audioTools.append(playSceneCueAudio, jumpSceneCueAudio);
+      miniMaxSpeakerAssignmentList.append(audioTools);
+
+      const modeWrap = document.createElement("div");
+      modeWrap.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.2fr);gap:8px;align-items:end;border:1px solid #155e75;border-radius:7px;background:#07111f;padding:9px;";
+      const performerSelect = document.createElement("select");
+      performerSelect.multiple = true;
+      performerSelect.size = Math.min(5, Math.max(2, speakers.length));
+      performerSelect.style.cssText = "min-height:74px;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:6px;font-size:12px;";
+      speakers.forEach((speaker) => {
+        const option = new Option(speaker.name, speaker.id);
+        option.selected = selectedIds.has(String(speaker.id));
+        performerSelect.append(option);
+      });
+      const performanceMode = makeSelect(["together", "cue_map"], segment.lyric_performance_mode || "together");
+      performanceMode.options[0].textContent = "Together / same full line";
+      performanceMode.options[1].textContent = "Split lyric cues";
+      performerSelect.onchange = () => {
+        const chosen = Array.from(performerSelect.selectedOptions || []).map((option) => speakers.find((speaker) => speaker.id === option.value)).filter(Boolean);
+        segment.lyric_singers = chosen.map((speaker) => speaker.name);
+        const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+        if (!refs.performer_scene_map || typeof refs.performer_scene_map !== "object") refs.performer_scene_map = {};
+        if (chosen.length) refs.performer_scene_map[segment.id] = chosen.map((speaker) => speaker.id);
+        else delete refs.performer_scene_map[segment.id];
+        state.fluxReferenceBuilder = refs;
+        if (chosen.length < 2) {
+          segment.lyric_performance_mode = "together";
+          segment.lyric_cue_map = [];
+        }
+        renderMiniMaxSpeakerAssignmentPanel();
+        autoSaveSessionQuiet("MiniMax singer performers changed").catch(() => null);
+      };
+      performanceMode.onchange = () => {
+        segment.lyric_performance_mode = performanceMode.value;
+        if (performanceMode.value === "cue_map" && !normalizeLyricCueMapForSegment(segment, undefined, { preserveBlank: true }).length) {
+          const performers = selectedPerformerSubjectsForSegment(segment);
+          segment.lyric_cue_map = lyricCueTextParts(segment.lyric_text).map((text, index) => {
+            const performer = performers[index % performers.length] || performers[0] || {};
+            return { text, singer_id: performer.id || "", singer_name: performer.name || "" };
+          });
+        }
+        renderMiniMaxSpeakerAssignmentPanel();
+        autoSaveSessionQuiet("MiniMax singer assignment mode changed").catch(() => null);
+      };
+      modeWrap.append(makeField("Singers / performers", performerSelect), makeField("Performance mode", performanceMode));
+      miniMaxSpeakerAssignmentList.append(modeWrap);
+      if (selectedPerformers.length >= 2 && segment.lyric_performance_mode === "cue_map" && !normalizeLyricCueMapForSegment(segment, undefined, { preserveBlank: true }).length) {
+        segment.lyric_cue_map = lyricCueTextParts(segment.lyric_text).map((text, index) => {
+          const performer = selectedPerformers[index % selectedPerformers.length] || selectedPerformers[0] || {};
+          return { text, singer_id: performer.id || "", singer_name: performer.name || "" };
+        });
+      }
+      if (selectedPerformers.length < 2 || segment.lyric_performance_mode !== "cue_map") {
+        const together = document.createElement("div");
+        const performerNames = Array.from(performerSelect.selectedOptions || []).map((option) => option.textContent).filter(Boolean);
+        together.textContent = performerNames.length > 1
+          ? `${performerNames.join(" and ")} will sing/speak the complete scene lyric together.`
+          : `${performerNames[0] || "The selected singer"} will sing/speak the complete scene lyric.`;
+        together.style.cssText = "border:1px solid #334155;border-radius:7px;background:#0f172a;padding:10px;color:#cbd5e1;font-size:12px;line-height:1.45;";
+        miniMaxSpeakerAssignmentList.append(together);
+        return;
+      }
+      const cues = normalizeLyricCueMapForSegment(segment, undefined, { preserveBlank: true });
+      segment.lyric_cue_map = cues;
+      const cueActions = document.createElement("div");
+      cueActions.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:8px;";
+      const addLyricCue = makeButton("Add Lyric Cue", "primary");
+      const addInstrumentalCue = makeButton("Add Instrumental Cue");
+      applyCompactButtonLabel(addLyricCue, "Add\nLyric Cue", { noMap: true, padding: "7px 6px" });
+      applyCompactButtonLabel(addInstrumentalCue, "Add\nInstrumental", { noMap: true, padding: "7px 6px", title: "Add Instrumental Cue" });
+      addLyricCue.onclick = () => {
+        const performer = selectedPerformers[cues.filter((cue) => cue.type !== "instrumental").length % selectedPerformers.length] || selectedPerformers[0] || speakers[0] || {};
+        cues.push({ type: "vocal", text: "", action_note: "", singer_id: performer.id || "", singer_name: performer.name || "", start: null, end: null });
+        segment.lyric_cue_map = cues;
+        renderMiniMaxSpeakerAssignmentPanel();
+      };
+      addInstrumentalCue.onclick = () => {
+        cues.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start: null, end: null });
+        segment.lyric_cue_map = cues;
+        renderMiniMaxSpeakerAssignmentPanel();
+      };
+      cueActions.append(addLyricCue, addInstrumentalCue);
+      miniMaxSpeakerAssignmentList.append(cueActions);
+      let draggedIndex = -1;
+      cues.forEach((cue, index) => {
+        const row = document.createElement("div");
+        row.style.cssText = "display:flex;flex-direction:column;gap:8px;border:1px solid #334155;border-radius:7px;background:#0f172a;padding:8px;";
+        row.addEventListener("dragover", (event) => {
+          if (draggedIndex < 0 || draggedIndex === index) return;
+          event.preventDefault();
+          row.style.borderColor = "#22d3ee";
+        });
+        row.addEventListener("dragleave", () => { row.style.borderColor = "#334155"; });
+        row.addEventListener("drop", (event) => {
+          event.preventDefault();
+          row.style.borderColor = "#334155";
+          if (draggedIndex < 0 || draggedIndex === index) return;
+          const [moved] = cues.splice(draggedIndex, 1);
+          cues.splice(index, 0, moved);
+          segment.lyric_cue_map = cues;
+          syncLyricTextFromCueMap(segment);
+          renderMiniMaxSpeakerAssignmentPanel();
+          autoSaveSessionQuiet("MiniMax singer cue reordered").catch(() => null);
+        });
+        const handle = document.createElement("button");
+        handle.type = "button";
+        handle.textContent = "::";
+        handle.title = "Drag to change lyric cue order";
+        handle.draggable = true;
+        handle.style.cssText = "height:38px;border:1px solid #334155;border-radius:6px;background:#07111f;color:#67e8f9;font-weight:900;cursor:grab;";
+        handle.addEventListener("dragstart", () => { draggedIndex = index; row.style.opacity = ".55"; });
+        handle.addEventListener("dragend", () => { draggedIndex = -1; row.style.opacity = ""; });
+        const number = document.createElement("div");
+        number.textContent = String(index + 1);
+        number.style.cssText = "font-size:14px;font-weight:900;color:#cffafe;text-align:center;";
+        const mainRow = document.createElement("div");
+        mainRow.style.cssText = "display:grid;grid-template-columns:32px 34px minmax(106px,.5fr) minmax(132px,.65fr) minmax(180px,1.4fr) 58px;gap:7px;align-items:center;";
+        const typeSelect = makeSelect(["vocal", "instrumental"], cue.type || "vocal");
+        typeSelect.options[0].textContent = "Lyric";
+        typeSelect.options[1].textContent = "Instrumental";
+        const singerSelect = makeSelect(speakers.map((speaker) => ({ value: speaker.id, label: speaker.name })), cue.singer_id);
+        const line = makeInput(cue.type === "instrumental" ? cue.action_note || "" : cue.text || "");
+        line.placeholder = cue.type === "instrumental" ? "Action note while nobody sings..." : "Exact lyric words for this singer...";
+        const remove = makeButton("Remove");
+        applyCompactButtonLabel(remove, "Remove", { minWidth: 0, padding: "7px 6px" });
+        typeSelect.addEventListener("change", () => {
+          cue.type = typeSelect.value === "instrumental" ? "instrumental" : "vocal";
+          if (cue.type === "instrumental") {
+            shiftCueLyricTextDown(cues, index, cue.text, selectedPerformers[index % selectedPerformers.length] || selectedPerformers[0] || speakers[0] || {});
+            cue.action_note = cue.action_note || "";
+            cue.text = "";
+            cue.singer_id = "";
+            cue.singer_name = "";
+          } else {
+            const singer = selectedPerformers[0] || speakers[0] || {};
+            cue.text = cue.text || cue.action_note || "";
+            cue.action_note = "";
+            cue.singer_id = cue.singer_id || singer.id || "";
+            cue.singer_name = cue.singer_name || singer.name || "";
+          }
+          segment.lyric_cue_map = cues;
+          renderMiniMaxSpeakerAssignmentPanel();
+        });
+        singerSelect.addEventListener("change", () => {
+          const singer = speakers.find((item) => item.id === singerSelect.value) || { id: singerSelect.value, name: singerSelect.selectedOptions[0]?.textContent || "" };
+          cue.singer_id = singer.id;
+          cue.singer_name = singer.name;
+          segment.lyric_cue_map = cues;
+          syncLyricTextFromCueMap(segment);
+          autoSaveSessionQuiet("MiniMax singer cue changed").catch(() => null);
+        });
+        line.addEventListener("input", () => {
+          if (cue.type === "instrumental") cue.action_note = line.value;
+          else cue.text = line.value;
+          segment.lyric_cue_map = cues;
+          syncLyricTextFromCueMap(segment);
+        });
+        line.addEventListener("change", () => autoSaveSessionQuiet("MiniMax lyric cue changed").catch(() => null));
+        remove.onclick = () => {
+          pushHistory();
+          cues.splice(index, 1);
+          segment.lyric_cue_map = cues;
+          syncLyricTextFromCueMap(segment);
+          renderMiniMaxSpeakerAssignmentPanel();
+          autoSaveSessionQuiet("MiniMax singer cue removed").catch(() => null);
+        };
+        singerSelect.disabled = cue.type === "instrumental";
+        mainRow.append(handle, number, typeSelect, singerSelect, line, remove);
+        const timingRow = document.createElement("div");
+        timingRow.style.cssText = "display:grid;grid-template-columns:minmax(44px,.45fr) minmax(44px,.45fr) 58px 64px 58px 58px 60px;gap:7px;align-items:center;padding-left:74px;";
+        const startLabel = document.createElement("div");
+        startLabel.textContent = `Start: ${formatCueTime(cue.start)}`;
+        startLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
+        const endLabel = document.createElement("div");
+        endLabel.textContent = `End: ${formatCueTime(cue.end)}`;
+        endLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
+        const playCue = makeButton("Play Cue", "primary");
+        const playFromCue = makeButton("Play From Here");
+        const setStart = makeButton("Set Start");
+        const setEnd = makeButton("Set End");
+        const clearTiming = makeButton("Clear Timing");
+        applyCompactButtonLabel(playCue, "Play\nCue", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Play only this cue's timed audio range." });
+        applyCompactButtonLabel(playFromCue, "From\nHere", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Play from this cue start." });
+        applyCompactButtonLabel(setStart, "Set\nStart", { noMap: true, minWidth: 0, padding: "6px 5px" });
+        applyCompactButtonLabel(setEnd, "Set\nEnd", { noMap: true, minWidth: 0, padding: "6px 5px" });
+        applyCompactButtonLabel(clearTiming, "Clear\nTime", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Clear Timing" });
+        const cueRange = singerCuePlaybackRangeForCue(segment, cues, index);
+        playCue.title = "Play from this cue start to its end, the next cue start, or the scene end.";
+        playFromCue.title = "Play from this cue start, or from the scene start if no cue start is set.";
+        playCue.onclick = () => {
+          playSingerCueRange(segment, cueRange.start, cueRange.end, playCue, "Play Cue");
+        };
+        playFromCue.onclick = () => {
+          playSingerCueRange(segment, cueRange.start, null, playFromCue, "Play From Here");
+        };
+        setStart.onclick = () => {
+          cue.start = singerCueRelativePlayheadTime(segment);
+          if (Number.isFinite(Number(cue.end)) && cue.end <= cue.start) cue.end = null;
+          segment.lyric_cue_map = cues;
+          renderMiniMaxSpeakerAssignmentPanel();
+        };
+        setEnd.onclick = () => {
+          cue.end = singerCueRelativePlayheadTime(segment);
+          if (Number.isFinite(Number(cue.start)) && cue.end <= cue.start) {
+            toast("Cue end must be after cue start.", true);
+            cue.end = null;
+          } else if (index + 1 < cues.length) {
+            cues[index + 1].start = cue.end;
+            if (Number.isFinite(Number(cues[index + 1].end)) && cues[index + 1].end <= cues[index + 1].start) cues[index + 1].end = null;
+          }
+          segment.lyric_cue_map = cues;
+          renderMiniMaxSpeakerAssignmentPanel();
+        };
+        clearTiming.onclick = () => {
+          cue.start = null;
+          cue.end = null;
+          segment.lyric_cue_map = cues;
+          renderMiniMaxSpeakerAssignmentPanel();
+        };
+        timingRow.append(startLabel, endLabel, playCue, playFromCue, setStart, setEnd, clearTiming);
+        row.append(mainRow, timingRow);
+        miniMaxSpeakerAssignmentList.append(row);
+      });
       return;
     }
     if (!shortFilm) {
@@ -6543,12 +7118,12 @@ function openBuilder(node) {
     miniMaxTurboLoraField.style.display = settings.use_turbo_lora ? "flex" : "none";
     miniMaxTurboLoraStrengthField.style.display = settings.use_turbo_lora ? "flex" : "none";
     miniMaxTurboNote.textContent = settings.use_turbo_lora
-      ? "Turbo is ON. The hidden API workflow uses MiniMax-H3 Turbo LoRA plus the dedicated Turbo sampler and simple scheduler. Steps defaults to 6 when Turbo is switched on and remains editable with a minimum of 4. EasyCache bypass is enabled automatically; the advanced control remains editable for experiments. Normal settings are restored when Turbo is turned off."
+      ? "Turbo is ON. The hidden API workflow uses MiniMax-H3 Turbo LoRA plus the dedicated Turbo sampler and simple scheduler. Steps defaults to 4 when Turbo is switched on and remains editable down to 1 for experiments. Values below 4 are outside the Turbo LoRA's usual 4-step target. EasyCache bypass is enabled automatically; the advanced control remains editable for experiments. Normal settings are restored when Turbo is turned off."
       : "Turbo is OFF. The normal MiniMax sampler, scheduler, and step settings are used.";
     miniMaxSamplerName.disabled = settings.use_turbo_lora;
     miniMaxScheduler.disabled = settings.use_turbo_lora;
     miniMaxSteps.disabled = false;
-    miniMaxSteps.min = settings.use_turbo_lora ? "4" : "1";
+    miniMaxSteps.min = "1";
     useSceneMiniMaxH3Settings.input.checked = Boolean(segment?.use_scene_minimax_h3_settings);
     useSceneMiniMaxH3Settings.input.disabled = !segment;
     const sceneMiniMaxSettingsLocked = Boolean(segment?.use_scene_minimax_h3_settings);
@@ -6581,6 +7156,8 @@ function openBuilder(node) {
     miniMaxPrompt.value = String(segment?.minimax_h3_prompt || segment?.i2v_prompt || "");
     miniMaxCreatePromptButton.textContent = `Create MiniMax ${modeLabel} Prompt`;
     miniMaxEditInstructionsButton.textContent = `Edit ${modeLabel} Instructions`;
+    const assignmentTabButton = miniMaxSubTabs.wrapper.querySelector('[data-value="speakers"]');
+    if (assignmentTabButton) applyCompactButtonLabel(assignmentTabButton, isMiniMaxSingerAssignmentMode(segment) ? "Singer Assignment" : "Speaker Assignment", { minWidth: 0, padding: "7px 6px" });
     miniMaxPromptRunnerNote.textContent = `Uses the existing ${gemmaRunnerLabel()} selection from LLM Runner. The result is saved only as this scene's MiniMax H3 prompt.`;
     miniMaxAudioNote.textContent = settings.audio_mode === "built_in_audio"
       ? "MiniMax generates the scene audio from the prompt. In Short Film mode, character voice presets are configured in Reference Builder and copied exactly into every matching scene prompt."
@@ -9712,6 +10289,20 @@ function openBuilder(node) {
     segment.flf_end_frame_stale = Boolean(segment.flf_end_frame_stale);
     segment.flf_final_prompt_ready = Boolean(segment.flf_final_prompt_ready);
     if (!Array.isArray(segment.lyric_singers)) segment.lyric_singers = [];
+    segment.lyric_performance_mode = ["together", "cue_map"].includes(String(segment.lyric_performance_mode || "").trim())
+      ? String(segment.lyric_performance_mode || "").trim()
+      : "together";
+    segment.lyric_cue_map = Array.isArray(segment.lyric_cue_map)
+      ? segment.lyric_cue_map.map((cue) => ({
+        type: ["instrumental", "vocal"].includes(String(cue?.type || "").trim()) ? String(cue.type).trim() : "vocal",
+        text: String(cue?.text || "").trim(),
+        action_note: String(cue?.action_note || cue?.actionNote || cue?.note || "").trim(),
+        singer_id: String(cue?.singer_id || cue?.singerId || cue?.subject_id || cue?.subjectId || "").trim(),
+        singer_name: String(cue?.singer_name || cue?.singerName || cue?.name || "").trim(),
+        start: Number.isFinite(Number(cue?.start)) ? Math.max(0, Number(cue.start)) : null,
+        end: Number.isFinite(Number(cue?.end)) ? Math.max(0, Number(cue.end)) : null,
+      })).filter((cue) => cue.type === "instrumental" || cue.text || cue.action_note)
+      : [];
     segment.minimax_speaker_assignments = normalizeMiniMaxSpeakerAssignments(
       segment.minimax_speaker_assignments || segment.speaker_assignments || segment.dialogue_cues || [],
     );
@@ -9894,7 +10485,7 @@ function openBuilder(node) {
     if (repairedIds.length) {
       state.repairedSegmentIdCount = Number(state.repairedSegmentIdCount || 0) + repairedIds.length;
       const refs = state.fluxReferenceBuilder;
-      const mapKeys = ["subject_scene_map", "scene_map", "scene_trigger_map", "ingredients_scene_map"];
+      const mapKeys = ["subject_scene_map", "performer_scene_map", "scene_map", "scene_trigger_map", "ingredients_scene_map"];
       if (refs && typeof refs === "object") {
         for (const { originalId, replacementId } of repairedIds) {
           if (!originalId) continue;
@@ -11978,6 +12569,7 @@ function openBuilder(node) {
       subject: { description: "", reference_type: "character", minimax_voice: normalizeMiniMaxH3Voice(), image: { path: "", data: "", name: "" } },
       subjects: [],
       subject_scene_map: {},
+      performer_scene_map: {},
       locations: [],
       scene_map: {},
       scene_trigger_map: {},
@@ -12590,6 +13182,13 @@ function openBuilder(node) {
     if (source.subject_scene_map && typeof source.subject_scene_map === "object") {
       for (const [sceneId, value] of Object.entries(source.subject_scene_map)) {
         normalized.subject_scene_map[sceneId] = Array.isArray(value) ? value.map(String).filter(Boolean) : String(value || "").split(",").map((item) => item.trim()).filter(Boolean);
+      }
+    }
+    normalized.performer_scene_map = {};
+    const rawPerformerSceneMap = source.performer_scene_map || source.performerSceneMap || source.lyric_performer_scene_map || source.lyricPerformerSceneMap;
+    if (rawPerformerSceneMap && typeof rawPerformerSceneMap === "object") {
+      for (const [sceneId, value] of Object.entries(rawPerformerSceneMap)) {
+        normalized.performer_scene_map[sceneId] = Array.isArray(value) ? value.map(String).filter(Boolean) : String(value || "").split(",").map((item) => item.trim()).filter(Boolean);
       }
     }
     normalized.locations = (normalized.cleared || normalized.locations_cleared) ? [] : dedupeRefsByName(Array.isArray(source.locations) ? source.locations : [])
@@ -13680,6 +14279,8 @@ function openBuilder(node) {
     startInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
     lyricTextInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
     lyricTextInput.dataset.vrgdgUserEdited = "0";
+    lyricSingersInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
+    lyricSingersInput.dataset.vrgdgUserEdited = "0";
     const disabled = !segment;
     for (const control of [labelInput, startInput, endInput, notesInput, ernieNotesInput, krea2TwoPassNotesInput, nbNotes, lyricTextInput, lyricSingersInput, i2vNotesInput, t2iPrompt, ernieT2IPrompt, krea2TwoPassT2IPrompt, nbPrompt, i2vPrompt, zEnhanceGemmaNotes, zEnhancePromptPreview, previewButton, ernieCreateButton, previewNBButton, deleteSegmentButton, createSceneVideoButton, miniMaxSceneVideoButtons[0]]) {
       control.disabled = disabled;
@@ -14933,6 +15534,26 @@ function openBuilder(node) {
         : "ordered ingredients, props, identity, or visual-detail reference";
     }
     return "visual reference";
+  }
+
+  function miniMaxH3MissingReferenceDescriptions(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    const missing = [];
+    if (normalizeMiniMaxH3Mode(mode) !== "reference_to_video" && normalizeMiniMaxH3Mode(mode) !== "video_to_video") return missing;
+    const items = miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
+      .filter((item) => item?.kind === "subject" || item?.kind === "location");
+    items.forEach((item, index) => {
+      const label = String(item?.label || `${item?.kind === "location" ? "Location" : "Character"} ${index + 1}`).trim();
+      if (!String(item?.description || "").trim()) missing.push(`${label} (${item?.kind === "location" ? "location" : "character"})`);
+    });
+    return missing;
+  }
+
+  function assertMiniMaxH3ReferenceDescriptionsReady(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    const missing = miniMaxH3MissingReferenceDescriptions(segment, mode);
+    if (!missing.length) return;
+    throw new Error(
+      `MiniMax prompt creation needs Reference Builder descriptions before it can assemble the fixed Image blocks.\n\nMissing description for:\n- ${missing.join("\n- ")}\n\nOpen Reference Builder and click Gemma Describe, or type the description manually, then create the prompt again.`,
+    );
   }
 
   function openMiniMaxReferenceSelector() {
@@ -16830,7 +17451,17 @@ function openBuilder(node) {
       segment.lyric_text = lyricTextInput.value || "";
       segment.lyric_no_lip_sync = isInstrumentalLyricText(segment.lyric_text);
     }
-    segment.lyric_singers = lyricSingersInput.value.split(",").map((item) => item.trim()).filter(Boolean);
+    const singerInspectorSegmentId = String(lyricSingersInput.dataset.vrgdgInspectorSegmentId || "");
+    if (
+      lyricSingersInput.dataset.vrgdgUserEdited === "1"
+      && singerInspectorSegmentId === String(segment.id || "")
+    ) {
+      segment.lyric_singers = lyricSingersInput.value.split(",").map((item) => item.trim()).filter(Boolean);
+      if (segment.lyric_singers.length < 2) {
+        segment.lyric_performance_mode = "together";
+        segment.lyric_cue_map = [];
+      }
+    }
     let editedT2IPrompt = t2iPrompt.value || "";
     if (state.imageModelMode === "ernie_image") editedT2IPrompt = ernieT2IPrompt.value || "";
     else if (state.imageModelMode === "krea2_2pass") editedT2IPrompt = krea2TwoPassT2IPrompt.value || "";
@@ -20768,6 +21399,297 @@ function openBuilder(node) {
     if (!locId) return null;
     const location = refs.locations.find((item) => String(item?.id || "").trim() === locId) || null;
     return location ? { ...location, id: locId } : null;
+  }
+
+  function selectedPerformerSubjectsForSegment(segment, refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder)) {
+    const normalizedRefs = normalizeFluxReferenceBuilder(refs);
+    const subjects = logicalReferenceSubjects(normalizedRefs);
+    const performerIds = sceneReferenceMapArray(normalizedRefs.performer_scene_map, segment);
+    if (performerIds.length) {
+      const validIds = new Set(performerIds.map(String));
+      return subjects.filter((subject) => validIds.has(String(subject?.id || "")));
+    }
+    const selected = new Set((Array.isArray(segment?.lyric_singers) ? segment.lyric_singers : String(segment?.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim().toLowerCase())
+      .filter(Boolean));
+    return subjects.filter((subject) => {
+      const id = String(subject?.id || "").trim();
+      const name = String(subject?.name || "").trim();
+      return selected.has(id.toLowerCase()) || selected.has(name.toLowerCase());
+    });
+  }
+
+  function syncPerformerInspectorForSegment(segment) {
+    if (!segment || String(activeSegment()?.id || "") !== String(segment.id || "")) return;
+    lyricSingersInput.value = Array.isArray(segment.lyric_singers) ? segment.lyric_singers.join(", ") : "";
+    lyricSingersInput.dataset.vrgdgInspectorSegmentId = String(segment.id || "");
+    lyricSingersInput.dataset.vrgdgUserEdited = "0";
+  }
+
+  function miniMaxH3SubjectLabelMapForSegment(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    const map = new Map();
+    let subjectNumber = 0;
+    miniMaxOrderedImageReferenceItemsForSegment(segment, mode).forEach((item) => {
+      if (item?.kind === "start_frame") return;
+      subjectNumber += 1;
+      const rawKey = String(item?.key || "").trim();
+      const subjectId = String(item?.id || item?.subject_id || item?.subjectId || rawKey.replace(/^subject:/, "") || "").trim();
+      const name = String(item?.label || item?.name || "").trim();
+      const value = {
+        label: `<Subject ${subjectNumber}>`,
+        alias: item?.kind === "subject" ? `(S${subjectNumber})` : "",
+        name,
+        kind: item?.kind || "reference",
+      };
+      if (subjectId) map.set(subjectId, value);
+      if (name) map.set(name.toLowerCase(), value);
+    });
+    return map;
+  }
+
+  function miniMaxH3PerformerLabel(subject, labelMap) {
+    const id = String(subject?.id || "").trim();
+    const name = String(subject?.name || "").trim();
+    const mapped = labelMap.get(id) || labelMap.get(name.toLowerCase());
+    if (mapped?.label) return `${mapped.label}${mapped.alias ? ` ${mapped.alias}` : ""}`;
+    return name || "the assigned performer";
+  }
+
+  function lyricCueTextParts(text) {
+    const clean = flattenLyricForPrompt(text);
+    if (!clean) return [];
+    const lines = String(text || "").split(/\r?\n+/).map((line) => flattenLyricForPrompt(line)).filter(Boolean);
+    if (lines.length > 1) return lines;
+    const words = clean.split(/\s+/).filter(Boolean);
+    if (words.length <= 2) return [clean];
+    const chunks = [];
+    for (let index = 0; index < words.length; index += 2) {
+      chunks.push(words.slice(index, index + 2).join(" "));
+    }
+    return chunks;
+  }
+
+  function normalizeLyricCueMapForSegment(segment, refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder), options = {}) {
+    const performers = selectedPerformerSubjectsForSegment(segment, refs);
+    if (performers.length < 2 || String(segment?.lyric_performance_mode || "together") !== "cue_map") return [];
+    const existing = Array.isArray(segment?.lyric_cue_map) ? segment.lyric_cue_map : [];
+    const parts = existing.length ? existing : lyricCueTextParts(segment?.lyric_text).map((text, index) => {
+      const performer = performers[index % performers.length] || performers[0] || {};
+      return { text, singer_id: performer.id || "", singer_name: performer.name || "" };
+    });
+    return parts.map((cue, index) => {
+      const type = String(cue?.type || "").trim() === "instrumental" ? "instrumental" : "vocal";
+      const performer = performers.find((subject) => String(subject.id) === String(cue?.singer_id || ""))
+        || performers.find((subject) => String(subject.name || "").toLowerCase() === String(cue?.singer_name || "").toLowerCase())
+        || performers[index % performers.length]
+        || null;
+      return {
+        type,
+        text: flattenLyricForPrompt(cue?.text),
+        action_note: String(cue?.action_note || cue?.actionNote || cue?.note || "").trim(),
+        singer_id: String(performer?.id || cue?.singer_id || "").trim(),
+        singer_name: String(performer?.name || cue?.singer_name || "").trim(),
+        start: Number.isFinite(Number(cue?.start)) ? Math.max(0, Number(cue.start)) : null,
+        end: Number.isFinite(Number(cue?.end)) ? Math.max(0, Number(cue.end)) : null,
+      };
+    }).filter((cue) => options.preserveBlank || cue.type === "instrumental" || cue.text);
+  }
+
+  function miniMaxH3VocalCueMapText(segment, mode = miniMaxH3ModeForSegment(segment), options = {}) {
+    const performers = selectedPerformerSubjectsForSegment(segment);
+    const lyricText = isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const cueMap = normalizeLyricCueMapForSegment(segment);
+    if (segmentUsesNoLipSyncPerformance(segment) || segment?.no_character_present || !performers.length) return "";
+    if (!lyricText && !cueMap.length) return "";
+    const labelMap = miniMaxH3SubjectLabelMapForSegment(segment, mode);
+    if (performers.length === 1 && lyricText) {
+      const performer = miniMaxH3PerformerLabel(performers[0], labelMap);
+      return `${performer} performs the exact full lyric/dialogue line from <Audio 1>: "${miniMaxH3PunctuatedCueText(lyricText)}"`;
+    }
+    if (String(segment?.lyric_performance_mode || "together") === "cue_map" && cueMap.length) {
+      const lines = cueMap.map((cue) => {
+        const timing = miniMaxH3CueTimingText(cue);
+        if (cue.type === "instrumental") {
+          const note = cue.action_note ? ` Action note: ${cue.action_note}` : "";
+          return `${timing}Instrumental / no vocal cue. No visible subject sings or lip-syncs; mouths stay closed or naturally relaxed.${note}`;
+        }
+        const subject = performers.find((item) => String(item.id) === String(cue.singer_id)) || { id: cue.singer_id, name: cue.singer_name };
+        return `${timing}${miniMaxH3PerformerLabel(subject, labelMap)} performs "${miniMaxH3PunctuatedCueText(cue.text)}" from <Audio 1>.`;
+      });
+      if (options.compact) return lines.join(" ");
+      return [
+        "Vocal cue map:",
+        ...lines,
+        "Only the assigned performer sings or speaks each cue. Other visible performers remain silent, mouth closed or naturally reacting, until assigned their own cue.",
+      ].join("\n");
+    }
+    const performerText = performers.map((subject) => miniMaxH3PerformerLabel(subject, labelMap)).join(" and ");
+    return `${performerText} perform the same complete lyric/dialogue line together from <Audio 1>: "${miniMaxH3PunctuatedCueText(lyricText)}"`;
+  }
+
+  function miniMaxH3CueTimingText(cue = {}) {
+    const start = Number(cue?.start);
+    const end = Number(cue?.end);
+    if (Number.isFinite(start) && Number.isFinite(end) && end > start) return `${start.toFixed(3)}s-${end.toFixed(3)}s: `;
+    if (Number.isFinite(start)) return `from ${start.toFixed(3)}s: `;
+    return "";
+  }
+
+  function miniMaxH3CutPlanForSegment(segment) {
+    const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
+    const fallback = storyboardCutPlanForDuration(duration, state.builderStoryboardDefaults?.minimax_h3_cut_frequency);
+    if (!isMiniMaxSingerAssignmentMode(segment) || String(segment?.lyric_performance_mode || "together") !== "cue_map") return fallback;
+    const cues = normalizeLyricCueMapForSegment(segment);
+    if (cues.length < 2) return fallback;
+    const cuts = [];
+    cues.forEach((cue, index) => {
+      const start = Number(cue?.start);
+      if (index > 0 && Number.isFinite(start) && start > 0.04 && start < duration - 0.04 && !cuts.some((time) => Math.abs(time - start) < 0.04)) {
+        cuts.push(Number(start.toFixed(3)));
+      }
+    });
+    if (!cuts.length) return fallback;
+    cuts.sort((a, b) => a - b);
+    return {
+      ...fallback,
+      frequency: state.builderStoryboardDefaults?.minimax_h3_cut_frequency ?? fallback.frequency,
+      cut_times_seconds: cuts,
+      cue_driven: true,
+      cue_count: cues.length,
+      instruction: miniMaxH3OfficialCutPlanInstruction({ ...fallback, cut_times_seconds: cuts, cue_driven: true, cue_count: cues.length }),
+    };
+  }
+
+  function miniMaxH3CueShotContractText(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    if (!isMiniMaxSingerAssignmentMode(segment) || String(segment?.lyric_performance_mode || "together") !== "cue_map") return "";
+    const cues = normalizeLyricCueMapForSegment(segment);
+    if (!cues.length) return "";
+    const performers = selectedPerformerSubjectsForSegment(segment);
+    const labelMap = miniMaxH3SubjectLabelMapForSegment(segment, mode);
+    const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
+    const lines = cues.map((cue, index) => {
+      const range = singerCuePlaybackRangeForCue(segment, cues, index);
+      const start = Number.isFinite(Number(cue.start)) ? Number(cue.start) : range.start;
+      const end = Number.isFinite(Number(cue.end)) && Number(cue.end) > start ? Number(cue.end) : range.end;
+      const timing = Number.isFinite(end) && end > start
+        ? `${start.toFixed(3)}s-${Math.min(duration || end, end).toFixed(3)}s`
+        : `from ${start.toFixed(3)}s`;
+      if (cue.type === "instrumental") {
+        const note = String(cue.action_note || "").trim();
+        return `[Shot ${index + 1}] ${timing}: instrumental/no vocal. No visible subject sings or lip-syncs.${note ? ` Visual action note: ${note}` : ""}`;
+      }
+      const subject = performers.find((item) => String(item.id) === String(cue.singer_id)) || { id: cue.singer_id, name: cue.singer_name };
+      return `[Shot ${index + 1}] ${timing}: ${miniMaxH3PerformerLabel(subject, labelMap)} is the only performer singing/lip-syncing <d>[English] ${miniMaxH3PunctuatedCueText(cue.text)}</d> from <Audio 1>. Other visible performers remain silent, mouth closed or naturally reacting.`;
+    });
+    return [
+      "Timed singer/lyric shot contract — authoritative:",
+      ...lines,
+      "Each listed cue is its own shot. Do not swap singers, merge lyric cues, or make an unassigned visible performer sing during another subject's cue.",
+    ].join("\n");
+  }
+
+  function singerCueRelativePlayheadTime(segment) {
+    const global = Math.max(0, Number(currentGlobalTime() || 0));
+    const sceneStart = Math.max(0, Number(segment?.start || 0));
+    const duration = Math.max(0, Number(segment?.end || sceneStart) - sceneStart);
+    return Math.max(0, Math.min(duration || Number.MAX_SAFE_INTEGER, global - sceneStart));
+  }
+
+  function formatCueTime(value) {
+    return Number.isFinite(Number(value)) ? `${Number(value).toFixed(3)}s` : "--";
+  }
+
+  function singerCuePlaybackRangeForCue(segment, cues = [], index = 0) {
+    const cue = cues[index] || {};
+    const sceneDuration = Math.max(0.1, Number(timelineSegmentDuration(segment) || 0.1));
+    const hasStart = Number.isFinite(Number(cue.start));
+    const start = Math.max(0, Math.min(sceneDuration, hasStart ? Number(cue.start) : 0));
+    const explicitEnd = Number(cue.end);
+    if (Number.isFinite(explicitEnd) && explicitEnd > start) {
+      return { start, end: Math.min(sceneDuration, explicitEnd), hasStart };
+    }
+    const nextCue = cues.slice(index + 1).find((item) => Number.isFinite(Number(item?.start)) && Number(item.start) > start);
+    if (nextCue) return { start, end: Math.min(sceneDuration, Number(nextCue.start)), hasStart };
+    return { start, end: sceneDuration > start ? sceneDuration : null, hasStart };
+  }
+
+  function shiftCueLyricTextDown(cues = [], index = 0, text = "", defaultPerformer = {}) {
+    const carried = flattenLyricForPrompt(text);
+    if (!carried) return;
+    cues.splice(index + 1, 0, { type: "vocal", text: carried, action_note: "", singer_id: defaultPerformer?.id || "", singer_name: defaultPerformer?.name || "", start: null, end: null });
+  }
+
+  function clearSingerCuePlaybackStop() {
+    if (singerCueStopTimer) window.clearTimeout(singerCueStopTimer);
+    if (singerCueStopRaf) window.cancelAnimationFrame(singerCueStopRaf);
+    singerCueStopTimer = 0;
+    singerCueStopRaf = 0;
+    singerCueStopAt = null;
+  }
+
+  function resetSingerCuePlayButton() {
+    if (activeSingerCuePlayButton) activeSingerCuePlayButton.textContent = activeSingerCuePlayLabel || "Play";
+    activeSingerCuePlayButton = null;
+    activeSingerCuePlayLabel = "";
+  }
+
+  function stopSingerCuePlaybackAtBoundary() {
+    const end = singerCueStopAt;
+    clearSingerCuePlaybackStop();
+    audio.pause();
+    if (Number.isFinite(end)) {
+      try {
+        audio.currentTime = end;
+        state.sceneAudioGlobalTime = end;
+      } catch {
+        // Browser may reject seeks before metadata is settled.
+      }
+    }
+    resetSingerCuePlayButton();
+    updateAudioScrubbers();
+  }
+
+  function armSingerCuePlaybackStop(start, end) {
+    clearSingerCuePlaybackStop();
+    const safeStart = Math.max(0, Number(start) || 0);
+    const safeEnd = Math.max(safeStart + 0.1, Number(end) || safeStart + 0.1);
+    singerCueStopAt = safeEnd;
+    singerCueStopTimer = window.setTimeout(stopSingerCuePlaybackAtBoundary, Math.max(40, (safeEnd - safeStart) * 1000 + 30));
+    const tick = () => {
+      if (singerCueStopAt == null) return;
+      if (audio.currentTime >= singerCueStopAt - 0.012) {
+        stopSingerCuePlaybackAtBoundary();
+        return;
+      }
+      singerCueStopRaf = window.requestAnimationFrame(tick);
+    };
+    singerCueStopRaf = window.requestAnimationFrame(tick);
+  }
+
+  function playSingerCueRange(segment, startRelative = 0, endRelative = null, button = null, label = "Play") {
+    if (!segment) return;
+    const sceneStart = Math.max(0, Number(segment.start || 0));
+    const sceneDuration = Math.max(0.1, Number(segment.end || sceneStart + 0.1) - sceneStart);
+    const start = sceneStart + Math.max(0, Math.min(sceneDuration, Number(startRelative) || 0));
+    const hasEnd = Number.isFinite(Number(endRelative)) && Number(endRelative) > Number(startRelative);
+    const end = hasEnd ? sceneStart + Math.max(0, Math.min(sceneDuration, Number(endRelative))) : null;
+    if (button && activeSingerCuePlayButton === button && !audio.paused) {
+      clearSingerCuePlaybackStop();
+      audio.pause();
+      resetSingerCuePlayButton();
+      return;
+    }
+    pauseAllAudio();
+    clearSingerCuePlaybackStop();
+    activateGlobalTimelineAudioPlayback(start);
+    if (button) {
+      resetSingerCuePlayButton();
+      activeSingerCuePlayButton = button;
+      activeSingerCuePlayLabel = label || button.textContent || "Play";
+      button.textContent = "Pause";
+    }
+    if (end != null) armSingerCuePlaybackStop(start, end);
+    audio.play().then(updatePlayPauseButton).catch(() => startSilentTimelinePlayback(start));
   }
 
   function segmentsShareMappedLocation(firstSegment, secondSegment) {
@@ -27957,6 +28879,189 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         });
         return items;
       };
+      const openCueMapEditor = (segment, performerIds = []) => {
+        const performers = logicalSubjects.filter((subject) => performerIds.includes(String(subject.id)));
+        if (performers.length < 2) {
+          toast("Choose at least two performers before splitting lyric cues.", true);
+          return;
+        }
+        const parts = lyricCueTextParts(segment.lyric_text);
+        if (!parts.length) {
+          toast("This scene needs lyric/dialogue text before cue mapping.", true);
+          return;
+        }
+        const existing = normalizeLyricCueMapForSegment(segment, refs, { preserveBlank: true });
+        const rows = (existing.length ? existing : parts.map((text, index) => {
+          const performer = performers[index % performers.length] || performers[0];
+          return { type: "vocal", text, action_note: "", singer_id: performer.id, singer_name: performer.name || "", start: null, end: null };
+        })).map((cue, index) => {
+          const performer = performers.find((subject) => subject.id === cue.singer_id) || performers[index % performers.length] || performers[0];
+          return {
+            type: cue.type === "instrumental" ? "instrumental" : "vocal",
+            text: cue.text || parts[index] || "",
+            action_note: cue.action_note || "",
+            singer_id: cue.type === "instrumental" ? "" : performer?.id || "",
+            singer_name: cue.type === "instrumental" ? "" : performer?.name || "",
+            start: Number.isFinite(Number(cue.start)) ? Number(cue.start) : null,
+            end: Number.isFinite(Number(cue.end)) ? Number(cue.end) : null,
+          };
+        });
+        const cueBackdrop = document.createElement("div");
+        cueBackdrop.style.cssText = "position:fixed;inset:0;z-index:100030;background:rgba(0,0,0,.76);display:flex;align-items:center;justify-content:center;padding:20px;box-sizing:border-box;";
+        const cuePanel = document.createElement("div");
+        cuePanel.style.cssText = "width:min(760px,calc(100vw - 40px));max-height:calc(100vh - 40px);overflow:auto;border:1px solid #155e75;border-radius:9px;background:#0b1220;color:#f8fafc;box-shadow:0 24px 80px rgba(0,0,0,.72);padding:15px;display:flex;flex-direction:column;gap:12px;";
+        const cueTitle = document.createElement("div");
+        cueTitle.innerHTML = `<div style="font-size:16px;font-weight:900;color:#cffafe;">Split Line Between Performers</div><div style="font-size:12px;color:#cbd5e1;margin-top:4px;">Assign each lyric/dialogue cue to exactly one performer. Everyone else stays silent during that cue.</div>`;
+        const cueList = document.createElement("div");
+        cueList.style.cssText = "display:flex;flex-direction:column;gap:8px;";
+        const renderCueRows = () => {
+          cueList.replaceChildren();
+          rows.forEach((row, index) => {
+            const line = document.createElement("div");
+            line.style.cssText = "display:flex;flex-direction:column;gap:7px;border:1px solid #1e3a5f;border-radius:7px;background:#071422;padding:8px;";
+            const top = document.createElement("div");
+            top.style.cssText = "display:grid;grid-template-columns:minmax(104px,.35fr) minmax(132px,.55fr) minmax(0,1fr) 34px;gap:7px;align-items:center;";
+            const type = makeSelect(["vocal", "instrumental"], row.type || "vocal");
+            type.options[0].textContent = "Lyric";
+            type.options[1].textContent = "Instrumental";
+            const text = makeInput(row.type === "instrumental" ? row.action_note || "" : row.text || "");
+            text.placeholder = row.type === "instrumental" ? "action note while nobody sings..." : "lyric cue...";
+            text.oninput = () => { row.text = text.value; };
+            const performer = makeSelect(performers.map((subject) => subject.id), row.singer_id || performers[index % performers.length]?.id || "");
+            Array.from(performer.options).forEach((option) => {
+              const subject = performers.find((item) => item.id === option.value);
+              option.textContent = subject?.name || "Character";
+            });
+            performer.disabled = row.type === "instrumental";
+            type.onchange = () => {
+              row.type = type.value === "instrumental" ? "instrumental" : "vocal";
+              if (row.type === "instrumental") {
+                shiftCueLyricTextDown(rows, index, row.text, performers[index % performers.length] || performers[0] || {});
+                row.action_note = row.action_note || "";
+                row.text = "";
+                row.singer_id = "";
+                row.singer_name = "";
+              } else {
+                const nextPerformer = performers[index % performers.length] || performers[0] || {};
+                row.text = row.text || row.action_note || "";
+                row.action_note = "";
+                row.singer_id = row.singer_id || nextPerformer.id || "";
+                row.singer_name = row.singer_name || nextPerformer.name || "";
+              }
+              renderCueRows();
+            };
+            performer.onchange = () => {
+              row.singer_id = performer.value;
+              row.singer_name = performers.find((subject) => subject.id === performer.value)?.name || "";
+            };
+            const remove = makeButton("×");
+            remove.title = "Remove cue";
+            remove.style.cssText += "min-width:0;width:34px;padding:6px 0;font-size:18px;line-height:1;";
+            remove.onclick = () => {
+              rows.splice(index, 1);
+              renderCueRows();
+            };
+            text.oninput = () => {
+              if (row.type === "instrumental") row.action_note = text.value;
+              else row.text = text.value;
+            };
+            top.append(type, performer, text, remove);
+            const timing = document.createElement("div");
+            timing.style.cssText = "display:grid;grid-template-columns:minmax(44px,.45fr) minmax(44px,.45fr) 58px 64px 58px 58px 60px;gap:7px;align-items:center;";
+            const startLabel = document.createElement("div");
+            startLabel.textContent = `Start: ${formatCueTime(row.start)}`;
+            startLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
+            const endLabel = document.createElement("div");
+            endLabel.textContent = `End: ${formatCueTime(row.end)}`;
+            endLabel.style.cssText = "font-size:11px;color:#a5f3fc;";
+            const playCue = makeButton("Play Cue", "primary");
+            const playFromCue = makeButton("Play From Here");
+            const setStart = makeButton("Set Start");
+            const setEnd = makeButton("Set End");
+            const clearTime = makeButton("Clear Timing");
+            applyCompactButtonLabel(playCue, "Play\nCue", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Play only this cue's timed audio range." });
+            applyCompactButtonLabel(playFromCue, "From\nHere", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Play from this cue start." });
+            applyCompactButtonLabel(setStart, "Set\nStart", { noMap: true, minWidth: 0, padding: "6px 5px" });
+            applyCompactButtonLabel(setEnd, "Set\nEnd", { noMap: true, minWidth: 0, padding: "6px 5px" });
+            applyCompactButtonLabel(clearTime, "Clear\nTime", { noMap: true, minWidth: 0, padding: "6px 5px", title: "Clear Timing" });
+            const rowRange = singerCuePlaybackRangeForCue(segment, rows, index);
+            playCue.title = "Play from this cue start to its end, the next cue start, or the scene end.";
+            playFromCue.title = "Play from this cue start, or from the scene start if no cue start is set.";
+            playCue.onclick = () => {
+              playSingerCueRange(segment, rowRange.start, rowRange.end, playCue, "Play Cue");
+            };
+            playFromCue.onclick = () => {
+              playSingerCueRange(segment, rowRange.start, null, playFromCue, "Play From Here");
+            };
+            setStart.onclick = () => { row.start = singerCueRelativePlayheadTime(segment); if (Number.isFinite(Number(row.end)) && row.end <= row.start) row.end = null; renderCueRows(); };
+            setEnd.onclick = () => {
+              row.end = singerCueRelativePlayheadTime(segment);
+              if (Number.isFinite(Number(row.start)) && row.end <= row.start) {
+                toast("Cue end must be after cue start.", true);
+                row.end = null;
+              } else if (index + 1 < rows.length) {
+                rows[index + 1].start = row.end;
+                if (Number.isFinite(Number(rows[index + 1].end)) && rows[index + 1].end <= rows[index + 1].start) rows[index + 1].end = null;
+              }
+              renderCueRows();
+            };
+            clearTime.onclick = () => { row.start = null; row.end = null; renderCueRows(); };
+            timing.append(startLabel, endLabel, playCue, playFromCue, setStart, setEnd, clearTime);
+            line.append(top, timing);
+            cueList.append(line);
+          });
+        };
+        const cueActions = document.createElement("div");
+        cueActions.style.cssText = "display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:8px;";
+        const addCue = makeButton("Add Lyric Cue");
+        const addInstrumental = makeButton("Add Instrumental");
+        const cancelCue = makeButton("Cancel");
+        const saveCue = makeButton("Save Cue Map", "primary");
+        applyCompactButtonLabel(addCue, "Add\nLyric Cue", { noMap: true, padding: "7px 6px" });
+        applyCompactButtonLabel(addInstrumental, "Add\nInstrumental", { noMap: true, padding: "7px 6px" });
+        applyCompactButtonLabel(saveCue, "Save\nCue Map", { noMap: true, padding: "7px 6px" });
+        addCue.onclick = () => {
+          const performer = performers[rows.length % performers.length] || performers[0];
+          rows.push({ type: "vocal", text: "", action_note: "", singer_id: performer?.id || "", singer_name: performer?.name || "", start: null, end: null });
+          renderCueRows();
+        };
+        addInstrumental.onclick = () => {
+          rows.push({ type: "instrumental", text: "", action_note: "", singer_id: "", singer_name: "", start: null, end: null });
+          renderCueRows();
+        };
+        cancelCue.onclick = () => cueBackdrop.remove();
+        saveCue.onclick = () => {
+          const saved = rows.map((row, index) => {
+            const performer = performers.find((subject) => subject.id === row.singer_id) || performers[index % performers.length] || performers[0];
+            return {
+              type: row.type === "instrumental" ? "instrumental" : "vocal",
+              text: row.type === "instrumental" ? "" : flattenLyricForPrompt(row.text),
+              action_note: row.type === "instrumental" ? String(row.action_note || "").trim() : "",
+              singer_id: row.type === "instrumental" ? "" : performer?.id || "",
+              singer_name: row.type === "instrumental" ? "" : performer?.name || "",
+              start: Number.isFinite(Number(row.start)) ? Math.max(0, Number(row.start)) : null,
+              end: Number.isFinite(Number(row.end)) ? Math.max(0, Number(row.end)) : null,
+            };
+          }).filter((row) => row.type === "instrumental" || (row.text && row.singer_id));
+          if (!saved.length) {
+            toast("Add at least one lyric cue before saving.", true);
+            return;
+          }
+          segment.lyric_performance_mode = "cue_map";
+          segment.lyric_cue_map = saved;
+          syncPerformerInspectorForSegment(segment);
+          cueBackdrop.remove();
+          renderMapping();
+        };
+        cueActions.append(addCue, addInstrumental, cancelCue, saveCue);
+        cuePanel.append(cueTitle, cueList, cueActions);
+        cueBackdrop.append(cuePanel);
+        document.body.append(cueBackdrop);
+        cueBackdrop.addEventListener("pointerdown", (event) => {
+          if (event.target === cueBackdrop) cueBackdrop.remove();
+        });
+        renderCueRows();
+      };
       mappingNote.textContent = singleGlobalSubject
         ? `Each row shows its current lyric or dialogue line. Click the visual cards to choose who is present, who performs the line, and the scene location.`
         : showSubjects
@@ -28025,7 +29130,10 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         performerSelect.multiple = true;
         performerSelect.size = Math.min(4, Math.max(2, logicalSubjects.length || 2));
         performerSelect.style.display = "none";
-        const selectedPerformers = new Set((Array.isArray(segment.lyric_singers) ? segment.lyric_singers : []).map((value) => String(value || "").trim().toLowerCase()));
+        const savedPerformerIds = sceneReferenceMapArray(refs.performer_scene_map, segment);
+        const selectedPerformers = new Set(savedPerformerIds.length
+          ? savedPerformerIds.map((value) => String(value || "").trim().toLowerCase())
+          : (Array.isArray(segment.lyric_singers) ? segment.lyric_singers : []).map((value) => String(value || "").trim().toLowerCase()));
         logicalSubjects.forEach((subject) => {
           const label = String(subject.name || "Character").trim();
           const option = new Option(label, subject.id);
@@ -28035,9 +29143,14 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         performerSelect.onchange = () => {
           const selectedOptions = Array.from(performerSelect.selectedOptions || []);
           segment.lyric_singers = selectedOptions.map((option) => option.textContent || option.value).filter(Boolean);
+          if (!refs.performer_scene_map || typeof refs.performer_scene_map !== "object") refs.performer_scene_map = {};
+          const performerIds = selectedOptions.map((option) => option.value).filter(Boolean);
+          if (performerIds.length) refs.performer_scene_map[segment.id] = performerIds;
+          else delete refs.performer_scene_map[segment.id];
           const present = new Set(Array.isArray(refs.subject_scene_map?.[segment.id]) ? refs.subject_scene_map[segment.id] : []);
           selectedOptions.forEach((option) => present.add(option.value));
           if (present.size) refs.subject_scene_map[segment.id] = Array.from(present);
+          syncPerformerInspectorForSegment(segment);
           renderMapping();
         };
         const selectedPerformerIds = Array.from(performerSelect.selectedOptions || []).map((option) => option.value);
@@ -28049,13 +29162,53 @@ Chrome vault corridor: A sealed industrial passage...</pre>
           selectedIds: selectedPerformerIds, multiple: true,
           onApply: (ids) => {
             segment.lyric_singers = logicalSubjects.filter((subject) => ids.includes(String(subject.id))).map((subject) => subject.name || "Character");
+            if (!refs.performer_scene_map || typeof refs.performer_scene_map !== "object") refs.performer_scene_map = {};
+            if (ids.length) refs.performer_scene_map[segment.id] = ids.map(String);
+            else delete refs.performer_scene_map[segment.id];
             const present = new Set(Array.isArray(refs.subject_scene_map?.[segment.id]) ? refs.subject_scene_map[segment.id] : []);
             ids.forEach((id) => present.add(id));
             if (present.size) refs.subject_scene_map[segment.id] = Array.from(present);
+            syncPerformerInspectorForSegment(segment);
             renderMapping();
           },
         });
         performerPanel.append(performerTitle, performerSelect, performerPreview);
+        if (selectedPerformerIds.length >= 2) {
+          const modeRow = document.createElement("div");
+          modeRow.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) auto;gap:6px;align-items:center;";
+          const modeSelect = makeSelect(["together", "cue_map"], segment.lyric_performance_mode || "together");
+          modeSelect.options[0].textContent = "Together";
+          modeSelect.options[1].textContent = "Split cue map";
+          modeSelect.title = "Together means all selected performers sing/speak the same full line. Split cue map assigns lyric chunks to specific performers.";
+          const editCueMap = makeButton("Cues", "primary");
+          editCueMap.title = "Assign lyric chunks to performers for this scene.";
+          editCueMap.style.cssText += "min-width:58px;padding:7px 8px;";
+          modeSelect.onchange = () => {
+            segment.lyric_performance_mode = modeSelect.value;
+            if (modeSelect.value === "cue_map" && !normalizeLyricCueMapForSegment(segment, refs, { preserveBlank: true }).length) {
+              const performers = logicalSubjects.filter((subject) => selectedPerformerIds.includes(String(subject.id)));
+              segment.lyric_cue_map = lyricCueTextParts(segment.lyric_text).map((text, cueIndex) => {
+                const performer = performers[cueIndex % performers.length] || performers[0] || {};
+                return { text, singer_id: performer.id || "", singer_name: performer.name || "" };
+              });
+            }
+            syncPerformerInspectorForSegment(segment);
+            renderMapping();
+          };
+          editCueMap.onclick = () => openCueMapEditor(segment, selectedPerformerIds);
+          modeRow.append(modeSelect, editCueMap);
+          const summary = document.createElement("div");
+          summary.style.cssText = "font-size:10px;color:#a5f3fc;line-height:1.35;";
+          const cueCount = normalizeLyricCueMapForSegment(segment, refs, { preserveBlank: true }).length;
+          summary.textContent = segment.lyric_performance_mode === "cue_map"
+            ? `${cueCount || 0} mapped cue${cueCount === 1 ? "" : "s"}; only assigned performer sings each cue.`
+            : "All selected performers sing/speak the same full line together.";
+          performerPanel.append(modeRow, summary);
+        } else if (segment.lyric_performance_mode !== "together") {
+          segment.lyric_performance_mode = "together";
+          segment.lyric_cue_map = [];
+          syncPerformerInspectorForSegment(segment);
+        }
         const locationPanel = document.createElement("div");
         locationPanel.style.cssText = referenceImagesEnabled
           ? "display:grid;grid-template-columns:minmax(120px,.78fr) minmax(150px,1fr);gap:8px;align-items:stretch;min-width:0;"
@@ -28467,6 +29620,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       }
       const validSubjectIds = new Set(logicalReferenceSubjects(refs).map((subject) => String(subject.id || "").trim()).filter(Boolean));
       if (!refs.subject_scene_map || typeof refs.subject_scene_map !== "object") refs.subject_scene_map = {};
+      if (!refs.performer_scene_map || typeof refs.performer_scene_map !== "object") refs.performer_scene_map = {};
       for (const [sceneId, ids] of Object.entries(refs.subject_scene_map || {})) {
         const pruned = Array.from(new Set((Array.isArray(ids) ? ids : []).map(String).map((id) => {
           const subject = refs.subjects.find((item) => item.id === id);
@@ -28475,12 +29629,33 @@ Chrome vault corridor: A sealed industrial passage...</pre>
         if (pruned.length) refs.subject_scene_map[sceneId] = pruned;
         else delete refs.subject_scene_map[sceneId];
       }
+      for (const [sceneId, ids] of Object.entries(refs.performer_scene_map || {})) {
+        const pruned = Array.from(new Set((Array.isArray(ids) ? ids : []).map(String).map((id) => {
+          const subject = refs.subjects.find((item) => item.id === id);
+          return subject ? (subjectExtraTargetId(subject) || subject.id) : "";
+        }).filter((id) => validSubjectIds.has(id))));
+        if (pruned.length) refs.performer_scene_map[sceneId] = pruned;
+        else delete refs.performer_scene_map[sceneId];
+      }
       for (const select of mappingList.querySelectorAll("[data-subject-map-segment-id]")) {
         const segmentId = select.dataset.subjectMapSegmentId || "";
         if (!segmentId) continue;
         const subjectIds = Array.from(select.selectedOptions || []).map((option) => option.value).filter((id) => validSubjectIds.has(id));
         if (subjectIds.length) refs.subject_scene_map[segmentId] = subjectIds;
         else delete refs.subject_scene_map[segmentId];
+      }
+      for (const segment of allEditableSegments()) {
+        const performerIds = sceneReferenceMapArray(refs.performer_scene_map, segment).filter((id) => validSubjectIds.has(id));
+        if (performerIds.length) {
+          refs.performer_scene_map[segment.id] = performerIds;
+          const performerNames = logicalReferenceSubjects(refs)
+            .filter((subject) => performerIds.includes(String(subject.id)))
+            .map((subject) => subject.name || "Character")
+            .filter(Boolean);
+          if (performerNames.length) segment.lyric_singers = performerNames;
+        } else {
+          delete refs.performer_scene_map[segment.id];
+        }
       }
       const validLocationIds = new Set((refs.locations || []).map((location) => String(location.id || "").trim()).filter(Boolean));
       if (!validLocationIds.size) {
@@ -28510,6 +29685,8 @@ Chrome vault corridor: A sealed industrial passage...</pre>
       state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
       renderFluxIngredientList(activeSegment());
       renderNBIngredientList(activeSegment());
+      syncPerformerInspectorForSegment(activeSegment());
+      syncMiniMaxH3Panel();
       render();
       await autoSaveSessionQuiet(`${referenceBuilderTargetLabel} reference builder`);
       toast(`${referenceBuilderTargetLabel} reference builder saved.`);
@@ -32295,7 +33472,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast(String(error?.message || error), true);
     } finally {
       clearMemoryButton.disabled = false;
-      clearMemoryButton.textContent = "Clear Memory";
+      styleCompactToolbarButton(clearMemoryButton, {
+        lines: ["Clear", "RAM"],
+        icon: "memory",
+        width: 52,
+        title: "Clear Builder, ComfyUI, and model memory caches.",
+      });
     }
   }
 
@@ -33235,6 +34417,258 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     await loadSessionFromProject(folder);
   }
+
+  const projectBatchQueueItems = [];
+  let projectBatchRunning = false;
+  let projectBatchStopRequested = false;
+
+  function projectBatchName(folder) {
+    return String(folder || "").split(/[\\/]/).filter(Boolean).pop() || String(folder || "Project");
+  }
+
+  function renderProjectBatchQueue() {
+    projectBatchQueue.replaceChildren();
+    if (!projectBatchQueueItems.length) {
+      const empty = document.createElement("div");
+      empty.textContent = "No projects queued yet.";
+      empty.style.cssText = "border:1px dashed #155e75;border-radius:6px;padding:10px;color:#7dd3fc;font-size:11px;text-align:center;";
+      projectBatchQueue.append(empty);
+      projectBatchRun.disabled = true;
+      return;
+    }
+    projectBatchQueueItems.forEach((item, index) => {
+      const row = document.createElement("div");
+      row.style.cssText = "display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:7px;align-items:center;border:1px solid #155e75;border-radius:6px;background:#0b1220;padding:7px;";
+      const number = document.createElement("div");
+      number.textContent = String(index + 1);
+      number.style.cssText = "width:22px;height:22px;border-radius:999px;background:#083344;color:#a5f3fc;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:900;";
+      const info = document.createElement("div");
+      info.style.cssText = "min-width:0;";
+      const name = document.createElement("div");
+      name.textContent = item.name || projectBatchName(item.folder);
+      name.style.cssText = "font-size:12px;font-weight:900;color:#f8fafc;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      const path = document.createElement("div");
+      path.textContent = item.folder;
+      path.title = item.folder;
+      path.style.cssText = "font-size:10px;color:#67e8f9;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      info.append(name, path);
+      const remove = makeButton("Remove");
+      remove.style.padding = "5px 7px";
+      remove.disabled = projectBatchRunning;
+      remove.onclick = () => {
+        projectBatchQueueItems.splice(index, 1);
+        renderProjectBatchQueue();
+      };
+      row.append(number, info, remove);
+      projectBatchQueue.append(row);
+    });
+    projectBatchRun.disabled = projectBatchRunning || !projectBatchQueueItems.length;
+  }
+
+  function addProjectToBatch(folder) {
+    const clean = String(folder || "").trim();
+    if (!clean) return false;
+    if (projectBatchQueueItems.some((item) => item.folder.toLowerCase() === clean.toLowerCase())) {
+      toast("That project is already in the batch queue.", true);
+      return false;
+    }
+    projectBatchQueueItems.push({ folder: clean, name: projectBatchName(clean) });
+    projectBatchStatus.textContent = `${projectBatchQueueItems.length} project${projectBatchQueueItems.length === 1 ? "" : "s"} queued.`;
+    renderProjectBatchQueue();
+    return true;
+  }
+
+  function setProjectBatchRunning(running) {
+    projectBatchRunning = Boolean(running);
+    projectBatchRun.disabled = projectBatchRunning || !projectBatchQueueItems.length;
+    projectBatchStop.disabled = !projectBatchRunning;
+    for (const button of [projectBatchAddCurrent, projectBatchAddRecent, projectBatchAddSession, projectBatchAddCustom]) button.disabled = projectBatchRunning;
+    projectBatchForceVideos.input.disabled = projectBatchRunning;
+    projectBatchContinueOnError.input.disabled = projectBatchRunning;
+    projectBatchClearMemory.input.disabled = projectBatchRunning;
+    renderProjectBatchQueue();
+  }
+
+  function showProjectBatchResultsModal(results = []) {
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(820px,calc(100vw - 48px));max-height:calc(100vh - 48px);overflow:hidden;border:1px solid #155e75;border-radius:8px;background:#0f172a;color:#cffafe;box-shadow:0 22px 70px rgba(0,0,0,.6);display:flex;flex-direction:column;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-bottom:1px solid #155e75;background:#083344;";
+    const completed = results.filter((item) => item.status === "complete");
+    const failed = results.filter((item) => item.status !== "complete");
+    const title = document.createElement("div");
+    title.textContent = `Project Batch Complete: ${completed.length} completed, ${failed.length} failed`;
+    title.style.cssText = "font-size:14px;font-weight:900;";
+    const close = makeButton("Close");
+    close.style.padding = "6px 10px";
+    header.append(title, close);
+    const body = document.createElement("div");
+    body.style.cssText = "display:flex;flex-direction:column;gap:9px;padding:14px;overflow:auto;";
+    results.forEach((item, index) => {
+      const row = document.createElement("div");
+      row.style.cssText = `display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;align-items:center;border:1px solid ${item.status === "complete" ? "#155e75" : "#7f1d1d"};border-radius:7px;background:#020617;padding:10px;`;
+      const info = document.createElement("div");
+      info.style.cssText = "min-width:0;display:flex;flex-direction:column;gap:5px;";
+      const name = document.createElement("div");
+      name.textContent = `${index + 1}. ${item.name || projectBatchName(item.folder)} — ${item.status === "complete" ? "Complete" : "Failed"}`;
+      name.style.cssText = `font-size:12px;font-weight:900;color:${item.status === "complete" ? "#a5f3fc" : "#fecaca"};`;
+      const path = document.createElement("div");
+      path.textContent = item.status === "complete" ? (item.finalVideoPath || "Completed, but no final video path was reported.") : item.error;
+      path.title = path.textContent;
+      path.style.cssText = "font-size:11px;color:#e2e8f0;white-space:pre-wrap;overflow-wrap:anywhere;line-height:1.35;";
+      const folder = document.createElement("div");
+      folder.textContent = item.folder;
+      folder.style.cssText = "font-size:10px;color:#67e8f9;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      info.append(name, path, folder);
+      const open = makeButton(item.status === "complete" ? "Open Video" : "Open Project");
+      open.disabled = item.status === "complete" && !item.finalVideoPath;
+      open.onclick = async () => {
+        const target = item.status === "complete" ? item.finalVideoPath : item.folder;
+        if (!target) return;
+        open.disabled = true;
+        open.textContent = "Opening...";
+        try {
+          await postJson("/vrgdg/music_builder/open_local_file", { path: target }, 30000);
+        } catch (error) {
+          toast(String(error?.message || error), true);
+        } finally {
+          open.disabled = false;
+          open.textContent = item.status === "complete" ? "Open Video" : "Open Project";
+        }
+      };
+      row.append(info, open);
+      body.append(row);
+    });
+    if (!results.length) {
+      const empty = document.createElement("div");
+      empty.textContent = "No projects were run.";
+      empty.style.cssText = "font-size:12px;color:#a1a1aa;";
+      body.append(empty);
+    }
+    box.append(header, body);
+    backdrop.append(box);
+    document.body.append(backdrop);
+    const finish = () => backdrop.remove();
+    close.onclick = finish;
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) finish();
+    });
+  }
+
+  async function runProjectBatchQueue() {
+    if (projectBatchRunning) return;
+    if (!projectBatchQueueItems.length) {
+      toast("Add at least one saved project to the Project Batch queue.", true);
+      return;
+    }
+    projectBatchStopRequested = false;
+    setProjectBatchRunning(true);
+    const queue = projectBatchQueueItems.map((item) => ({ ...item }));
+    const results = [];
+    const progress = createProgressWindow("Project Batch");
+    const startedAt = Date.now();
+    try {
+      for (let index = 0; index < queue.length; index += 1) {
+        if (projectBatchStopRequested) break;
+        const item = queue[index];
+        const name = item.name || projectBatchName(item.folder);
+        const prefix = `Project ${index + 1}/${queue.length}: ${name}`;
+        projectBatchStatus.textContent = `${prefix}\nLoading project...`;
+        progress.set(`${prefix}\nLoading project...`, Math.round((index / queue.length) * 100));
+        let result = { ...item, status: "failed", finalVideoPath: "", error: "" };
+        try {
+          const loaded = await loadSessionFromProject(item.folder);
+          if (!loaded) throw new Error("Project could not be loaded.");
+          await saveSession({ quiet: true, throwOnError: true });
+          projectBatchStatus.textContent = `${prefix}\nRunning Render All...`;
+          progress.set(`${prefix}\nRunning Render All. The normal Render All progress window will show scene details.`, Math.round((index / queue.length) * 100));
+          state.batchCancelled = false;
+          const renderResult = await renderAllScenes({
+            sceneScope: "all",
+            forceVideos: Boolean(projectBatchForceVideos.input.checked),
+            suppressFinalModal: true,
+          });
+          if (projectBatchStopRequested || state.batchCancelled) throw new Error("Stopped by user.");
+          await saveSession({ quiet: true, throwOnError: true });
+          const finalVideoPath = String(renderResult?.final_video_path || state.finalVideoPath || "");
+          if (!finalVideoPath) throw new Error("Render All finished without reporting a final video path.");
+          result.status = "complete";
+          result.finalVideoPath = finalVideoPath;
+          result.error = "";
+          results.push(result);
+          projectBatchStatus.textContent = `${prefix}\nComplete.\n${result.finalVideoPath || ""}`;
+          if (projectBatchClearMemory.input.checked && index < queue.length - 1) {
+            progress.set(`${prefix}\nClearing memory before the next project...`, Math.round(((index + 0.9) / queue.length) * 100));
+            await runClearMemoryWorkflowQuiet(progress, `Project Batch ${name}`, Math.round(((index + 0.95) / queue.length) * 100));
+          }
+        } catch (error) {
+          result.error = String(error?.message || error);
+          results.push(result);
+          projectBatchStatus.textContent = `${prefix}\nFailed:\n${result.error}`;
+          if (!projectBatchContinueOnError.input.checked || projectBatchStopRequested || state.batchCancelled) break;
+        }
+      }
+      const completed = results.filter((item) => item.status === "complete").length;
+      const failed = results.filter((item) => item.status !== "complete").length;
+      const elapsed = renderLogDuration(Date.now() - startedAt);
+      progress.set(`Project Batch finished.\nCompleted: ${completed}\nFailed: ${failed}\nElapsed: ${elapsed}`, 100);
+      progress.close(4500);
+      projectBatchStatus.textContent = `Project Batch finished.\nCompleted: ${completed}\nFailed: ${failed}\nElapsed: ${elapsed}`;
+      showProjectBatchResultsModal(results);
+    } finally {
+      state.batchCancelled = false;
+      setProjectBatchRunning(false);
+    }
+  }
+
+  projectBatchButton.onclick = () => {
+    projectBatchPanel.style.display = projectBatchPanel.style.display === "none" ? "flex" : "none";
+  };
+  projectBatchAddCurrent.onclick = () => {
+    const folder = String(projectInput.value || state.projectFolder || "").trim();
+    if (!folder) {
+      toast("Create or load a project before adding the current project to Project Batch.", true);
+      return;
+    }
+    addProjectToBatch(folder);
+  };
+  projectBatchAddRecent.onclick = async () => {
+    try {
+      const data = await getJson(projectListUrl());
+      const choice = await showLoadProjectModal(Array.isArray(data.projects) ? data.projects : []);
+      if (choice?.project_folder) addProjectToBatch(choice.project_folder);
+    } catch (error) {
+      toast(String(error?.message || error), true);
+    }
+  };
+  projectBatchAddSession.onclick = async () => {
+    try {
+      const folder = await pickProjectSessionFile();
+      if (folder) addProjectToBatch(folder);
+    } catch (error) {
+      toast(String(error?.message || error), true);
+    }
+  };
+  projectBatchAddCustom.onclick = async () => {
+    const folder = await showTextInputModal({
+      title: "Add Project To Batch",
+      label: "Project folder path",
+      value: "",
+      placeholder: "Full project folder path...",
+      confirmLabel: "Add Project",
+    });
+    if (folder) addProjectToBatch(folder);
+  };
+  projectBatchRun.onclick = runProjectBatchQueue;
+  projectBatchStop.onclick = () => {
+    projectBatchStopRequested = true;
+    state.batchCancelled = true;
+    projectBatchStatus.textContent = "Stop requested. The current render will stop at the next safe checkpoint.";
+    toast("Project Batch stop requested.");
+  };
+  renderProjectBatchQueue();
 
   async function archiveGeneratedSceneImage(segment, imageInfo) {
     ensureSegmentRuntimeFields(segment);
@@ -35648,6 +37082,582 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return [safePrompt, subjectMultiplicityBlock, block, visualOnlyBlock].filter(Boolean).join("\n\n").trim();
   }
 
+  function miniMaxH3CreativePromptContextForSegment(segment, mode) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const nativeAudio = settings.audio_mode === "built_in_audio";
+    const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
+    const exactDuration = String(Number(duration.toFixed(3)));
+    const aspectRatio = String(settings.aspect_ratio || "16:9").match(/\d+\s*:\s*\d+/)?.[0]?.replace(/\s+/g, "") || "16:9";
+    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const dialogueAssignments = visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment);
+    const lyricText = dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.text).join(" ")
+      : isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const performanceMode = visualOnly
+      ? "no_lip_sync"
+      : normalizeVideoType(segment?.performance_mode || state.videoType);
+    const cameraMotionSpeed = Number(segment?.camera_motion_speed ?? state.builderStoryboardDefaults?.camera_motion_speed ?? 4);
+    const characterMotionSpeed = Number(segment?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed ?? 4);
+    const cameraMotionGuidance = String(segment?.camera_motion_speed_guidance || state.builderStoryboardDefaults?.camera_guidance || "").trim();
+    const characterMotionGuidance = String(segment?.character_motion_guidance || state.builderStoryboardDefaults?.character_guidance || "").trim();
+    const cutPlan = miniMaxH3CutPlanForSegment(segment);
+    const shotPlan = miniMaxH3OfficialShotPlan(cutPlan);
+    const compact = (value, limit = 900) => {
+      const text = String(value || "").replace(/\s+/g, " ").trim();
+      return text.length > limit ? `${text.slice(0, limit).trim()}...` : text;
+    };
+    const add = (parts, label, value, limit = 900) => {
+      const text = compact(value, limit);
+      if (text) parts.push(`${label}:\n${text}`);
+    };
+    const parts = [
+      "MiniMax H3 shot-description task.",
+      `Return exactly ${shotPlan.length} JSON shot description${shotPlan.length === 1 ? "" : "s"}: {"shots":[{"description":"..."}]}`,
+      "Write only creative shot text. Do not include [Shot N] labels, cut times, Audio, Continuity, fixed sections, markdown, or analysis.",
+      `Mode: ${miniMaxH3ModeLabel(mode)}`,
+      `Duration: ${exactDuration}s, ${aspectRatio}`,
+      `Audio mode: ${nativeAudio ? "Built-in MiniMax audio" : "Input Audio 1 preserved by Builder"}`,
+      `Shot count: ${shotPlan.length}`,
+    ];
+    const cutTimes = shotPlan.slice(1).map((shot) => shot.timecode);
+    if (cutTimes.length) {
+      parts.push(`Builder cut times for your planning only: ${cutTimes.join(", ")}. Do not write these times.`);
+    } else {
+      parts.push("Continuous shot: return one description only.");
+    }
+    parts.push(`Camera speed: ${Number.isFinite(cameraMotionSpeed) ? cameraMotionSpeed : 4}/10${cameraMotionGuidance ? ` - ${compact(cameraMotionGuidance, 240)}` : ""}.`);
+    parts.push(`Character speed: ${Number.isFinite(characterMotionSpeed) ? characterMotionSpeed : 4}/10${characterMotionGuidance ? ` - ${compact(characterMotionGuidance, 240)}` : ""}.`);
+    if (cameraMotionSpeed >= 7) {
+      parts.push("Camera rule: use energetic, visibly active camera movement; avoid slow/static/locked-off language.");
+    }
+    if (characterMotionSpeed >= 4) {
+      parts.push("Character rule: include clear body action, gesture, step, or set interaction; mouth movement alone is not enough.");
+    }
+    if (segment?.no_character_present) {
+      parts.push("Vocal performance: no visible character / no lip sync. Do not invent a visible singer or speaker.");
+    } else if (performanceMode === "no_lip_sync") {
+      parts.push("Vocal performance: visual-only / no lip sync. Use lyric only as hidden mood/story context.");
+    } else if (lyricText && performanceMode === "speaking") {
+      parts.push("Vocal performance: speaking with exact dialogue lip sync. Mention the visible speaking action naturally in the shot descriptions, but do not write separate audio sections.");
+      add(parts, "Exact dialogue order", miniMaxDialogueOrderText(segment) || `The assigned speaker says exactly: "${lyricText}"`);
+    } else if (lyricText) {
+      parts.push("Vocal performance: singing with exact lyric lip sync. Mention the visible singing action naturally in the shot descriptions, but do not write separate audio sections or repeat boilerplate in every cut.");
+      add(parts, "Exact lyric line", lyricText);
+    } else {
+      parts.push("Vocal performance: no exact lyric or dialogue is assigned to this scene.");
+    }
+    const cueShotContract = miniMaxH3CueShotContractText(segment, mode);
+    if (cueShotContract) add(parts, "Timed singer / shot contract", cueShotContract, 1800);
+    const vocalCueMap = miniMaxH3VocalCueMapText(segment, mode);
+    if (vocalCueMap) {
+      add(parts, "Performer / vocal cue map", vocalCueMap);
+      if (selectedPerformerSubjectsForSegment(segment).length >= 2) {
+        parts.push("Multi-performer rule: use exact subject labels such as <Subject 1> (S1), <Subject 2> (S2), and <Audio 1> in the shot descriptions. For each assigned cue, write that the assigned subject precisely lip-syncs to <Audio 1>, singing or speaking the cue inside <d>[English] cue.</d>. Do not make an unassigned performer sing or speak during another performer's cue; keep them silent, mouth closed, or naturally reacting.");
+        parts.push("Shot wording rule: do not begin descriptions with 'The camera cuts to' or 'The camera...'. Start with the resulting framing or subject action, e.g. 'A panning medium shot shows...' or '<Subject 2> (S2) steps forward...'.");
+      }
+    }
+    add(parts, "Scene idea", sceneVideoConceptPromptText(segment));
+    add(parts, "Scene notes", segment?.notes || segment?.director_note);
+    add(parts, "Motion/camera request", segment?.i2v_notes);
+    add(parts, "Story beat", segment?.story_beat);
+    add(parts, "Lyric section", segment?.lyric_section);
+    add(parts, "Subject", segment?.no_character_present ? "No main character is visible in this scene." : segmentMappedSubjectText(segment));
+    add(parts, "Location", segmentMappedLocationText(segment));
+    const referenceLabels = miniMaxH3ReferenceAssignmentLines(segment, mode)
+      .map((line) => String(line || "").split(":")[0].trim())
+      .filter(Boolean);
+    if (referenceLabels.length) {
+      parts.push(`Available renderer reference labels: ${referenceLabels.join(", ")}. Mention labels only when useful in the shot text; do not define them.`);
+    }
+    if (mode === "video_to_video") {
+      const videoAssignments = miniMaxH3VideoAssignmentLines(segment);
+      if (videoAssignments.length) parts.push(`Available video reference labels: ${videoAssignments.map((line) => String(line || "").split(":")[0].trim()).filter(Boolean).join(", ")}.`);
+    }
+    add(parts, "Manual audio direction for staging only", segment?.audio_direction);
+    add(parts, "Continuity notes for staging only", segment?.continuity);
+    return parts.join("\n\n");
+  }
+
+  function miniMaxH3Timecode(seconds = 0) {
+    const total = Math.max(0, Number(seconds) || 0);
+    const minutes = Math.floor(total / 60);
+    const secs = total - minutes * 60;
+    return `${String(minutes).padStart(2, "0")}:${secs.toFixed(3).padStart(6, "0")}`;
+  }
+
+  function miniMaxH3OfficialShotScheduleLines(cutPlan = {}) {
+    const cuts = Array.isArray(cutPlan.cut_times_seconds) ? cutPlan.cut_times_seconds : [];
+    const lines = ["[Shot 1] starts at 00:00.000 and has no timestamp after the label."];
+    cuts.forEach((time, index) => {
+      lines.push(`[Shot ${index + 2}] At ${miniMaxH3Timecode(time)}, begin a new continuity-preserving cut.`);
+    });
+    return lines;
+  }
+
+  function miniMaxH3OfficialShotPlan(cutPlan = {}) {
+    const cuts = Array.isArray(cutPlan.cut_times_seconds) ? cutPlan.cut_times_seconds : [];
+    return [
+      { number: 1, time: 0, timecode: "00:00.000" },
+      ...cuts.map((time, index) => ({
+        number: index + 2,
+        time: Number(time || 0),
+        timecode: miniMaxH3Timecode(time),
+      })),
+    ];
+  }
+
+  function miniMaxH3OfficialCutPlanInstruction(cutPlan = {}) {
+    const duration = Number(cutPlan.exact_duration_seconds || 0);
+    const exactDuration = Number.isFinite(duration) ? Number(duration.toFixed(3)) : 0;
+    const cuts = Array.isArray(cutPlan.cut_times_seconds) ? cutPlan.cut_times_seconds : [];
+    if (cutPlan.cue_driven) {
+      const timingText = cuts.map((time) => miniMaxH3Timecode(time)).join(", ");
+      return `EDITING / CUT PLAN — MANDATORY: The timed singer/lyric cue map controls this exact ${exactDuration}-second segment. Create exactly ${cuts.length + 1} shot${cuts.length ? "s" : ""}${cuts.length ? ` with hard cuts at ${timingText}` : ""}. Each shot corresponds to one cue row in order: instrumental rows mean no visible lip-sync, and lyric rows mean only the assigned subject sings that cue. The builder will write [Shot 1] and every later [Shot N] At MM:SS.mmm label. Return only the creative description for each shot. Do not omit, merge, add, reorder, or shift cue shots.`;
+    }
+    if (!cuts.length) {
+      return `EDITING / CUT PLAN — MANDATORY: Use one smooth, continuous, uninterrupted shot for the full ${exactDuration}-second segment. Output only [Shot 1]. Use no additional shot label, hard cut, angle reset, montage, dissolve, scene change, or transition. Camera and character movement may develop inside the same continuous take.`;
+    }
+    const timingText = cuts.map((time) => miniMaxH3Timecode(time)).join(", ");
+    return `EDITING / CUT PLAN — MANDATORY: Cut frequency ${cutPlan.frequency}/10 for this exact ${exactDuration}-second segment requires exactly ${cuts.length} hard cut${cuts.length === 1 ? "" : "s"} at ${timingText}, creating ${cuts.length + 1} coherent shots. The builder will write [Shot 1] and every later [Shot N] At MM:SS.mmm label. Return only the creative description for each shot. Each later description should stage a continuity-preserving camera/shot cut. Do not omit, merge, add, or shift a scheduled cut. Do not add extra shots, montage beats, dissolves, scene changes, or transitions outside this schedule.`;
+  }
+
+  function miniMaxH3ReferenceAssignmentLines(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    if (normalizedMode === "image_to_video") {
+      return ["<Picture 1>: exact start frame and authoritative opening composition, character identity, clothing, location, lighting, and visual-state anchor."];
+    }
+    if (normalizedMode !== "reference_to_video" && normalizedMode !== "video_to_video") return [];
+    return miniMaxOrderedImageReferenceItemsForSegment(segment, normalizedMode).map((item, index) => {
+      const detail = [item.label, item.description].map((value) => String(value || "").trim()).filter(Boolean).join(" — ");
+      return `<Picture ${index + 1}>: ${miniMaxReferencePurposeText(item, segment)}${detail ? `. ${detail}` : ""}`;
+    });
+  }
+
+  function miniMaxH3VideoAssignmentLines(segment) {
+    return (Array.isArray(segment?.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
+      .filter((item) => String(item?.path || "").trim())
+      .slice(0, 3)
+      .map((item, index) => {
+        const purpose = normalizeMiniMaxH3VideoPurpose(item.purpose);
+        const purposeLabel = MINIMAX_H3_VIDEO_REFERENCE_PURPOSES.find((option) => option.value === purpose)?.label || "Continuation / Extension";
+        const timing = Number(item.start_seconds || 0) > 0 || Number(item.duration || 0) > 0
+          ? ` Use from ${Math.max(0, Number(item.start_seconds || 0))}s${Number(item.duration || 0) > 0 ? ` for ${Math.max(0, Number(item.duration || 0))}s` : " onward"}.`
+          : "";
+        const audio = item.use_audio ? " Its embedded audio is also supplied as a paired reference." : " Do not use its embedded audio.";
+        return `<Video ${index + 1}>: ${purposeLabel}.${timing}${audio}`;
+      });
+  }
+
+  function miniMaxH3OpeningLine(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
+    const exactDuration = String(Number(duration.toFixed(3)));
+    const aspectRatio = String(settings.aspect_ratio || "16:9").match(/\d+\s*:\s*\d+/)?.[0]?.replace(/\s+/g, "") || "16:9";
+    const style = String(segment?.minimax_h3_video_style || state.builderStoryboardDefaults?.video_style || "").trim();
+    const styleText = style || "photorealistic";
+    return `Generate a ${exactDuration}-second ${aspectRatio} ${styleText} video.`;
+  }
+
+  function miniMaxH3AudioAssignmentBlock(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const nativeAudio = settings.audio_mode === "built_in_audio";
+    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const dialogueAssignments = visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment);
+    const dialogueOrder = visualOnly ? "" : miniMaxDialogueOrderText(segment);
+    const lyricText = dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.text).join(" ")
+      : isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const performanceMode = visualOnly
+      ? "no_lip_sync"
+      : normalizeVideoType(segment?.performance_mode || state.videoType);
+    const singerNames = (dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.speaker_name)
+      : Array.isArray(segment?.lyric_singers)
+        ? segment.lyric_singers
+        : String(segment?.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const performerLabel = singerNames.length
+      ? singerNames.join(singerNames.length === 2 ? " and " : ", ")
+      : "the visible performer";
+    if (segment?.no_character_present) {
+      return nativeAudio
+        ? "Native audio: generate only low environmental ambience and requested sound effects. Do not invent a singer, speaker, dialogue, lyrics, or voice."
+        : "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, rhythm, phrasing, tone, and duration. Do not invent a visible singer or speaker.";
+    }
+    if (performanceMode === "no_lip_sync") {
+      return nativeAudio
+        ? "Native audio: generate only ambience and requested sound effects. Do not generate speech, singing, lyrics, dialogue, or visible mouth synchronization."
+        : "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, rhythm, phrasing, tone, and duration, but do not show singing, speaking, or mouth synchronization.";
+    }
+    if (lyricText && performanceMode === "speaking") {
+      return nativeAudio
+        ? `Native audio: generate the exact dialogue only. ${dialogueOrder ? `Mandatory dialogue order:\n${dialogueOrder}` : `${performerLabel} says the exact line “${lyricText}”.`} Do not merge speakers, reorder cues, replace, alter, repeat, extend, improvise, omit, or add words. Use silence, breathing, facial reaction, physical action, and low ambience for all remaining time.`
+        : `Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, rhythm, phrasing, tone, and duration, and use it as the exact voice, timing, and lip-sync reference. ${performerLabel} says the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely to that spoken line in Audio 1. Do not replace, alter, extend, or add words.`;
+    }
+    if (lyricText) {
+      return `Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, rhythm, phrasing, tone, and duration, and use it as the exact vocal, timing, and lip-sync reference. ${performerLabel} is singing the exact line “${lyricText}”. Synchronize lips, mouth shapes, jaw movement, facial muscles, and breathing precisely only while that sung line is audible in Audio 1. Never stretch, restart, or repeat the full lyric across every timestamp. When the vocal ends, the mouth closes or relaxes naturally while physical action continues. Do not generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects.`;
+    }
+    return nativeAudio
+      ? "Native audio: generate only ambience and requested sound effects. Do not invent lyrics, dialogue, or voices."
+      : "Audio 1: use unchanged as the primary and only audio track. Preserve its exact music, vocals, timing, rhythm, phrasing, tone, and duration. Do not generate, add, replace, remix, or extend any music, ambience, dialogue, vocals, or sound effects.";
+  }
+
+  function miniMaxH3FinalAudioBlock(segment) {
+    const block = miniMaxH3AudioAssignmentBlock(segment);
+    if (!block) return "";
+    return block.replace(/^Audio 1:/, "Audio:").replace(/^Native audio:/, "Native audio:");
+  }
+
+  function miniMaxH3ContinuityBlock(segment) {
+    const parts = [];
+    const subjectText = segment?.no_character_present ? "" : segmentMappedSubjectText(segment);
+    const locationText = segmentMappedLocationText(segment);
+    const manualContinuity = String(segment?.continuity || "").trim();
+    const lyricSingers = Array.isArray(segment?.lyric_singers)
+      ? segment.lyric_singers.map((value) => String(value || "").trim()).filter(Boolean)
+      : String(segment?.lyric_singers || "").split(/[,;\n]+/).map((value) => String(value || "").trim()).filter(Boolean);
+    if (subjectText) parts.push(`Preserve the mapped character identity, wardrobe, hair, body proportions, accessories, and performance continuity exactly:\n${subjectText}`);
+    else if (lyricSingers.length && !segment?.no_character_present) parts.push(`Preserve the visible performer identity for ${lyricSingers.join(", ")} consistently throughout the clip.`);
+    if (locationText) parts.push(`Preserve the mapped location/environment, lighting, spatial orientation, materials, and atmosphere consistently:\n${locationText}`);
+    if (manualContinuity) parts.push(manualContinuity);
+    parts.push("Do not add, remove, duplicate, clone, or replace mapped subjects unless the creative shot action explicitly asks for it.");
+    return `Continuity: ${parts.join("\n")}`;
+  }
+
+  function stripMiniMaxH3FixedSectionsFromCreative(prompt) {
+    let text = String(prompt || "").trim();
+    text = text.replace(/^\s*Generate\s+(?:an?|the)\s+[\s\S]*?(?=\n\s*(?:Image\s+\d+\s*:|\[\s*\d|CUT TO:|Audio(?:\s+1)?\s*:|Native audio\s*:|Continuity\s*:)|$)/i, "").trim();
+    text = text.replace(/(?:^|\n)\s*(?:Ordered [^\n]*assignments?[^\n]*:\s*)?(?:Image\s+\d+(?:\s*\([^)]*\))?\s*:[^\n]*(?:\n|$))+/gi, "\n").trim();
+    text = text.replace(/(?:^|\n)\s*(?:Ordered video assignments?[^\n]*:\s*)?(?:Video\s+\d+\s*:[^\n]*(?:\n|$))+/gi, "\n").trim();
+    text = text.replace(/(?:^|\n)\s*Audio\s+1\s*:[\s\S]*?(?=\n\s*(?:\[\s*\d|CUT TO:|Audio\s*:|Continuity\s*:|MINIMAX|REFERENCE SUBJECT COUNT|VISUAL-ONLY|$))/gi, "\n").trim();
+    text = text.replace(/(?:^|\n)\s*Audio\s*:[\s\S]*?(?=\n\s*(?:Continuity\s*:|MINIMAX|REFERENCE SUBJECT COUNT|VISUAL-ONLY|$))/gi, "\n").trim();
+    text = text.replace(/(?:^|\n)\s*Native audio\s*:[\s\S]*?(?=\n\s*(?:\[\s*\d|CUT TO:|Audio\s*:|Continuity\s*:|MINIMAX|REFERENCE SUBJECT COUNT|VISUAL-ONLY|$))/gi, "\n").trim();
+    text = text.replace(/(?:^|\n)\s*Continuity\s*:[\s\S]*?(?=\n\s*(?:MINIMAX|REFERENCE SUBJECT COUNT|VISUAL-ONLY|$))/gi, "\n").trim();
+    text = stripMiniMaxH3ManagedPromptBlock(text, "MINIMAX NATIVE VOICE IDENTITY — MANDATORY AND VERBATIM");
+    text = stripMiniMaxH3ManagedPromptBlock(text, "REFERENCE SUBJECT COUNT — MANDATORY");
+    text = stripMiniMaxH3ManagedPromptBlock(text, "VISUAL-ONLY B-ROLL / NO-LIP-SYNC SAFETY — MANDATORY AND FINAL");
+    return text.replace(/\n{3,}/g, "\n\n").trim();
+  }
+
+  function miniMaxH3FallbackShotDescription(segment, shotIndex = 0, mode = miniMaxH3ModeForSegment(segment)) {
+    const cues = isMiniMaxSingerAssignmentMode(segment) && String(segment?.lyric_performance_mode || "together") === "cue_map"
+      ? normalizeLyricCueMapForSegment(segment)
+      : [];
+    const cue = cues[shotIndex] || null;
+    const labelMap = miniMaxH3SubjectLabelMapForSegment(segment, mode);
+    const performers = selectedPerformerSubjectsForSegment(segment);
+    const environment = "inside the mapped environment";
+    if (cue?.type === "instrumental") {
+      return normalizeMiniMaxH3ShotDescription(`An atmospheric cinematic shot shows the scene ${environment} during an instrumental no-vocal moment. Any visible performers remain silent with closed or naturally relaxed mouths while the camera creates visual movement through posture, wind, clothing motion, and the surrounding environment.`);
+    }
+    if (cue) {
+      const subject = performers.find((item) => String(item.id) === String(cue.singer_id)) || { id: cue.singer_id, name: cue.singer_name };
+      const performer = miniMaxH3PerformerLabel(subject, labelMap);
+      const lyric = miniMaxH3CapitalizeCueText(miniMaxH3PunctuatedCueText(cue.text));
+      return normalizeMiniMaxH3ShotDescription(`A clear medium close-up shows only ${performer} ${environment}, with the face and mouth unobstructed. ${performer} precisely lip-syncs to <Audio 1>, <d>[English] ${lyric}</d>, while no other visible performer sings or lip-syncs.`);
+    }
+    const subject = performers[0] ? miniMaxH3PerformerLabel(performers[0], labelMap) : "the mapped performer";
+    return normalizeMiniMaxH3ShotDescription(`A cinematic shot shows ${subject} ${environment}, preserving identity, wardrobe, lighting, and location continuity while the camera stages a clear music-video performance moment.`);
+  }
+
+  function parseMiniMaxH3ShotDescriptionPayload(rawPrompt, cutPlan = {}, segment = null, mode = miniMaxH3ModeForSegment(segment)) {
+    const text = String(rawPrompt || "").trim();
+    if (!text) throw new Error("The LLM returned an empty MiniMax shot-description payload.");
+    const extractLeadingJson = (value) => {
+      const source = String(value || "").trim();
+      const start = source.indexOf("{");
+      if (start < 0) return source;
+      let depth = 0;
+      let inString = false;
+      let escaped = false;
+      for (let index = start; index < source.length; index += 1) {
+        const ch = source[index];
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === "\"") inString = false;
+          continue;
+        }
+        if (ch === "\"") {
+          inString = true;
+          continue;
+        }
+        if (ch === "{") depth += 1;
+        else if (ch === "}") {
+          depth -= 1;
+          if (depth === 0) return source.slice(start, index + 1);
+        }
+      }
+      return source;
+    };
+    const jsonText = extractLeadingJson(text);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch (error) {
+      throw new Error(`The LLM did not return valid JSON shot descriptions. Raw output:\n${text}`);
+    }
+    const shotPlan = miniMaxH3OfficialShotPlan(cutPlan);
+    const rawShots = Array.isArray(parsed?.shots) ? parsed.shots : [];
+    if (rawShots.length !== shotPlan.length) {
+      throw new Error(`The LLM returned ${rawShots.length} shot description${rawShots.length === 1 ? "" : "s"}, but the builder expected ${shotPlan.length}.`);
+    }
+    return rawShots.map((item, index) => {
+      const description = typeof item === "string" ? item : String(item?.description || item?.text || item?.shot || "").trim();
+      if (!description) {
+        toast(`Gemma returned a blank description for shot ${index + 1}; Builder filled it from the singer cue map.`, true);
+        return miniMaxH3FallbackShotDescription(segment, index, mode);
+      }
+      if (/\[\s*Shot\s+\d+\s*\]/i.test(description) || /\bAt\s+\d{1,2}:\d{2}(?:\.\d{1,3})?\b/i.test(description)) {
+        throw new Error(`The LLM included shot labels or cut times inside shot ${index + 1}. Generate again so the builder can own labels/timing.`);
+      }
+      return normalizeMiniMaxH3ShotDescription(description);
+    });
+  }
+
+  function normalizeMiniMaxH3DialogueTags(text) {
+    return String(text || "")
+    .replace(/<\|[^<>]*\|>/g, "")
+    .replace(/<\s*tool_call\|?>+/gi, "")
+    .replace(/<d>\s*\[+\s*([A-Za-z][A-Za-z -]{1,30})\]\s*/gi, "<d>[$1] ")
+    .replace(/<d>\s*\[([^\]]+)\]\s*([^<]*?)\s*<\/d>/gi, (_match, language, lyric) => {
+      const cleanLanguage = String(language || "English").trim() || "English";
+      const cleanLyric = miniMaxH3CapitalizeCueText(miniMaxH3PunctuatedCueText(lyric));
+      return cleanLyric ? `<d>[${cleanLanguage}] ${cleanLyric}</d>` : "";
+    }).replace(/<d>\s*(?!\[[^\]]+\]\s*)([^<]*?)\s*<\/d>/gi, (_match, lyric) => {
+      const cleanLyric = miniMaxH3CapitalizeCueText(miniMaxH3PunctuatedCueText(lyric));
+      return cleanLyric ? `<d>[English] ${cleanLyric}</d>` : "";
+    });
+  }
+
+  function miniMaxH3PunctuatedCueText(value) {
+    let text = String(value || "").trim();
+    if (text && !/[.!?…]["')\]]?$/.test(text)) text += ".";
+    return text;
+  }
+
+  function miniMaxH3CapitalizeCueText(value) {
+    return String(value || "").replace(/^(\s*["'“‘(]*)([a-z])/, (_match, prefix, letter) => `${prefix}${letter.toUpperCase()}`);
+  }
+
+  function miniMaxH3CleanSubjectNoun(value, fallback = "reference") {
+    const text = String(value || "").replace(/\s+/g, " ").trim() || fallback;
+    return text.replace(/^(?:the\s+)+/i, "the ");
+  }
+
+  function normalizeMiniMaxH3ShotDescription(text) {
+    return normalizeMiniMaxH3DialogueTags(String(text || "")
+      .replace(/\bto\s+Audio\s+1\b/gi, "to <Audio 1>")
+      .replace(/\bfrom\s+Audio\s+1\b/gi, "from <Audio 1>")
+      .replace(/\bwith\s+Audio\s+1\b/gi, "with <Audio 1>")
+      .replace(/\bin\s+Audio\s+1\b/gi, "in <Audio 1>")
+      .replace(/\bAudio\s+1\b/g, "<Audio 1>")
+      .replace(/<+Audio 1>+/g, "<Audio 1>")
+      .replace(/\s+/g, " ")
+      .trim());
+  }
+
+  function miniMaxH3SentenceFragmentAfterCut(text) {
+    let clean = normalizeMiniMaxH3ShotDescription(text);
+    clean = clean.replace(/^(?:cut\s+to\s+)?(?:a|an|the)\s+/i, (match) => match.toLowerCase());
+    return clean;
+  }
+
+  function miniMaxH3CleanPostCutGrammar(text) {
+    let clean = String(text || "").replace(/\s+/g, " ").trim();
+    clean = clean.replace(/\bthe camera cuts\s+to\s+(?=(?:the\s+)?camera\b)/gi, "the camera cuts. ");
+    clean = clean.replace(/\bthe camera cuts\.\s*(?:the\s+camera\s+cuts(?:\s+to)?\.?\s*)+/gi, "the camera cuts. ");
+    clean = clean.replace(/\bthe camera cuts\s+to\s+((?:a|an|the)\s+(?:(?:extreme|tight|wide|medium|close|low-angle|high-angle|over-the-shoulder|tracking|panning|orbiting|dolly|handheld|static|locked-off|profile|two-shot|single|insert|detail|wide-angle|telephoto)[\s-]+){0,6}(?:close-up|shot|view|angle|frame|framing)(?:\s+of\b[^.]{0,140})?\s+(?:shows|captures|reveals|frames|focuses|follows|tracks|pans|pushes|orbits|opens|begins)\b)/gi, (_match, fragment) => {
+      return `the camera cuts. ${miniMaxH3CapitalizeCueText(fragment)}`;
+    });
+    clean = clean.replace(/\bthe camera cuts\.\s+([a-z])/g, (_match, letter) => `the camera cuts. ${letter.toUpperCase()}`);
+    return clean;
+  }
+
+  function miniMaxH3PostCutShotText(text) {
+    const clean = normalizeMiniMaxH3ShotDescription(text);
+    if (/^(?:the\s+)?camera\b/i.test(clean)) {
+      return miniMaxH3CleanPostCutGrammar(`the camera cuts. ${clean}`);
+    }
+    if (/^(?:a|an|the)\s+[\w-]+(?:\s+[\w-]+){0,8}\s+shot(?:\s+of\b[^.]{0,120})?\s+(?:shows|captures|reveals|frames|focuses|follows|tracks|pans|pushes|orbits|opens|begins)\b/i.test(clean)) {
+      return miniMaxH3CleanPostCutGrammar(`the camera cuts. ${clean}`);
+    }
+    return miniMaxH3CleanPostCutGrammar(`the camera cuts to ${miniMaxH3SentenceFragmentAfterCut(clean)}`);
+  }
+
+  function miniMaxH3OfficialShotBodyFromDescriptions(segment, descriptions = []) {
+    const cutPlan = miniMaxH3CutPlanForSegment(segment);
+    const shotPlan = miniMaxH3OfficialShotPlan(cutPlan);
+    if (descriptions.length !== shotPlan.length) {
+      throw new Error(`Cannot assemble MiniMax shots: expected ${shotPlan.length} description${shotPlan.length === 1 ? "" : "s"}, got ${descriptions.length}.`);
+    }
+    return shotPlan.map((shot, index) => {
+      const description = normalizeMiniMaxH3ShotDescription(descriptions[index]);
+      if (shot.number === 1) return `[Shot 1] ${description}`;
+      return `[Shot ${shot.number}] At ${shot.timecode}, ${miniMaxH3PostCutShotText(description)}`;
+    }).join("\n\n");
+  }
+
+  function miniMaxH3OfficialReferencePlan(segment, mode = miniMaxH3ModeForSegment(segment)) {
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    const cutPlan = miniMaxH3CutPlanForSegment(segment);
+    const shotList = miniMaxH3OfficialShotPlan(cutPlan).map((shot) => `[Shot ${shot.number}]`).join(", ");
+    const pictureItems = normalizedMode === "image_to_video"
+      ? [{ kind: "start_frame", label: "opening frame", description: "the exact first frame and visual composition anchor" }]
+      : (normalizedMode === "reference_to_video" || normalizedMode === "video_to_video")
+        ? miniMaxOrderedImageReferenceItemsForSegment(segment, normalizedMode)
+        : [];
+    let subjectNumber = 0;
+    const pictureDefinitions = [];
+    const subjectDefinitions = [];
+    const retention = [];
+    const subjects = [];
+    pictureItems.forEach((item, index) => {
+      const pictureLabel = `<Picture ${index + 1}>`;
+      const name = miniMaxH3CleanSubjectNoun(item?.label || item?.name || `${item?.kind === "location" ? "location" : "reference"} ${index + 1}`);
+      const isLocation = item?.kind === "location";
+      const displayName = isLocation ? "environment" : name;
+      const description = String(item?.description || "").trim();
+      const purpose = miniMaxReferencePurposeText(item, segment);
+      if (item?.kind === "start_frame") {
+        pictureDefinitions.push(`${pictureLabel} is the first frame of [Shot 1], used as the exact opening composition and visual-state anchor.`);
+        retention.push(`${pictureLabel} ([Shot 1] first frame): fully_preserved - the opening composition, subject placement, environment, lighting, and visual state are retained as the starting frame.`);
+        return;
+      }
+      subjectNumber += 1;
+      const subjectLabel = `<Subject ${subjectNumber}>`;
+      const noun = isLocation
+        ? "environment"
+        : item?.kind === "subject"
+          ? displayName
+          : `${displayName} reference`;
+      const nounPhrase = /^(?:the|a|an)\s+/i.test(noun) ? noun : `the ${noun}`;
+      subjectDefinitions.push(`${subjectLabel} is ${nounPhrase} in ${pictureLabel}, used as ${purpose}${description ? `: ${description}` : "."}`);
+      retention.push(`${subjectLabel} (appears in ${shotList || "[Shot 1]"}): fully_preserved - ${description || `${displayName} is preserved according to its reference role.`}`);
+      subjects.push({ label: subjectLabel, name: displayName, kind: item?.kind || "reference", description, pictureLabel });
+    });
+    const videoDefinitions = miniMaxH3VideoAssignmentLines(segment).map((line) => line.replace(/^<Video\s+(\d+)>\s*:\s*/, "<Video $1> is a reference video used as "));
+    const videoRetention = miniMaxH3VideoAssignmentLines(segment).map((line, index) => {
+      const purpose = line.replace(/^<Video\s+\d+>\s*:\s*/, "").trim();
+      return `<Video ${index + 1}> (reference-video structure): weak_reference - ${purpose}`;
+    });
+    return {
+      subjects,
+      subjectDefinitions,
+      pictureDefinitions,
+      videoDefinitions,
+      retention: [...retention, ...videoRetention],
+    };
+  }
+
+  function miniMaxH3OfficialAudioDefinition(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (settings.audio_mode === "built_in_audio") return "";
+    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const dialogueAssignments = visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment);
+    const lyricText = dialogueAssignments.length
+      ? dialogueAssignments.map((cue) => cue.text).join(" ")
+      : isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
+    const multiCueSingers = isMiniMaxSingerAssignmentMode(segment)
+      && String(segment?.lyric_performance_mode || "together") === "cue_map"
+      && selectedPerformerSubjectsForSegment(segment).length >= 2;
+    const performer = segment?.no_character_present || multiCueSingers ? "the target video" : "<Subject 1> (S1)";
+    const lyricClause = lyricText && !visualOnly
+      ? selectedPerformerSubjectsForSegment(segment).length >= 2
+        ? ` ${miniMaxH3VocalCueMapText(segment, miniMaxH3ModeForSegment(segment), { compact: true })}`
+        : ` The exact performed lyric/dialogue line is "${miniMaxH3PunctuatedCueText(lyricText)}"`
+      : "";
+    return `<Audio 1> is the complete synchronized song and vocal track for ${performer}, reused as the target video's complete final soundtrack and timing reference.${lyricClause}`;
+  }
+
+  function miniMaxH3OfficialSummary(segment, mode, refs) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    const taskTypes = [];
+    if (normalizedMode === "video_to_video") taskTypes.push("video editing");
+    if (normalizedMode === "image_to_video") taskTypes.push("keyframe completion");
+    if (normalizedMode === "reference_to_video" || refs.subjects.length) taskTypes.push("reference generation");
+    if (settings.audio_mode === "input_audio") taskTypes.push("audio reuse");
+    if (!taskTypes.length) taskTypes.push("text generation");
+    const subjectNames = refs.subjects.map((item) => item.kind === "location" ? `${item.label} (environment)` : `${item.label} (${item.name})`);
+    const subjectText = subjectNames.length ? subjectNames.join(" and ") : "the described target scene";
+    const audioText = settings.audio_mode === "input_audio"
+      ? " <Audio 1> is reused as the complete soundtrack and timing reference."
+      : " MiniMax generates the native audio requested by the scene.";
+    return `[${Array.from(new Set(taskTypes)).join(" + ")}] The target video is a ${miniMaxH3OpeningStyle(segment)} scene featuring ${subjectText}.${audioText}`;
+  }
+
+  function miniMaxH3OpeningStyle(segment) {
+    return String(segment?.minimax_h3_video_style || state.builderStoryboardDefaults?.video_style || "").trim() || "photorealistic cinematic";
+  }
+
+  function miniMaxH3OfficialSoundscape(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (settings.audio_mode === "input_audio") {
+      return "overall_soundscape:\nNo additional environmental or physical sounds are added over <Audio 1>.";
+    }
+    const audioDirection = String(segment?.audio_direction || "").trim();
+    return `overall_soundscape:\n${audioDirection || "Subtle location-appropriate ambience, physical movement sounds, breathing, and non-verbal performance sounds support the scene without adding unrequested dialogue."}`;
+  }
+
+  function miniMaxH3OfficialMusic(segment) {
+    const settings = miniMaxH3SettingsForSegment(segment);
+    if (settings.audio_mode === "input_audio") {
+      return "non_diegetic_music:\n<Audio 1> is reused as the complete audience-facing song/music track.";
+    }
+    return "non_diegetic_music:\nN/A";
+  }
+
+  function miniMaxH3OfficialIntegratedDescription(segment, mode, creative) {
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    const prefix = normalizedMode === "image_to_video"
+      ? `For the target video, at 0.00 seconds into the target video, <Picture 1> (from [Shot 1]) is fully referenced.\n\n`
+      : "";
+    return `${prefix}integrated_multimodal_description:\n${creative}`;
+  }
+
+  function assembleMiniMaxH3OfficialPromptFromCreative(segment, mode, creativePrompt) {
+    const normalizedMode = normalizeMiniMaxH3Mode(mode);
+    const cutPlan = miniMaxH3CutPlanForSegment(segment);
+    const shotDescriptions = parseMiniMaxH3ShotDescriptionPayload(creativePrompt, cutPlan, segment, normalizedMode);
+    const creative = miniMaxH3OfficialShotBodyFromDescriptions(segment, shotDescriptions);
+    if (!creative) {
+      throw new Error("The LLM returned no creative MiniMax scene body. Try again, or add more scene notes so it has action/camera material to write.");
+    }
+    if (normalizedMode === "text_to_video" || normalizedMode === "image_to_video") {
+      return [
+        miniMaxH3OfficialIntegratedDescription(segment, normalizedMode, creative),
+        miniMaxH3OfficialSoundscape(segment),
+        miniMaxH3OfficialMusic(segment),
+      ].filter(Boolean).join("\n\n").trim();
+    }
+    const refs = miniMaxH3OfficialReferencePlan(segment, normalizedMode);
+    const audioDefinition = miniMaxH3OfficialAudioDefinition(segment);
+    const definitions = [
+      ...refs.subjectDefinitions,
+      ...refs.pictureDefinitions,
+      ...refs.videoDefinitions,
+      audioDefinition,
+    ].filter(Boolean);
+    const retention = [
+      ...refs.retention,
+      audioDefinition ? "<Audio 1>: fully_copy - <Audio 1> is reused 1:1 as the target video's complete final audio track." : "",
+    ].filter(Boolean);
+    return [
+      `subject_definitions:\n${definitions.join("\n")}`,
+      `summary:\n${miniMaxH3OfficialSummary(segment, normalizedMode, refs)}`,
+      `retention_analysis:\n${retention.join("\n")}`,
+      `detailed_description:\nThe target video is in a ${miniMaxH3OpeningStyle(segment)} music-video style.\n\n${creative}`,
+      miniMaxH3OfficialSoundscape(segment),
+      miniMaxH3OfficialMusic(segment),
+    ].filter(Boolean).join("\n\n").trim();
+  }
+
+  function assembleMiniMaxH3PromptFromCreative(segment, mode, creativePrompt) {
+    return assembleMiniMaxH3OfficialPromptFromCreative(segment, mode, creativePrompt);
+  }
+
   function miniMaxH3PromptContextForSegment(segment, mode) {
     const settings = miniMaxH3SettingsForSegment(segment);
     const nativeAudio = settings.audio_mode === "built_in_audio";
@@ -35686,7 +37696,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const characterMotionSpeed = Number(segment?.character_motion_speed ?? state.builderStoryboardDefaults?.character_motion_speed ?? 4);
     const cameraMotionGuidance = String(segment?.camera_motion_speed_guidance || state.builderStoryboardDefaults?.camera_guidance || "").trim();
     const characterMotionGuidance = String(segment?.character_motion_guidance || state.builderStoryboardDefaults?.character_guidance || "").trim();
-    const cutPlan = storyboardCutPlanForDuration(duration, state.builderStoryboardDefaults?.minimax_h3_cut_frequency);
+    const cutPlan = miniMaxH3CutPlanForSegment(segment);
     parts.push(
       `Camera motion speed: ${Number.isFinite(cameraMotionSpeed) ? cameraMotionSpeed : 4}/10.`,
       cameraMotionGuidance || "Follow the selected camera speed as a hard motion requirement.",
@@ -35694,6 +37704,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       characterMotionGuidance || "Include physical character action appropriate to the selected character-motion speed.",
       cutPlan.instruction,
     );
+    const cueShotContract = miniMaxH3CueShotContractText(segment, mode);
+    if (cueShotContract) parts.push(cueShotContract);
     if (cameraMotionSpeed >= 7) {
       parts.push("MANDATORY CAMERA RULE: use energetic, visibly active camera movement. Slow, gentle, subtle, restrained, locked-off, static, and hold camera language contradicts this setting and must not appear.");
     }
@@ -35836,6 +37848,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return [];
   }
 
+  function miniMaxH3PromptVisionImagesForRunner(segment, mode) {
+    if ((state.textGemmaRunner || "builtin") === "builtin") return [];
+    return miniMaxH3PromptVisionImages(segment, mode);
+  }
+
   async function createMiniMaxH3PromptWithLLM() {
     const segment = requireActiveSegment();
     if (!segment) return;
@@ -35853,13 +37870,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast("Create or load a Builder project before creating MiniMax prompts.", true);
       return;
     }
-    const visionImages = miniMaxH3PromptVisionImages(segment, mode);
+    const rendererPromptImages = miniMaxH3PromptVisionImages(segment, mode);
+    const visionImages = miniMaxH3PromptVisionImagesForRunner(segment, mode);
     const rendererReferenceImages = mode === "reference_to_video"
       ? miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
       : [];
     const sceneImageUse = miniMaxH3SceneImageUseForSegment(segment);
     const sceneImageSourceAvailable = Boolean(segmentImageSource(segment)?.path || segmentImageSource(segment)?.data);
-    if (mode === "image_to_video" && !visionImages.length) {
+    if (mode === "image_to_video" && !rendererPromptImages.length) {
       toast("Image to Video needs a selected scene image before the LLM can create its MiniMax prompt.", true);
       return;
     }
@@ -35869,6 +37887,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     if (mode === "reference_to_video" && !rendererReferenceImages.length) {
       toast("Reference to Video needs at least one ordered Reference Builder image.", true);
+      return;
+    }
+    try {
+      assertMiniMaxH3ReferenceDescriptionsReady(segment, mode);
+    } catch (error) {
+      toast(String(error?.message || error), true);
       return;
     }
     const videoReferences = (Array.isArray(segment.minimax_h3_video_references) ? segment.minimax_h3_video_references : [])
@@ -35881,7 +37905,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast("MiniMax image/reference prompting needs a vision-capable API model selected in LLM Runner.", true);
       return;
     }
-    const context = miniMaxH3PromptContextForSegment(segment, mode);
+    const context = miniMaxH3CreativePromptContextForSegment(segment, mode);
     const miniMaxVisualOnly = segmentUsesNoLipSyncPerformance(segment);
     const promptLyricText = miniMaxVisualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
     const promptSingerNames = miniMaxVisualOnly ? [] : (Array.isArray(segment.lyric_singers)
@@ -35911,9 +37935,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         repair_model_file: miniMaxTextGemmaModelSelect.value,
         mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
         t2i_prompt: context,
-        user_notes: "Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.",
-        subject_context: segment.no_character_present ? "" : segmentMappedSubjectText(segment),
-        location_context: segmentMappedLocationText(segment),
+        user_notes: "",
+        subject_context: "",
+        location_context: "",
         no_character_present: Boolean(segment.no_character_present),
         image_references: visionImages,
         prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(segment),
@@ -35922,15 +37946,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         singers: promptSingerNames,
         audio_mode: miniMaxH3SettingsForSegment(segment).audio_mode,
         speaker_assignments: miniMaxVisualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment),
-        theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
-        story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
-        subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
+        theme_style_path: "",
+        story_idea_path: "",
+        subject_scene_path: "",
         unload_after: true,
         temperature: 0.45,
         top_p: 0.92,
         max_new_tokens: 4000,
       }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-      const prompt = applyMiniMaxH3NativeVoiceBlock(String(data.prompt || ""), segment);
+      const prompt = assembleMiniMaxH3PromptFromCreative(segment, mode, String(data.prompt || ""));
       if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
       pushHistory();
       segment.minimax_h3_prompt = prompt;
@@ -37575,13 +39599,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         workingSegment.minimax_h3_video_references = (Array.isArray(segment.minimax_h3_video_references)
           ? segment.minimax_h3_video_references
           : []).map((item) => ({ ...item }));
-        const visionImages = miniMaxH3PromptVisionImages(workingSegment, mode);
+        const rendererPromptImages = miniMaxH3PromptVisionImages(workingSegment, mode);
+        const visionImages = miniMaxH3PromptVisionImagesForRunner(workingSegment, mode);
         const rendererReferenceImages = mode === "reference_to_video"
           ? miniMaxOrderedImageReferenceItemsForSegment(workingSegment, mode)
           : [];
         const sceneImageUse = miniMaxH3SceneImageUseForSegment(workingSegment);
         const sceneImageSourceAvailable = Boolean(segmentImageSource(workingSegment)?.path || segmentImageSource(workingSegment)?.data);
-        if (mode === "image_to_video" && !visionImages.length) {
+        if (mode === "image_to_video" && !rendererPromptImages.length) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Image to Video needs a selected scene image.`);
         }
         if (mode === "reference_to_video" && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
@@ -37590,6 +39615,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (mode === "reference_to_video" && !rendererReferenceImages.length) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Reference to Video needs ordered Reference Builder images.`);
         }
+        assertMiniMaxH3ReferenceDescriptionsReady(workingSegment, mode);
         if (mode === "video_to_video" && !workingSegment.minimax_h3_video_references.some((item) => String(item?.path || "").trim())) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Video to Video needs a reference video.`);
         }
@@ -37608,10 +39634,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
           repair_model_file: miniMaxTextGemmaModelSelect.value,
           mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
-          t2i_prompt: miniMaxH3PromptContextForSegment(workingSegment, mode),
-          user_notes: `Follow the MiniMax H3 mode contract and the exact ordered media assignments in the scene context.\n\n${customSourceContract}`,
-          subject_context: workingSegment.no_character_present ? "" : segmentMappedSubjectText(workingSegment),
-          location_context: segmentMappedLocationText(workingSegment),
+          t2i_prompt: miniMaxH3CreativePromptContextForSegment(workingSegment, mode),
+          user_notes: customSourceContract,
+          subject_context: "",
+          location_context: "",
           no_character_present: Boolean(workingSegment.no_character_present),
           image_references: visionImages,
           prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(workingSegment),
@@ -37624,9 +39650,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           camera_motion_speed_guidance: workingSegment.camera_motion_speed_guidance,
           character_motion_speed: workingSegment.character_motion_speed,
           character_motion_guidance: workingSegment.character_motion_guidance,
-          theme_style_path: state.useVrgdgTextContext ? state.themeStylePath || "" : "",
-          story_idea_path: state.useVrgdgTextContext ? state.storyIdeaPath || "" : "",
-          subject_scene_path: state.useVrgdgTextContext ? state.subjectScenePath || "" : "",
+          theme_style_path: "",
+          story_idea_path: "",
+          subject_scene_path: "",
           unload_after: options.unloadAfter !== false,
           temperature: 0.45,
           top_p: 0.92,
@@ -37634,16 +39660,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
         const generatedPrompt = String(data.prompt || "").trim();
         if (!generatedPrompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
-        const prompt = applyMiniMaxH3NativeVoiceBlock(
-          normalizeStoryboardInputAudioVocalTimeline(
-            ensureStoryboardRequiredTemporalWorldEffect(
-              ensureStoryboardRequiredVideoStyle(generatedPrompt, options.storyboardPayload || {}),
-              options.storyboardPayload || {},
-            ),
-            workingSegment,
-          ),
-          workingSegment,
-        );
+        const prompt = assembleMiniMaxH3PromptFromCreative(workingSegment, mode, generatedPrompt);
         return {
           ...data,
           prompt,
@@ -39848,6 +41865,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       );
       const timing = built?.timing || {};
       const postTrim = built?.post_render_trim || {};
+      const builtTurboSettings = built?.turbo_settings || {};
+      const builtAdvancedSettings = built?.advanced_settings || {};
+      const turboLine = builtTurboSettings.enabled
+        ? `\nTurbo: ON — effective steps ${Number(builtAdvancedSettings.effective_steps || builtTurboSettings.steps || miniMaxSettings.steps)}; LoRA ${builtTurboSettings.lora_name || miniMaxSettings.turbo_lora_name} @ ${builtTurboSettings.strength ?? miniMaxSettings.turbo_lora_strength}`
+        : `\nTurbo: OFF — steps ${Number(builtAdvancedSettings.steps || miniMaxSettings.steps)}`;
+      const settingsScopeLine = `\nSettings scope: ${segment?.use_scene_minimax_h3_settings ? "locked scene settings" : "project/global settings"}`;
       const finalDuration = Number(postTrim.duration);
       if (!Number.isFinite(finalDuration) || Math.abs(finalDuration - sceneDuration) > 0.001) {
         throw new Error(
@@ -39860,6 +41883,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         `${batchLabel}Queueing MiniMax H3...\n`
         + `Timeline: ${sceneDuration.toFixed(3)}s\n`
         + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`
+        + turboLine
+        + settingsScopeLine
         + (continuityImageNumber ? `\nContinuity: ${continuityInput.continuityMode === "exact_start_frame" ? "exact start" : "spatial reference"} (Image ${continuityImageNumber})` : ""),
         pct(30),
       );
@@ -40726,7 +42751,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       progress.set(`Render All complete.\n\nFinal video:\n${stitched.final_video_path}\n\nScene clips:\n${stitched.video_folder}\n\nTotal time: ${renderLogDuration(summary.total_ms)}\nActive scene rendering: ${renderLogDuration(summary.render_ms)}\nFinal stitching: ${renderLogDuration(summary.stitch_ms)}\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}`, 100);
       progress.close(6500);
       toast(`Render All complete:\n${stitched.final_video_path}`);
-      showFinalVideoReadyModal(stitched.final_video_path);
+      if (!options.suppressFinalModal) showFinalVideoReadyModal(stitched.final_video_path);
+      return stitched;
     } catch (error) {
       const failedAt = Date.now();
       const message = String(error?.message || error);
@@ -42850,9 +44876,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const songDuration = Number(audio.duration || state.duration || 0);
       if (!Number.isFinite(duration) || duration <= 0) throw new Error("Scene length must be greater than zero.");
       if (!Number.isFinite(songDuration) || songDuration <= 0) throw new Error("Load a song first so its duration is available.");
-      const fullScenes = Math.floor(songDuration / duration);
-      const remainder = songDuration - fullScenes * duration;
-      const count = Math.max(1, fullScenes + (remainder >= duration * 0.5 ? 1 : 0));
+      const count = Math.max(1, Math.ceil(songDuration / duration));
       return Array.from({ length: count }, (_, index) => ({
         start: index * duration,
         end: index === count - 1 ? songDuration : (index + 1) * duration,
@@ -42867,7 +44891,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         examples.innerHTML = `<strong style="color:#e0f2fe;">Fixed length + scene count</strong><br>Create the requested number of consecutive scenes, all with the same duration.`;
         actionSelect.disabled = false;
       } else if (modeSelect.value === "fit") {
-        examples.innerHTML = `<strong style="color:#e0f2fe;">Fit to song duration</strong><br>Fill the loaded song using the preferred scene length. A final scene at least half that length is kept; a smaller remainder is added to the previous scene.`;
+        examples.innerHTML = `<strong style="color:#e0f2fe;">Fit to song duration</strong><br>Fill the entire loaded song using the preferred scene length. Any remainder becomes its own shorter final scene so generated clips never lose the ending.`;
         actionSelect.value = "replace";
         actionSelect.disabled = true;
       } else if (modeSelect.value === "durations") {
@@ -45605,7 +47629,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
 
   function openGemmaRunnerModal() {
     const backdrop = document.createElement("div");
-    backdrop.style.cssText = "position:fixed;inset:0;z-index:100006;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;";
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100020;background:rgba(0,0,0,.62);display:flex;align-items:center;justify-content:center;";
     const box = document.createElement("div");
     box.style.cssText = "width:min(700px,calc(100vw - 40px));border:1px solid #155e75;border-radius:8px;background:#111827;color:#f8fafc;box-shadow:0 20px 70px rgba(0,0,0,.55);padding:16px;display:flex;flex-direction:column;gap:12px;";
     const header = document.createElement("div");
@@ -45899,6 +47923,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         testApi.textContent = "Test LLM API";
       }
     };
+    return backdrop;
   }
 
   function confirmDeleteMediaAction(type, path) {
@@ -46700,6 +48725,585 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     });
   }
 
+  function openAutoBuildModal() {
+    const backdrop = document.createElement("div");
+    backdrop.style.cssText = "position:fixed;inset:0;z-index:100011;background:rgba(0,0,0,.74);display:flex;align-items:center;justify-content:center;padding:18px;box-sizing:border-box;";
+    const box = document.createElement("div");
+    box.style.cssText = "width:min(720px,calc(100vw - 36px));max-height:calc(100vh - 36px);overflow:hidden;border:1px solid #0891b2;border-radius:14px;background:linear-gradient(180deg,#0f172a,#0b1220);color:#f8fafc;box-shadow:0 28px 90px rgba(0,0,0,.72);display:flex;flex-direction:column;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:14px;padding:16px 18px;border-bottom:1px solid #164e63;background:linear-gradient(135deg,#083344,#0f172a);";
+    const headingWrap = document.createElement("div");
+    headingWrap.style.cssText = "display:flex;align-items:center;gap:11px;min-width:0;";
+    const headingIcon = document.createElement("div");
+    headingIcon.innerHTML = `<svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${COMPACT_TOOLBAR_ICONS.auto}</svg>`;
+    headingIcon.style.cssText = "width:42px;height:42px;border:1px solid #22d3ee;border-radius:10px;background:#063b4a;color:#67e8f9;display:flex;align-items:center;justify-content:center;flex:0 0 auto;";
+    const heading = document.createElement("div");
+    heading.innerHTML = '<div style="font-size:19px;font-weight:950;color:#ecfeff;">Auto Build Music Video</div><div style="font-size:12px;color:#a5f3fc;margin-top:3px;">Add four things. Auto Build prepares everything else for you.</div>';
+    const close = makeButton("Close");
+    close.style.padding = "7px 10px";
+    headingWrap.append(headingIcon, heading);
+    header.append(headingWrap, close);
+
+    const body = document.createElement("div");
+    body.style.cssText = "padding:16px 18px;display:flex;flex-direction:column;gap:12px;overflow:auto;";
+    const engineCard = document.createElement("div");
+    engineCard.style.cssText = "border:1px solid #334155;border-radius:10px;background:#0f172a;padding:11px;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:center;";
+    const engineCopy = document.createElement("div");
+    engineCopy.innerHTML = '<div style="font-size:12px;font-weight:900;color:#e0f2fe;">Video model</div><div style="font-size:11px;color:#94a3b8;margin-top:2px;">Auto Build applies the correct prompt format for the selected engine.</div>';
+    const engineToggle = document.createElement("div");
+    engineToggle.style.cssText = "display:grid;grid-template-columns:1fr 1fr;gap:5px;";
+    const ltxEngine = makeButton("LTX");
+    const miniMaxEngine = makeButton("MiniMax");
+    ltxEngine.style.minWidth = "76px";
+    miniMaxEngine.style.minWidth = "76px";
+    let selectedEngine = normalizeProjectVideoEngine(state.projectVideoEngine);
+    const syncEngineButtons = () => {
+      for (const [button, value] of [[ltxEngine, "ltx"], [miniMaxEngine, "minimax_h3"]]) {
+        const active = selectedEngine === value;
+        button.style.background = active ? "#06b6d4" : "#1e293b";
+        button.style.borderColor = active ? "#67e8f9" : "#475569";
+        button.style.color = active ? "#082f49" : "#e2e8f0";
+        button.setAttribute("aria-pressed", active ? "true" : "false");
+      }
+    };
+    let syncAutoBuildRunnerStatus = () => {};
+    ltxEngine.onclick = () => { selectedEngine = "ltx"; syncEngineButtons(); syncAutoBuildRunnerStatus(); };
+    miniMaxEngine.onclick = () => { selectedEngine = "minimax_h3"; syncEngineButtons(); syncAutoBuildRunnerStatus(); };
+    syncEngineButtons();
+    engineToggle.append(ltxEngine, miniMaxEngine);
+    engineCard.append(engineCopy, engineToggle);
+
+    const runnerCard = document.createElement("div");
+    runnerCard.style.cssText = "border:1px solid #334155;border-radius:10px;background:#0f172a;padding:11px;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:center;";
+    const runnerCopy = document.createElement("div");
+    const runnerTitle = document.createElement("div");
+    runnerTitle.textContent = "LLM runner";
+    runnerTitle.style.cssText = "font-size:12px;font-weight:900;color:#e0f2fe;";
+    const runnerStatus = document.createElement("div");
+    runnerStatus.style.cssText = "font-size:11px;color:#94a3b8;margin-top:2px;";
+    const openRunner = makeButton("LLM Runner", "primary");
+    openRunner.style.minWidth = "116px";
+    syncAutoBuildRunnerStatus = () => {
+      const runnerLabel = gemmaRunnerLabel({ vision: selectedEngine === "minimax_h3" });
+      const needsKey = state.textGemmaRunner === "llm_api" && !String(state.llmApiKey || "").trim();
+      const needsVisionModel = selectedEngine === "minimax_h3" && state.textGemmaRunner === "llm_api" && !llmApiVisionModelSelected();
+      runnerStatus.textContent = needsKey
+        ? `${runnerLabel} selected, but no API key is set.`
+        : needsVisionModel
+        ? `${runnerLabel} selected, but choose a vision-capable API model.`
+        : `Current: ${runnerLabel}`;
+      runnerStatus.style.color = needsKey || needsVisionModel ? "#fdba74" : "#94a3b8";
+    };
+    openRunner.onclick = () => {
+      const runnerBackdrop = openGemmaRunnerModal();
+      const timer = setInterval(() => {
+        syncAutoBuildRunnerStatus();
+        if (!runnerBackdrop?.isConnected) clearInterval(timer);
+      }, 500);
+    };
+    runnerCopy.append(runnerTitle, runnerStatus);
+    runnerCard.append(runnerCopy, openRunner);
+    syncAutoBuildRunnerStatus();
+
+    const songInput = document.createElement("input");
+    songInput.type = "file";
+    songInput.accept = "audio/*,.mp3,.wav,.flac,.m4a,.ogg";
+    songInput.style.display = "none";
+    const singerInput = document.createElement("input");
+    singerInput.type = "file";
+    singerInput.accept = "image/png,image/jpeg,image/webp,.png,.jpg,.jpeg,.webp";
+    singerInput.style.display = "none";
+    const locationInput = document.createElement("input");
+    locationInput.type = "file";
+    locationInput.multiple = true;
+    locationInput.accept = "image/png,image/jpeg,image/webp,.png,.jpg,.jpeg,.webp";
+    locationInput.style.display = "none";
+    body.append(songInput, singerInput, locationInput);
+
+    const selected = { song: null, singer: null, locations: [] };
+    const uploadCard = (number, title, caption, buttonLabel, optional = false) => {
+      const card = document.createElement("div");
+      card.style.cssText = "border:1px solid #334155;border-radius:10px;background:#111827;padding:11px;display:grid;grid-template-columns:34px minmax(0,1fr) auto;gap:10px;align-items:center;";
+      const badge = document.createElement("div");
+      badge.textContent = String(number);
+      badge.style.cssText = "width:30px;height:30px;border:1px solid #0891b2;border-radius:999px;background:#083344;color:#a5f3fc;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:950;";
+      const copy = document.createElement("div");
+      const label = document.createElement("div");
+      label.innerHTML = `${escapeHtml(title)}${optional ? ' <span style="font-size:10px;color:#94a3b8;font-weight:700;">(optional)</span>' : ""}`;
+      label.style.cssText = "font-size:13px;font-weight:900;color:#e2e8f0;";
+      const status = document.createElement("div");
+      status.textContent = caption;
+      status.style.cssText = "font-size:11px;color:#94a3b8;margin-top:3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      copy.append(label, status);
+      const choose = makeButton(buttonLabel, "primary");
+      choose.style.minWidth = "116px";
+      card.append(badge, copy, choose);
+      return { card, choose, status };
+    };
+
+    const currentAudioPath = String(audioInput.value || state.audioPath || "").trim();
+    const songRow = uploadCard(1, "Song", currentAudioPath ? `Using current audio: ${currentAudioPath.split(/[\\/]/).pop()}` : "MP3, WAV, FLAC, M4A, or OGG", "Choose Song");
+    const singerRow = uploadCard(3, "Singer image", "One clear reference image of the singer", "Choose Singer");
+    const locationRow = uploadCard(4, "Location images", "One image repeats; multiple images rotate every two scenes", "Add Locations", true);
+    songRow.choose.onclick = () => songInput.click();
+    singerRow.choose.onclick = () => singerInput.click();
+    locationRow.choose.onclick = () => locationInput.click();
+    songInput.onchange = () => {
+      selected.song = songInput.files?.[0] || null;
+      songRow.status.textContent = selected.song ? selected.song.name : (currentAudioPath ? `Using current audio: ${currentAudioPath.split(/[\\/]/).pop()}` : "Choose a song file");
+    };
+    singerInput.onchange = () => {
+      selected.singer = singerInput.files?.[0] || null;
+      singerRow.status.textContent = selected.singer ? selected.singer.name : "Choose one singer image";
+    };
+    locationInput.onchange = () => {
+      selected.locations = Array.from(locationInput.files || []);
+      locationRow.status.textContent = selected.locations.length
+        ? `${selected.locations.length} location image${selected.locations.length === 1 ? "" : "s"}: ${selected.locations.map((file) => file.name).join(", ")}`
+        : "No locations selected; Auto Build will continue without them";
+    };
+
+    const lyricsCard = document.createElement("div");
+    lyricsCard.style.cssText = "border:1px solid #334155;border-radius:10px;background:#111827;padding:11px;display:grid;grid-template-columns:34px minmax(0,1fr);gap:10px;align-items:start;";
+    const lyricsBadge = document.createElement("div");
+    lyricsBadge.textContent = "2";
+    lyricsBadge.style.cssText = "width:30px;height:30px;border:1px solid #0891b2;border-radius:999px;background:#083344;color:#a5f3fc;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:950;";
+    const lyricsWrap = document.createElement("div");
+    const lyricsLabel = document.createElement("div");
+    lyricsLabel.textContent = "Lyrics";
+    lyricsLabel.style.cssText = "font-size:13px;font-weight:900;color:#e2e8f0;margin-bottom:7px;";
+    const lyricsInput = document.createElement("textarea");
+    lyricsInput.placeholder = "Paste the complete lyrics here...";
+    lyricsInput.spellcheck = true;
+    lyricsInput.style.cssText = "width:100%;box-sizing:border-box;min-height:150px;resize:vertical;border:1px solid #475569;border-radius:8px;background:#020617;color:#f8fafc;padding:10px;font-size:12px;line-height:1.45;";
+    lyricsWrap.append(lyricsLabel, lyricsInput);
+    lyricsCard.append(lyricsBadge, lyricsWrap);
+
+    const note = document.createElement("div");
+    note.style.cssText = "border:1px solid #155e75;border-radius:9px;background:#062b36;padding:10px 12px;color:#bae6fd;font-size:11px;line-height:1.45;";
+    note.textContent = "Auto Build creates complete 8-second coverage, uses the LLM to describe the singer and locations, transcribes the existing scenes, maps everything, applies the recommended defaults, and generates prompts. It returns you to the normal timeline so you can review every lyric note.";
+    const projectWarning = document.createElement("div");
+    const getAutoBuildProjectFolder = () => String(projectInput.value || state.projectFolder || "").trim();
+    let projectFolder = getAutoBuildProjectFolder();
+    projectWarning.style.cssText = `border:1px solid #92400e;border-radius:9px;background:#451a03;padding:10px 12px;color:#fed7aa;font-size:11px;line-height:1.45;${projectFolder ? "display:none;" : ""}`;
+    const projectWarningText = document.createElement("div");
+    projectWarningText.textContent = "Auto Build needs a project folder to save the song and reference images.";
+    const createProjectNow = makeButton("Create Project Now", "primary");
+    createProjectNow.style.cssText += "margin-top:8px;padding:7px 10px;background:#f97316;border-color:#fdba74;color:#431407;font-size:12px;font-weight:800;";
+    projectWarning.append(projectWarningText, createProjectNow);
+    const status = document.createElement("div");
+    status.style.cssText = "display:none;border:1px solid #0891b2;border-radius:9px;background:#083344;padding:11px 12px;color:#cffafe;font-size:12px;font-weight:800;white-space:pre-wrap;line-height:1.45;";
+    body.append(engineCard, runnerCard, songRow.card, lyricsCard, singerRow.card, locationRow.card, note, projectWarning, status);
+
+    const footer = document.createElement("div");
+    footer.style.cssText = "display:grid;grid-template-columns:1fr minmax(210px,auto);gap:10px;padding:13px 18px;border-top:1px solid #164e63;background:#0f172a;";
+    const cancel = makeButton("Cancel");
+    const build = makeButton("Build My Music Video", "primary");
+    build.style.cssText += "font-size:13px;padding:11px 18px;background:linear-gradient(180deg,#22d3ee,#0891b2);border-color:#67e8f9;";
+    const refreshProjectReady = () => {
+      projectFolder = getAutoBuildProjectFolder();
+      const ready = Boolean(projectFolder);
+      projectWarning.style.display = ready ? "none" : "block";
+      build.textContent = ready ? "Build My Music Video" : "Create Project & Build";
+      build.title = ready
+        ? "Build the music-video timeline from the inputs above."
+        : "Create a project first, then continue Auto Build without losing the inputs above.";
+      return ready;
+    };
+    refreshProjectReady();
+    footer.append(cancel, build);
+    box.append(header, body, footer);
+    backdrop.append(box);
+    document.body.append(backdrop);
+
+    const closeModal = () => backdrop.remove();
+    close.onclick = closeModal;
+    cancel.onclick = closeModal;
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) closeModal();
+    });
+    const ensureAutoBuildProject = async () => {
+      if (refreshProjectReady()) return true;
+      createProjectNow.disabled = true;
+      build.disabled = true;
+      try {
+        const created = await newProject();
+        refreshProjectReady();
+        return Boolean(created && getAutoBuildProjectFolder());
+      } finally {
+        createProjectNow.disabled = false;
+        build.disabled = false;
+      }
+    };
+    createProjectNow.onclick = async () => {
+      await ensureAutoBuildProject();
+    };
+
+    const imageBaseName = (file, fallback) => String(file?.name || fallback || "Reference")
+      .replace(/\.[^.]+$/, "")
+      .replace(/[_-]+/g, " ")
+      .trim() || fallback || "Reference";
+    const hasRealTimeline = () => {
+      const scenes = allEditableSegments();
+      if (scenes.length > 1) return true;
+      const scene = scenes[0];
+      if (!scene) return false;
+      return Boolean(
+        String(scene.lyric_text || scene.notes || scene.t2i_prompt || scene.i2v_prompt || scene.minimax_h3_prompt || "").trim()
+        || scene.image
+        || scene.video_path
+        || !/^New scene$/i.test(String(scene.label || "New scene"))
+      );
+    };
+
+    const generateAutoBuildMiniMaxPrompts = async () => {
+      const scenes = [...state.segments];
+      const progress = createProgressWindow("Auto Build MiniMax Prompts");
+      let created = 0;
+      let historySaved = false;
+      try {
+        state.batchCancelled = false;
+        for (let index = 0; index < scenes.length; index += 1) {
+          assertBatchNotStopped();
+          const segment = scenes[index];
+          const mode = "reference_to_video";
+          const visionImages = miniMaxH3PromptVisionImagesForRunner(segment, mode);
+          const rendererReferences = miniMaxOrderedImageReferenceItemsForSegment(segment, mode);
+          if (!rendererReferences.length) throw new Error(`${sceneDisplayName(segment, index)} has no mapped Reference Builder image.`);
+          assertMiniMaxH3ReferenceDescriptionsReady(segment, mode);
+          if (visionImages.length && state.textGemmaRunner === "llm_api" && !llmApiVisionModelSelected()) {
+            throw new Error("MiniMax reference prompting needs a vision-capable API model selected in LLM Runner.");
+          }
+          const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+          const lyricText = visualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
+          const singerNames = visualOnly ? [] : (Array.isArray(segment.lyric_singers)
+            ? segment.lyric_singers
+            : String(segment.lyric_singers || "").split(/[,;\n]+/))
+            .map((value) => String(value || "").trim())
+            .filter(Boolean);
+          const percent = 5 + Math.round((index / Math.max(1, scenes.length)) * 90);
+          progress.set(`Creating MiniMax prompt ${index + 1}/${scenes.length}: ${sceneDisplayName(segment, index)}\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`, percent);
+          const data = await postJson("/vrgdg/music_builder/generate_t2v", {
+            ...textGemmaRunnerPayload(),
+            project_folder: projectFolder,
+            scene_id: segment.id || "",
+            builder_instruction_key: miniMaxH3InstructionKey(mode),
+            model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
+            repair_model_file: miniMaxTextGemmaModelSelect.value,
+            mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
+            t2i_prompt: miniMaxH3CreativePromptContextForSegment(segment, mode),
+            user_notes: "",
+            subject_context: "",
+            location_context: "",
+            no_character_present: Boolean(segment.no_character_present),
+            image_references: visionImages,
+            prompt_only_scene_inspiration: false,
+            performance_mode: "singing",
+            lyric_text: lyricText,
+            singers: singerNames,
+            audio_mode: "input_audio",
+            speaker_assignments: [],
+            theme_style_path: "",
+            story_idea_path: "",
+            subject_scene_path: "",
+            unload_after: index === scenes.length - 1,
+            temperature: 0.45,
+            top_p: 0.92,
+            max_new_tokens: 4000,
+          }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
+          const prompt = assembleMiniMaxH3PromptFromCreative(segment, mode, String(data.prompt || ""));
+          if (!prompt) throw new Error(`${sceneDisplayName(segment, index)} returned an empty MiniMax prompt.`);
+          if (!historySaved) {
+            pushHistory();
+            historySaved = true;
+          }
+          segment.minimax_h3_prompt = prompt;
+          segment.minimax_h3_prompt_origin = "gemma";
+          created += 1;
+          await autoSaveSessionQuiet(`Auto Build MiniMax prompt ${index + 1}`);
+        }
+        progress.set(`Created ${created} MiniMax video prompt${created === 1 ? "" : "s"}.`, 100);
+        progress.close(1600);
+        return created;
+      } catch (error) {
+        progress.set(`Auto Build MiniMax prompts stopped after ${created}/${scenes.length}:\n${String(error?.message || error)}`, 100);
+        progress.close(5000);
+        throw error;
+      }
+    };
+
+    const validateAutoBuildPromptRunner = () => {
+      if (state.textGemmaRunner === "llm_api") {
+        if (!String(state.llmApiKey || "").trim()) {
+          throw new Error("LLM API is selected, but no API key is set. Open LLM Runner in Auto Build, paste/test the key, then start Auto Build again.");
+        }
+        if (selectedEngine === "minimax_h3" && !llmApiVisionModelSelected()) {
+          throw new Error("MiniMax Auto Build uses reference images for prompt writing. Open LLM Runner and choose a vision-capable API model.");
+        }
+      }
+      if (state.textGemmaRunner === "lm_studio" && !String(state.lmStudioModel || "").trim()) {
+        throw new Error("LM Studio is selected, but no model name is set. Open LLM Runner, load/select a model, then start Auto Build again.");
+      }
+    };
+
+    const applyAutoBuildSingerPerformerMapping = (singer) => {
+      const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+      if (!refs.subject_scene_map || typeof refs.subject_scene_map !== "object") refs.subject_scene_map = {};
+      state.segments.forEach((segment, index) => {
+        refs.subject_scene_map[segment.id] = Array.from(new Set([singer.id, ...sceneReferenceMapArray(refs.subject_scene_map, segment, index)].filter(Boolean)));
+        segment.lyric_singers = [singer.name];
+        segment.lyric_no_lip_sync = false;
+        segment.no_character_present = false;
+        const cueText = String(segment.lyric_text || "").trim();
+        segment.minimax_speaker_assignments = cueText && !isInstrumentalLyricText(cueText)
+          ? normalizeMiniMaxSpeakerAssignments([{
+            speaker_id: singer.id,
+            speaker_name: singer.name,
+            text: cueText,
+          }])
+          : [];
+      });
+      refs.use_subject_reference = true;
+      state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
+    };
+
+    build.onclick = async () => {
+      const lyrics = String(lyricsInput.value || "").trim();
+      if (!lyrics) {
+        toast("Paste the complete lyrics before starting Auto Build.", true);
+        lyricsInput.focus();
+        return;
+      }
+      if (!selected.singer) {
+        toast("Choose one singer reference image before starting Auto Build.", true);
+        return;
+      }
+      try {
+        validateAutoBuildPromptRunner();
+      } catch (error) {
+        syncAutoBuildRunnerStatus();
+        toast(String(error?.message || error), true);
+        openGemmaRunnerModal();
+        return;
+      }
+      if (hasRealTimeline() && !window.confirm("Auto Build will replace the current base timeline and its insert scenes. Continue?")) return;
+      if (!await ensureAutoBuildProject()) {
+        toast("Create a project before starting Auto Build.", true);
+        return;
+      }
+      const audioAvailable = Boolean(selected.song || String(audioInput.value || state.audioPath || "").trim());
+      if (!audioAvailable) {
+        toast("Choose a song before starting Auto Build.", true);
+        return;
+      }
+
+      build.disabled = true;
+      cancel.disabled = true;
+      close.disabled = true;
+      createProjectNow.disabled = true;
+      for (const control of [ltxEngine, miniMaxEngine, openRunner, songRow.choose, singerRow.choose, locationRow.choose, lyricsInput]) control.disabled = true;
+      status.style.display = "block";
+      const setStatus = (message) => {
+        status.textContent = message;
+        status.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      };
+
+      try {
+        setStatus("1/7  Loading the song...");
+        if (selected.song) {
+          const loaded = await chooseProjectAudioFile(selected.song);
+          if (!loaded) throw new Error("The selected song could not be loaded into the project.");
+        }
+        const songDuration = Number(state.audioDuration || audio.duration || state.duration || 0);
+        if (!Number.isFinite(songDuration) || songDuration <= 0) throw new Error("The song duration could not be read.");
+
+        state.projectVideoEngine = normalizeProjectVideoEngine(selectedEngine);
+        state.videoType = "singing";
+        state.videoModelMode = "rtv";
+        state.miniMaxH3Settings = cloneMiniMaxH3Settings({
+          ...state.miniMaxH3Settings,
+          video_mode: "reference_to_video",
+          audio_mode: "input_audio",
+        });
+        syncVideoTypeControl();
+        syncProjectVideoEngineUI();
+        syncVideoModePanel();
+        syncI2VVideoSettingsPanel();
+
+        setStatus("2/7  Creating complete 8-second timeline coverage...");
+        const sceneCount = Math.max(1, Math.ceil(songDuration / 8));
+        const timings = Array.from({ length: sceneCount }, (_, index) => ({
+          start: index * 8,
+          end: Math.min(songDuration, (index + 1) * 8),
+        }));
+        await applyBulkSegmentTimings(timings, "replace");
+        state.overlaySegments = [];
+        state.activeTrack = "base";
+        state.duration = songDuration;
+
+        setStatus("3/7  Adding and mapping singer and location references...");
+        const refs = normalizeFluxReferenceBuilder(state.fluxReferenceBuilder);
+        refs.cleared = false;
+        refs.locations_cleared = false;
+        refs.subjects = refs.subjects.filter((item) => !String(item?.id || "").startsWith("auto_build_singer_"));
+        refs.locations = refs.locations.filter((item) => !String(item?.id || "").startsWith("auto_build_location_"));
+        const singerData = await readFileAsDataUrl(selected.singer);
+        const singer = {
+          id: `auto_build_singer_${Date.now()}`,
+          name: "Singer",
+          description: "",
+          reference_type: "character",
+          trigger_phrase: "",
+          trigger_position: "start",
+          extra_reference_for: "",
+          extra_reference_note: "",
+          minimax_voice: normalizeMiniMaxH3Voice(),
+          image: { path: "", data: singerData, name: selected.singer.name || "singer.png" },
+        };
+        refs.subjects.unshift(singer);
+        refs.subject_count = refs.subjects.length;
+        refs.subject = {
+          description: singer.description,
+          reference_type: "character",
+          minimax_voice: normalizeMiniMaxH3Voice(),
+          image: { ...singer.image },
+        };
+        refs.use_subject_reference = true;
+        const autoLocations = [];
+        const locationData = await Promise.all(selected.locations.map((file) => readFileAsDataUrl(file)));
+        selected.locations.forEach((file, index) => {
+          const location = {
+            id: `auto_build_location_${Date.now()}_${index}`,
+            name: imageBaseName(file, `Location ${index + 1}`),
+            description: "",
+            trigger_phrase: "",
+            trigger_position: "start",
+            image: { path: "", data: locationData[index], name: file.name || `location_${index + 1}.png` },
+          };
+          refs.locations.push(location);
+          autoLocations.push(location);
+        });
+
+        setStatus("3/7  Describing singer and location references with the LLM...");
+        await describeReferenceImageWithGemma(singer, "subject", {
+          unloadAfter: autoLocations.length === 0,
+          clearBeforeLoad: false,
+        });
+        if (!String(singer.description || "").trim()) {
+          singer.description = "The lead singer and visible performer in every scene.";
+        }
+        refs.subject.description = singer.description;
+        for (let index = 0; index < autoLocations.length; index += 1) {
+          const location = autoLocations[index];
+          setStatus(`3/7  Describing location ${index + 1}/${autoLocations.length} with the LLM...`);
+          await describeReferenceImageWithGemma(location, "location", {
+            unloadAfter: index === autoLocations.length - 1,
+            clearBeforeLoad: false,
+          });
+        }
+        refs.use_location_references = autoLocations.length > 0;
+        refs.subject_scene_map = {};
+        refs.scene_map = {};
+        state.segments.forEach((segment, index) => {
+          refs.subject_scene_map[segment.id] = [singer.id];
+          if (autoLocations.length) refs.scene_map[segment.id] = autoLocations[Math.floor(index / 2) % autoLocations.length].id;
+          else delete refs.scene_map[segment.id];
+          segment.lyric_singers = [singer.name];
+          segment.lyric_no_lip_sync = false;
+          segment.no_character_present = false;
+          segment.minimax_speaker_assignments = [];
+          segment.story_beat = "";
+          segment.minimax_h3_mode = "reference_to_video";
+          segment.minimax_h3_scene_image_use = "off";
+        });
+        state.fluxReferenceBuilder = normalizeFluxReferenceBuilder(refs);
+
+        setStatus("4/7  Applying recommended scene defaults...");
+        state.builderStoryLayer = normalizeBuilderStoryLayer({
+          enabled: true,
+          overall_story_idea: "",
+          user_story_arc: "",
+          song_story_brief: "",
+          lyric_story_strength: 3,
+          image_world_style: "natural",
+          image_custom_style_direction: "",
+        });
+        state.builderStoryboardDefaults = normalizeBuilderStoryboardDefaults({
+          ...state.builderStoryboardDefaults,
+          video_style: "Cinematic realism",
+          video_style_custom: "",
+          temporal_world_effect: "",
+          temporal_world_effect_custom: "",
+          global_consistency_phrase: "",
+          camera_flow: "intimate_closeups",
+          camera_motion_speed: 6,
+          minimax_h3_cut_frequency: 3,
+          performance_style: "",
+          character_motion_speed: 4,
+          camera_guidance: builderMotionSpeedGuidance(6, "camera"),
+          character_guidance: builderMotionSpeedGuidance(4, "character"),
+        });
+        state.defaultFacialPerformance = "";
+        state.defaultFacialPerformanceCustom = "";
+        let previousMotion = "";
+        state.segments.forEach((segment, index) => {
+          const camera = storyboardCameraFlowEntry("intimate_closeups", index, previousMotion);
+          if (camera?.shot) segment.shot_type = camera.shot;
+          if (camera?.camera) segment.camera_motion = camera.camera;
+          previousMotion = String(segment.camera_motion || previousMotion);
+          segment.performance_style = "";
+          segment.facial_performance = "";
+          segment.facial_performance_custom = "";
+          segment.character_motion = builderMotionSpeedGuidance(4, "character");
+        });
+
+        setStatus("5/7  Transcribing the existing scenes and filling lyric notes...");
+        await transcribeExistingScenesWithOptions({
+          referenceLyrics: lyrics,
+          language: "english",
+          replaceAll: true,
+          instrumentalText: "[instrumental]",
+        }, {
+          recordHistory: false,
+        });
+        applyAutoBuildSingerPerformerMapping(singer);
+
+        setStatus("6/7  Saving references and timeline mappings...");
+        await saveSession({ quiet: true, throwOnError: true });
+        syncInspector();
+        render();
+
+        setStatus("7/7  Preparing video prompts. The normal prompt progress window will open next...");
+        closeModal();
+        if (selectedEngine === "minimax_h3") {
+          await generateAutoBuildMiniMaxPrompts();
+        } else {
+          await gemmaVideoAllTextOnly({
+            promptRunMode: "redo_all",
+            gemmaInputMode: "text",
+            sceneScope: "all",
+          });
+        }
+        state.activeId = state.segments[0]?.id || state.activeId;
+        state.activeTrack = "base";
+        syncInspector();
+        render();
+        const promptCount = selectedEngine === "minimax_h3"
+          ? state.segments.filter((segment) => String(segment.minimax_h3_prompt || "").trim()).length
+          : state.segments.filter((segment) => String(segment.i2v_prompt || "").trim()).length;
+        toast(`Auto Build complete.\nCreated ${state.segments.length} scenes with full song coverage.\nGenerated ${promptCount} video prompt${promptCount === 1 ? "" : "s"}.\nReview the timeline and lyric notes before rendering.`);
+      } catch (error) {
+        setStatus(`Auto Build paused:\n${String(error?.message || error)}\n\nAny completed timeline work has been preserved for review.`);
+        build.disabled = false;
+        cancel.disabled = false;
+        close.disabled = false;
+        createProjectNow.disabled = false;
+        for (const control of [ltxEngine, miniMaxEngine, openRunner, songRow.choose, singerRow.choose, locationRow.choose, lyricsInput]) control.disabled = false;
+        toast(`Auto Build paused:\n${String(error?.message || error)}`, true);
+      }
+    };
+  }
+
   function openWizardFromBuilder() {
     const setWizardVideoMode = (mode) => {
       const normalized = String(mode || "").trim().toLowerCase();
@@ -47426,7 +50030,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             ? String(data.prompt || "").trim()
             : segment ? finalizeVideoPromptDraftOnly(segment, data.prompt) : String(data.prompt || "").trim();
           const prompt = miniMaxProject
-            ? applyMiniMaxH3NativeVoiceBlock(finalizedPrompt, segment)
+            ? finalizedPrompt
             : applyWizardStoryboardTriggerPhrases(finalizedPrompt, scene);
           if (!prompt) throw new Error(`${scene.label || `Scene ${index + 1}`}: ${runnerGenericName} returned an empty Storyboard video prompt.`);
           if (segment) {
@@ -47755,6 +50359,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   });
   lyricTextInput.addEventListener("change", () => {
     lyricTextInput.dataset.vrgdgUserEdited = "1";
+    updateActiveFromInputs({ skipHistory: true });
+  });
+  lyricSingersInput.addEventListener("focus", pushHistory);
+  lyricSingersInput.addEventListener("input", () => {
+    lyricSingersInput.dataset.vrgdgUserEdited = "1";
+    updateActiveFromInputs({ skipHistory: true });
+  });
+  lyricSingersInput.addEventListener("change", () => {
+    lyricSingersInput.dataset.vrgdgUserEdited = "1";
     updateActiveFromInputs({ skipHistory: true });
   });
   freezeTimingControl.input.addEventListener("change", () => {
@@ -48539,6 +51152,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     } catch (error) {
       console.error("VRGDG Video Wizard failed to open", error);
       toast(`Video Wizard failed to open:\n${String(error?.message || error)}`, true);
+    }
+  };
+  autoBuildButton.onclick = () => {
+    try {
+      openAutoBuildModal();
+    } catch (error) {
+      console.error("VRGDG Auto Build failed to open", error);
+      toast(`Auto Build failed to open:\n${String(error?.message || error)}`, true);
     }
   };
   storyboardBuilderButton.onclick = () => {
@@ -49707,7 +52328,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (miniMaxUseTurboLora.input.checked) {
       currentSettings.steps_before_turbo = Math.max(1, Math.trunc(Number(miniMaxSteps.value) || DEFAULT_MINIMAX_H3_SETTINGS.steps));
       currentSettings.easy_cache_bypass_before_turbo = miniMaxEasyCacheBypass.input.checked;
-      miniMaxSteps.value = "6";
+      miniMaxSteps.value = "4";
       miniMaxEasyCacheBypass.input.checked = true;
     } else {
       miniMaxSteps.value = String(currentSettings.steps_before_turbo || DEFAULT_MINIMAX_H3_SETTINGS.steps);
@@ -49768,6 +52389,20 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       return;
     }
     pushHistory();
+    if (isMiniMaxSingerAssignmentMode(segment)) {
+      const selectedPerformers = selectedPerformerSubjectsForSegment(segment);
+      const performer = selectedPerformers[0] || speakers[0];
+      segment.lyric_performance_mode = selectedPerformers.length >= 2 ? "cue_map" : "together";
+      segment.lyric_singers = selectedPerformers.length
+        ? selectedPerformers.map((subject) => subject.name || "Character")
+        : [performer.name || "Character"];
+      const cues = Array.isArray(segment.lyric_cue_map) ? segment.lyric_cue_map : [];
+      cues.push({ text: "", singer_id: performer.id || "", singer_name: performer.name || "" });
+      segment.lyric_cue_map = cues;
+      renderMiniMaxSpeakerAssignmentPanel();
+      autoSaveSessionQuiet("MiniMax lyric cue added").catch(() => null);
+      return;
+    }
     const cues = ensureMiniMaxSpeakerAssignments(segment, speakers);
     const speaker = speakers[0];
     cues.push(...normalizeMiniMaxSpeakerAssignments([{ speaker_id: speaker.id, speaker_name: speaker.name, text: "" }]));

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -37405,7 +37405,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return [safePrompt, subjectMultiplicityBlock, block, visualOnlyBlock].filter(Boolean).join("\n\n").trim();
   }
 
-  function miniMaxH3CreativePromptContextForSegment(segment, mode) {
+  function miniMaxH3CreativePromptContextForSegment(segment, mode, options = {}) {
     const settings = miniMaxH3SettingsForSegment(segment);
     const nativeAudio = settings.audio_mode === "built_in_audio";
     const duration = Math.max(0, Number(segment?.end || 0) - Number(segment?.start || 0));
@@ -37481,6 +37481,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     add(parts, "Scene idea", sceneVideoConceptPromptText(segment));
     add(parts, "Scene notes", segment?.notes || segment?.director_note);
+    add(parts, "Storyboard Builder context", options.storyboardContext || options.extraStoryboardNotes, 2200);
     add(parts, "Motion/camera request", segment?.i2v_notes);
     add(parts, "Story beat", segment?.story_beat);
     add(parts, "Lyric section", segment?.lyric_section);
@@ -38176,6 +38177,66 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return miniMaxH3PromptVisionImages(segment, mode);
   }
 
+  async function runMiniMaxH3PromptGeneration(segment, mode, options = {}) {
+    const visionImages = miniMaxH3PromptVisionImagesForRunner(segment, mode);
+    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
+    const promptLyricText = visualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
+    const promptSingerNames = visualOnly ? [] : (Array.isArray(segment.lyric_singers)
+      ? segment.lyric_singers
+      : String(segment.lyric_singers || "").split(/[,;\n]+/))
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const data = await postJson("/vrgdg/music_builder/generate_t2v", {
+      ...textGemmaRunnerPayload(),
+      project_folder: options.projectFolder || activeProjectFolderForSave(),
+      scene_id: options.sceneId || segment.id || "",
+      builder_instruction_key: options.builderInstructionKey || miniMaxH3InstructionKey(mode),
+      model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
+      repair_model_file: miniMaxTextGemmaModelSelect.value,
+      mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
+      t2i_prompt: miniMaxH3CreativePromptContextForSegment(segment, mode, options.contextOptions || {}),
+      user_notes: String(options.userNotes || ""),
+      subject_context: "",
+      location_context: "",
+      no_character_present: Boolean(segment.no_character_present),
+      image_references: visionImages,
+      prompt_only_scene_inspiration: options.promptOnlySceneInspiration ?? miniMaxH3SceneImageIsPromptInspiration(segment),
+      performance_mode: options.performanceMode || effectiveVideoPerformanceModeForSegment(segment),
+      lyric_text: promptLyricText,
+      singers: promptSingerNames,
+      audio_mode: options.audioMode || miniMaxH3SettingsForSegment(segment).audio_mode,
+      speaker_assignments: Array.isArray(options.speakerAssignments)
+        ? options.speakerAssignments
+        : visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment),
+      camera_motion_speed: segment.camera_motion_speed,
+      camera_motion_speed_guidance: segment.camera_motion_speed_guidance,
+      character_motion_speed: segment.character_motion_speed,
+      character_motion_guidance: segment.character_motion_guidance,
+      theme_style_path: "",
+      story_idea_path: "",
+      subject_scene_path: "",
+      unload_after: options.unloadAfter !== false,
+      temperature: Number(options.temperature ?? 0.45),
+      top_p: Number(options.topP ?? 0.92),
+      max_new_tokens: Number(options.maxNewTokens ?? 4000),
+    }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
+    const generatedPrompt = String(data.prompt || "").trim();
+    if (!generatedPrompt) {
+      throw new Error(options.emptyPromptMessage || `The LLM returned an empty MiniMax ${miniMaxH3ModeLabel(mode)} prompt.`);
+    }
+    const prompt = assembleMiniMaxH3PromptFromCreative(segment, mode, generatedPrompt);
+    if (!prompt) {
+      throw new Error(options.emptyPromptMessage || `The LLM returned an empty MiniMax ${miniMaxH3ModeLabel(mode)} prompt.`);
+    }
+    return {
+      ...data,
+      prompt,
+      already_finalized: true,
+      minimax_h3_mode: mode,
+      used_minimax_h3_instructions: true,
+    };
+  }
+
   async function createMiniMaxH3PromptWithLLM() {
     const segment = requireActiveSegment();
     if (!segment) return;
@@ -38228,14 +38289,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast("MiniMax image/reference prompting needs a vision-capable API model selected in LLM Runner.", true);
       return;
     }
-    const context = miniMaxH3CreativePromptContextForSegment(segment, mode);
-    const miniMaxVisualOnly = segmentUsesNoLipSyncPerformance(segment);
-    const promptLyricText = miniMaxVisualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
-    const promptSingerNames = miniMaxVisualOnly ? [] : (Array.isArray(segment.lyric_singers)
-      ? segment.lyric_singers
-      : String(segment.lyric_singers || "").split(/[,;\n]+/))
-      .map((value) => String(value || "").trim())
-      .filter(Boolean);
     if (mode === "text_to_video" && !sceneVideoConceptPromptText(segment) && !String(segment.i2v_notes || segment.story_beat || segment.lyric_text || "").trim()) {
       toast("Add a scene idea, notes, story beat, lyrics, or motion direction before creating a Text to Video prompt.", true);
       return;
@@ -38249,40 +38302,15 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       progress.set(`Autosaving this scene before LLM prompting...`, 8);
       await autoSaveSessionQuiet(`MiniMax ${modeLabel} prompt`);
       progress.set(`Running ${visionImages.length ? "vision-assisted" : "text-only"} MiniMax prompt direction...\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`, 42);
-      const data = await postJson("/vrgdg/music_builder/generate_t2v", {
-        ...textGemmaRunnerPayload(),
-        project_folder: projectFolder,
-        scene_id: segment.id || "",
-        builder_instruction_key: miniMaxH3InstructionKey(mode),
-        model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
-        repair_model_file: miniMaxTextGemmaModelSelect.value,
-        mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
-        t2i_prompt: context,
-        user_notes: "",
-        subject_context: "",
-        location_context: "",
-        no_character_present: Boolean(segment.no_character_present),
-        image_references: visionImages,
-        prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(segment),
-        performance_mode: effectiveVideoPerformanceModeForSegment(segment),
-        lyric_text: promptLyricText,
-        singers: promptSingerNames,
-        audio_mode: miniMaxH3SettingsForSegment(segment).audio_mode,
-        speaker_assignments: miniMaxVisualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment),
-        theme_style_path: "",
-        story_idea_path: "",
-        subject_scene_path: "",
-        unload_after: true,
-        temperature: 0.45,
-        top_p: 0.92,
-        max_new_tokens: 4000,
-      }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-      const prompt = assembleMiniMaxH3PromptFromCreative(segment, mode, String(data.prompt || ""));
-      if (!prompt) throw new Error(`The LLM returned an empty MiniMax ${modeLabel} prompt.`);
+      const data = await runMiniMaxH3PromptGeneration(segment, mode, {
+        projectFolder,
+        unloadAfter: true,
+        emptyPromptMessage: `The LLM returned an empty MiniMax ${modeLabel} prompt.`,
+      });
       pushHistory();
-      segment.minimax_h3_prompt = prompt;
+      segment.minimax_h3_prompt = data.prompt;
       segment.minimax_h3_prompt_origin = "gemma";
-      miniMaxPrompt.value = prompt;
+      miniMaxPrompt.value = data.prompt;
       render();
       await autoSaveSessionQuiet(`MiniMax ${modeLabel} prompt complete`);
       progress.set(`MiniMax ${modeLabel} prompt ready.`, 100);
@@ -39898,9 +39926,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const workingSegment = storyboardSceneCloneForI2V(segment, scene);
       const extraUserNotes = storyboardVideoExtraNotes(scene, options.storyboardPayload || {});
       if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
-        workingSegment.i2v_notes = [String(workingSegment.i2v_notes || "").trim(), extraUserNotes]
-          .filter(Boolean)
-          .join("\n\n");
         const mode = miniMaxH3ModeForSegment(segment);
         const modeLabel = miniMaxH3ModeLabel(mode);
         const storyboardPlanningMode = normalizeMiniMaxShortFilmPlanningMode(
@@ -39908,10 +39933,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           || options.storyboardPayload?.shortFilmPlanningMode
           || state.builderStoryboardDefaults?.short_film_planning_mode,
         );
-        const isMiniMaxShortFilmPrompt = effectiveVideoPerformanceModeForSegment(workingSegment) === "speaking";
-        const storyboardInstructionKey = isMiniMaxShortFilmPrompt
-          ? miniMaxH3ShortFilmInstructionKey(mode, storyboardPlanningMode)
-          : miniMaxH3InstructionKey(mode);
+        const storyboardInstructionKey = miniMaxH3InstructionKey(mode);
         const customSourceContract = storyboardPlanningMode === "fully_custom"
           ? "FULLY CUSTOM SHORT FILM: Every populated scene-card field is authoritative. Format only what the user supplied. Do not invent, rewrite, reorder, merge, omit, or replace dialogue, speakers, story beats, actions, shot/framing, camera motion, setting, references, audio direction, sound, or continuity. Leave unspecified choices unspecified."
           : "GUIDED SHORT FILM: Preserve exact dialogue and speaker order while using the supplied film-planning fields to stage a coherent narrative scene.";
@@ -39949,44 +39971,21 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           `${options.progressLabel || scene.label || sceneDisplayName(segment, segmentIndexInfo(segment).index)}: creating MiniMax ${modeLabel} prompt with the scene's H3 instructions...\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`,
           Math.min(92, Number(options.progressPercent || 35) + 18),
         );
-        const data = await postJson("/vrgdg/music_builder/generate_t2v", {
-          ...textGemmaRunnerPayload(),
-          project_folder: activeProjectFolderForSave(),
-          scene_id: segment.id || "",
-          builder_instruction_key: storyboardInstructionKey,
-          model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
-          repair_model_file: miniMaxTextGemmaModelSelect.value,
-          mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
-          t2i_prompt: miniMaxH3CreativePromptContextForSegment(workingSegment, mode),
-          user_notes: customSourceContract,
-          subject_context: "",
-          location_context: "",
-          no_character_present: Boolean(workingSegment.no_character_present),
-          image_references: visionImages,
-          prompt_only_scene_inspiration: miniMaxH3SceneImageIsPromptInspiration(workingSegment),
-          performance_mode: effectiveVideoPerformanceModeForSegment(workingSegment),
-          lyric_text: segmentUsesNoLipSyncPerformance(workingSegment) || isInstrumentalLyricText(workingSegment.lyric_text) ? "" : flattenLyricForPrompt(workingSegment.lyric_text),
-          singers: segmentUsesNoLipSyncPerformance(workingSegment) ? [] : (Array.isArray(workingSegment.lyric_singers) ? workingSegment.lyric_singers : []),
-          audio_mode: miniMaxH3SettingsForSegment(workingSegment).audio_mode,
-          speaker_assignments: segmentUsesNoLipSyncPerformance(workingSegment) ? [] : miniMaxDialogueAssignmentsForSegment(workingSegment),
-          camera_motion_speed: workingSegment.camera_motion_speed,
-          camera_motion_speed_guidance: workingSegment.camera_motion_speed_guidance,
-          character_motion_speed: workingSegment.character_motion_speed,
-          character_motion_guidance: workingSegment.character_motion_guidance,
-          theme_style_path: "",
-          story_idea_path: "",
-          subject_scene_path: "",
-          unload_after: options.unloadAfter !== false,
-          temperature: 0.45,
-          top_p: 0.92,
-          max_new_tokens: 4000,
-        }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-        const generatedPrompt = String(data.prompt || "").trim();
-        if (!generatedPrompt) throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`);
-        const prompt = assembleMiniMaxH3PromptFromCreative(workingSegment, mode, generatedPrompt);
+        const data = await runMiniMaxH3PromptGeneration(workingSegment, mode, {
+          projectFolder: activeProjectFolderForSave(),
+          sceneId: segment.id || "",
+          builderInstructionKey: storyboardInstructionKey,
+          contextOptions: {
+            storyboardContext: extraUserNotes,
+            storyboardPayload: options.storyboardPayload || {},
+            storyboardScene: scene,
+          },
+          userNotes: customSourceContract,
+          unloadAfter: options.unloadAfter !== false,
+          emptyPromptMessage: `${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: LLM returned an empty MiniMax ${modeLabel} prompt.`,
+        });
         return {
           ...data,
-          prompt,
           already_finalized: true,
           minimax_h3_mode: mode,
           used_minimax_h3_instructions: true,
@@ -49297,50 +49296,23 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           if (visionImages.length && state.textGemmaRunner === "llm_api" && !llmApiVisionModelSelected()) {
             throw new Error("MiniMax reference prompting needs a vision-capable API model selected in LLM Runner.");
           }
-          const visualOnly = segmentUsesNoLipSyncPerformance(segment);
-          const lyricText = visualOnly || isInstrumentalLyricText(segment.lyric_text) ? "" : flattenLyricForPrompt(segment.lyric_text);
-          const singerNames = visualOnly ? [] : (Array.isArray(segment.lyric_singers)
-            ? segment.lyric_singers
-            : String(segment.lyric_singers || "").split(/[,;\n]+/))
-            .map((value) => String(value || "").trim())
-            .filter(Boolean);
           const percent = 5 + Math.round((index / Math.max(1, scenes.length)) * 90);
           progress.set(`Creating MiniMax prompt ${index + 1}/${scenes.length}: ${sceneDisplayName(segment, index)}\n${gemmaRunnerLine({ vision: Boolean(visionImages.length) })}`, percent);
-          const data = await postJson("/vrgdg/music_builder/generate_t2v", {
-            ...textGemmaRunnerPayload(),
-            project_folder: projectFolder,
-            scene_id: segment.id || "",
-            builder_instruction_key: miniMaxH3InstructionKey(mode),
-            model_file: visionImages.length ? miniMaxGemmaModelSelect.value : miniMaxTextGemmaModelSelect.value,
-            repair_model_file: miniMaxTextGemmaModelSelect.value,
-            mmproj_file: visionImages.length ? miniMaxMmprojSelect.value : "",
-            t2i_prompt: miniMaxH3CreativePromptContextForSegment(segment, mode),
-            user_notes: "",
-            subject_context: "",
-            location_context: "",
-            no_character_present: Boolean(segment.no_character_present),
-            image_references: visionImages,
-            prompt_only_scene_inspiration: false,
-            performance_mode: "singing",
-            lyric_text: lyricText,
-            singers: singerNames,
-            audio_mode: "input_audio",
-            speaker_assignments: [],
-            theme_style_path: "",
-            story_idea_path: "",
-            subject_scene_path: "",
-            unload_after: index === scenes.length - 1,
-            temperature: 0.45,
-            top_p: 0.92,
-            max_new_tokens: 4000,
-          }, GEMMA_VIDEO_PROMPT_TIMEOUT_MS);
-          const prompt = assembleMiniMaxH3PromptFromCreative(segment, mode, String(data.prompt || ""));
-          if (!prompt) throw new Error(`${sceneDisplayName(segment, index)} returned an empty MiniMax prompt.`);
+          const data = await runMiniMaxH3PromptGeneration(segment, mode, {
+            projectFolder,
+            sceneId: segment.id || "",
+            unloadAfter: index === scenes.length - 1,
+            promptOnlySceneInspiration: false,
+            performanceMode: "singing",
+            audioMode: "input_audio",
+            speakerAssignments: [],
+            emptyPromptMessage: `${sceneDisplayName(segment, index)} returned an empty MiniMax prompt.`,
+          });
           if (!historySaved) {
             pushHistory();
             historySaved = true;
           }
-          segment.minimax_h3_prompt = prompt;
+          segment.minimax_h3_prompt = data.prompt;
           segment.minimax_h3_prompt_origin = "gemma";
           created += 1;
           await autoSaveSessionQuiet(`Auto Build MiniMax prompt ${index + 1}`);

--- a/web/VRGDG_UIThemes.js
+++ b/web/VRGDG_UIThemes.js
@@ -72,6 +72,26 @@
         warning: "#f0c96b",
       },
     },
+    graphite: {
+      label: "Graphite",
+      colors: {
+        bg0: "#0a0a0a",
+        bg1: "#141414",
+        bg2: "#202020",
+        bg3: "#303030",
+        text0: "#ffffff",
+        text1: "#d6d6d6",
+        text2: "#969696",
+        border0: "#343434",
+        border1: "#565656",
+        primary: "#ffffff",
+        primary2: "#c8c8c8",
+        primaryText: "#101010",
+        success: "#eeeeee",
+        danger: "#b8b8b8",
+        warning: "#d8d8d8",
+      },
+    },
     neon: {
       label: "Neon",
       colors: {
@@ -397,6 +417,7 @@
       }
       [${ROOT_ATTR}][data-vrgdg-ui-theme="dark"],
       [${ROOT_ATTR}][data-vrgdg-ui-theme="studio"],
+      [${ROOT_ATTR}][data-vrgdg-ui-theme="graphite"],
       [${ROOT_ATTR}][data-vrgdg-ui-theme="neon"],
       [${ROOT_ATTR}][data-vrgdg-ui-theme="forest"] {
         color-scheme: dark;


### PR DESCRIPTION
## What changed

- add the configurable scene render wait limit from 1-24 hours and keep it project-persistent
- add/extend Builder Auto Build, compact toolbar controls, and safer close confirmation with Save + Close / Close Without Saving / Go Back
- refresh Builder UI typography and compact shared tabs/buttons so MiniMax/LTX/image panels are less crowded
- add MiniMax Singer Assignment cue mapping for multi-performer music scenes
- support timed lyric and instrumental cues, per-cue singer selection, per-cue audio playback, auto-cascading cue boundaries, and synced Ref Builder/Singer Assignment mappings
- make newly generated split lyric cue maps start with two larger chunks instead of auto-splitting every couple of words
- add timed Dialogue and Instrumental rows to MiniMax built-in-audio Speaker Assignment, including Start, End, Play Cue, From Here, and boundary-sync controls
- add Auto Time This Scene for MiniMax singer cues by reusing the existing Stable-ts timestamp workflow on scene audio chunks
- add a small backend helper to prepare scene audio WAV clips for timestamp-based cue timing
- add a global Ref Builder Mapping control to apply Together vs Split cue map across all multi-performer scenes while preserving per-scene overrides
- make MiniMax cue timing drive shot count/cut times for split lyric and timed speaker cues
- update MiniMax H3 prompt generation so Gemma returns only creative shot JSON while the Builder assembles fixed reference/audio/continuity sections
- unify MiniMax H3 prompt generation so the side panel, Storyboard Builder, Wizard Storyboard All, and Auto Build share the same final prompt pipeline
- pass Storyboard Builder context into that shared MiniMax H3 context so storyboard beats, style, camera guidance, temporal/world effects, facial direction, audio notes, and continuity stay aligned
- add MiniMax prompt cleanup/fallbacks for malformed dialogue tags, awkward post-cut wording, and blank Gemma shot descriptions
- update MiniMax Turbo defaults to 4 editable steps and allow experimental lower values down to 1
- update What's New release notes for the above behavior

## Why

The Builder needed a simpler end-to-end music-video setup path, safer multi-singer MiniMax prompt handling, less crowded controls, and a single MiniMax H3 prompt path so users get the same format whether they generate from the side panel, Storyboard Builder, Wizard, or Auto Build. Built-in-audio dialogue scenes also needed the same timed cue workflow as singer assignment instead of the older manual-only speaker rows.

## User impact

Users can auto-build and review music-video timelines more quickly, assign who sings each timed lyric cue, auto-time those cues from scene audio, audition cue ranges directly in the UI, preserve those mappings in saved projects, and generate MiniMax prompts that better respect singer timing, storyboard context, and audio continuity. MiniMax built-in-audio dialogue scenes can now be planned with timed dialogue and instrumental cue rows before generating native audio. Long renders can be monitored beyond the old hardcoded two-hour limit.

## Validation

- Get-Content -Raw web\VRGDG_MusicVideoBuilderUI.js | node --input-type=module --check
- Get-Content -Raw update_notes.json | ConvertFrom-Json
- git diff --check
