### PR TITLE
Run automatic memory cleanup after every scene render

### DIFF
--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -43392,6 +43392,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const videoPath = await renderSceneVideoWithProgress(renderTarget, renderIndex, progress, {
         existingVideoAction,
       });
+      await runClearMemoryWorkflowQuiet(progress, `${sceneDisplayName(renderTarget, renderIndex)} render`, 98);
       progress.close(900);
       toast(`Scene video ready:\n${videoPath}`);
     } catch (error) {
@@ -43460,6 +43461,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const videoPath = await renderMiniMaxSceneVideoWithProgress(renderTarget, renderIndex, progress, {
         existingVideoAction,
       });
+      await runClearMemoryWorkflowQuiet(progress, `${sceneDisplayName(renderTarget, renderIndex)} render`, 98);
       progress.close(900);
       toast(`MiniMax H3 scene video ready:\n${videoPath}`);
     } catch (error) {


### PR DESCRIPTION
What changed:

When automatic RAM/VRAM cleanup is enabled, single-scene LTX and MiniMax H3 renders now run the same hidden Clear RAM workflow used by the manual Clear RAM button after the scene finishes.

Why:

Render All already performed this cleanup, but the individual Create Scene Video actions did not, allowing model and cache memory to remain allocated between renders.

Impact:

The setting remains authoritative: unchecked skips automatic cleanup, while the manual Clear RAM button remains available at all times.

Validation:

- python -m unittest tests.test_builder_scene_render_timeout tests.test_builder_history_memory
- JavaScript module syntax check via Node
- git diff --check