### PR TITLE
Fix LM Studio vision payloads and preserve Auto Build shot counts

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -3550,7 +3550,9 @@ def _run_lm_studio_vision(payload, instruction_text, pil_images, temperature=0.2
     images = list(pil_images or [])
     if not images:
         raise ValueError("LM Studio vision needs at least one image.")
-    content = [{"type": "message", "role": "user", "content": str(instruction_text or "")}]
+    # Native LM Studio chat accepts multimodal input blocks directly. Do not
+    # wrap the text in an OpenAI-style message object inside `input`.
+    content = [{"type": "text", "content": str(instruction_text or "")}]
     for image in images:
         content.append({
             "type": "image",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -38502,10 +38502,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     const shotPlan = miniMaxH3OfficialShotPlan(cutPlan);
     const rawShots = Array.isArray(parsed?.shots) ? parsed.shots : [];
-    if (rawShots.length !== shotPlan.length) {
+    if (rawShots.length > shotPlan.length) {
       throw new Error(`The LLM returned ${rawShots.length} shot description${rawShots.length === 1 ? "" : "s"}, but the builder expected ${shotPlan.length}.`);
     }
-    return rawShots.map((item, index) => {
+    const normalizedShots = rawShots.slice();
+    if (normalizedShots.length < shotPlan.length) {
+      const missingCount = shotPlan.length - normalizedShots.length;
+      toast(`The LLM returned ${normalizedShots.length} of ${shotPlan.length} shot descriptions; Builder filled ${missingCount} missing shot${missingCount === 1 ? "" : "s"} so the scheduled cuts remain intact.`, true);
+      while (normalizedShots.length < shotPlan.length) normalizedShots.push({});
+    }
+    return normalizedShots.map((item, index) => {
       const description = typeof item === "string" ? item : String(item?.description || item?.text || item?.shot || "").trim();
       if (!description) {
         toast(`Gemma returned a blank description for shot ${index + 1}; Builder filled it from the singer cue map.`, true);
@@ -54156,4 +54162,3 @@ app.registerExtension({
     };
   },
 });
-


### PR DESCRIPTION
Summary
Send LM Studio vision text as a native text input block.
Preserve scheduled cuts when the LLM returns too few shot descriptions.
Continue rejecting responses with excess shots.
Notify users when missing descriptions are filled automatically.
Testing
git diff --check
Runtime verification requires restarting ComfyUI and retrying the workflow.