### PR TITLE
Prepare Python 3.13 native build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ git clone https://github.com/vrgamegirl19/comfyui-vrgamedevgirl.git
 Then install the Python requirements using the Python environment that runs ComfyUI. For the Windows portable build, run this from `ComfyUI_windows_portable`:
 
 ```bat
+python_embeded\python.exe -m pip install --upgrade pip setuptools wheel
+python_embeded\python.exe -m pip install Cython scikit-build-core
 python_embeded\python.exe -m pip install -r ComfyUI\custom_nodes\comfyui-vrgamedevgirl\requirements.txt
 ```
+
+The first two commands prepare the build tooling needed by `voxcpm` and `llama-cpp-python`, especially on Windows with Python 3.13. `llama-cpp-python` may also need a working CMake/Ninja and C++ compiler when a compatible prebuilt wheel is unavailable. Python 3.12 is the safer choice for older Windows portable environments.
 
 Restart ComfyUI and hard refresh the browser page after installation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "transformers",
     "accelerate",
     "huggingface_hub",
+    "Cython",
+    "scikit-build-core",
     "voxcpm",
     "llama-cpp-python",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,7 @@ demucs
 transformers
 accelerate
 huggingface_hub
+Cython
+scikit-build-core
 voxcpm
 llama-cpp-python


### PR DESCRIPTION
## Summary

- Add Cython and scikit-build-core to the project dependency metadata.
- Document the required Windows installation order for native dependency builds.
- Add guidance about CMake/Ninja, C++ compiler requirements, and Python 3.12 fallback.

## Why

On fresh Windows Python 3.13 installations, VoxCPM can fail while building `editdistance` without Cython, and llama-cpp-python can fail when its scikit-build-core backend is unavailable. This addresses issue #95.

## Validation

- `git diff --cached --check` passed.
- Dependency installation was not run in this environment.