### PR TITLE
Feature/minimax h3 sol attention

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -3550,7 +3550,9 @@ def _run_lm_studio_vision(payload, instruction_text, pil_images, temperature=0.2
     images = list(pil_images or [])
     if not images:
         raise ValueError("LM Studio vision needs at least one image.")
-    content = [{"type": "message", "role": "user", "content": str(instruction_text or "")}]
+    # Native LM Studio chat accepts multimodal input blocks directly. Do not
+    # wrap the text in an OpenAI-style message object inside `input`.
+    content = [{"type": "text", "content": str(instruction_text or "")}]
     for image in images:
         content.append({
             "type": "image",

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -2504,6 +2504,18 @@ def _require_minimax_h3_memory_efficient_sage_attention():
         ) from exc
 
 
+def _require_minimax_h3_sol_attention():
+    """Check the optional Kijai node before emitting a Sol-Attn workflow node."""
+    custom_nodes_root = os.path.join(folder_paths.base_path, "custom_nodes")
+    node_root = os.path.join(custom_nodes_root, "ComfyUI-SolAttn_triton")
+    if not os.path.isfile(os.path.join(node_root, "__init__.py")):
+        raise RuntimeError(
+            "MiniMax H3 Sol Attention is enabled, but ComfyUI-SolAttn_triton is not installed. "
+            "Install https://github.com/kijai/ComfyUI-SolAttn_triton in ComfyUI/custom_nodes, "
+            "then restart ComfyUI."
+        )
+
+
 def _patch_minimax_h3_advanced_settings(prompt, payload):
     sampler_id = _api_node_id_by_class(prompt, "KSamplerSelect", fallback="123")
     scheduler_id = _api_node_id_by_class(prompt, "BasicScheduler", fallback="124")
@@ -2667,6 +2679,49 @@ def _patch_minimax_h3_memory_efficient_sage_attention(prompt, payload):
     return {"enabled": True, "node": node_id}
 
 
+def _patch_minimax_h3_sol_attention(prompt, payload):
+    enabled = _bool_payload(payload, "use_sol_attention", False)
+    if not enabled:
+        return {"enabled": False, "node": ""}
+
+    _require_minimax_h3_sol_attention()
+    scheduler_id = _api_node_id_by_class(prompt, "BasicScheduler", fallback="124")
+    guider_id = _api_node_id_by_class(prompt, "BasicGuider", fallback="126")
+    model_ref = prompt.get(scheduler_id, {}).get("inputs", {}).get("model")
+    if not isinstance(model_ref, list) or len(model_ref) != 2:
+        raise ValueError("MiniMax H3 Sol Attention patch could not find the current model connection.")
+
+    node_id = "9301"
+    while node_id in prompt:
+        node_id = str(int(node_id) + 1)
+    tau = _float_payload(payload, "sol_attention_tau", 1.3, 0.0, 4.0)
+    start_percent = _float_payload(payload, "sol_attention_start_percentage", 0.2, 0.0, 1.0)
+    end_percent = _float_payload(payload, "sol_attention_end_percentage", 0.9, 0.0, 1.0)
+    min_tokens = _int_payload(payload, "sol_attention_min_tokens", 4096, 0, 1 << 20)
+    prompt[node_id] = {
+        "class_type": "SolAttnPatch",
+        "inputs": {
+            "model": list(model_ref),
+            "tau": tau,
+            "start_percent": start_percent,
+            "end_percent": end_percent,
+            "min_tokens": min_tokens,
+        },
+        "_meta": {"title": "MiniMax H3 Sol Attention"},
+    }
+    patched_ref = [node_id, 0]
+    _set_api_input(prompt, scheduler_id, "model", patched_ref)
+    _set_api_input(prompt, guider_id, "model", patched_ref)
+    return {
+        "enabled": True,
+        "node": node_id,
+        "tau": tau,
+        "start_percent": start_percent,
+        "end_percent": end_percent,
+        "min_tokens": min_tokens,
+    }
+
+
 def _patch_minimax_h3_loras(prompt, payload):
     enabled = _bool_payload(payload, "use_loras", False) or _bool_payload(payload, "use_custom_loras", False)
     if not enabled:
@@ -2757,6 +2812,8 @@ def _patch_minimax_h3_loras(prompt, payload):
 def _build_minimax_h3_api_prompt(payload):
     if _bool_payload(payload, "use_memory_efficient_sage_attention", False):
         _require_minimax_h3_memory_efficient_sage_attention()
+    if _bool_payload(payload, "use_sol_attention", False):
+        _require_minimax_h3_sol_attention()
     raw_audio_mode = str(payload.get("audio_mode") or payload.get("audioMode") or "input_audio").strip().lower().replace("-", "_").replace(" ", "_")
     audio_mode = "built_in_audio" if raw_audio_mode in {"built_in_audio", "native_audio", "generated_audio"} else "input_audio"
     workflow_template = _minimax_h3_built_in_audio_api_template_path() if audio_mode == "built_in_audio" else _minimax_h3_api_template_path()
@@ -2900,6 +2957,7 @@ def _build_minimax_h3_api_prompt(payload):
     lora_settings = _patch_minimax_h3_loras(prompt, payload)
     turbo_settings = _patch_minimax_h3_turbo(prompt, payload)
     memory_efficient_sage_attention = _patch_minimax_h3_memory_efficient_sage_attention(prompt, payload)
+    sol_attention = _patch_minimax_h3_sol_attention(prompt, payload)
     if turbo_settings["enabled"]:
         advanced_settings = {
             **advanced_settings,
@@ -2935,6 +2993,7 @@ def _build_minimax_h3_api_prompt(payload):
         "lora_settings": lora_settings,
         "turbo_settings": turbo_settings,
         "memory_efficient_sage_attention": memory_efficient_sage_attention,
+        "sol_attention": sol_attention,
     }
 
 

--- a/tests/test_builder_minimax_sol_attention.py
+++ b/tests/test_builder_minimax_sol_attention.py
@@ -1,0 +1,92 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+RUNNER_SOURCE = (ROOT / "VRGDG_WorkflowRunnerNodes.py").read_text(encoding="utf-8")
+
+
+def _load_sol_patch():
+    tree = ast.parse(RUNNER_SOURCE)
+    wanted = {
+        "_api_node_id_by_class",
+        "_int_payload",
+        "_float_payload",
+        "_bool_payload",
+        "_set_api_input",
+        "_patch_minimax_h3_sol_attention",
+    }
+    definitions = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    namespace = {}
+    exec(compile(ast.Module(body=definitions, type_ignores=[]), str(ROOT), "exec"), namespace)
+    namespace["_require_minimax_h3_sol_attention"] = lambda: None
+    return namespace["_patch_minimax_h3_sol_attention"]
+
+
+class BuilderMiniMaxSolAttentionTests(unittest.TestCase):
+    def test_video_settings_exposes_a_separate_sol_attention_block_after_fp16(self):
+        sage_block = BUILDER_SOURCE.index('makeSettingsSection("Sage Attention"')
+        fp16 = BUILDER_SOURCE.index("miniMaxFp16Accumulation.wrapper", sage_block)
+        sol_block = BUILDER_SOURCE.index('makeSettingsSection("Sol Attention"', fp16)
+        self.assertLess(sage_block, fp16)
+        self.assertLess(fp16, sol_block)
+        for option in (
+            "use_sol_attention",
+            "sol_attention_tau",
+            "sol_attention_start_percentage",
+            "sol_attention_end_percentage",
+            "sol_attention_min_tokens",
+        ):
+            self.assertIn(option, BUILDER_SOURCE)
+
+    def test_render_payload_persists_all_sol_attention_options(self):
+        payload_start = BUILDER_SOURCE.index("use_sol_attention: miniMaxSolAttention.input.checked")
+        payload = BUILDER_SOURCE[payload_start : payload_start + 500]
+        self.assertIn("sol_attention_tau: miniMaxSolAttentionTau.value", payload)
+        self.assertIn("sol_attention_start_percentage: miniMaxSolAttentionStartPercentage.value", payload)
+        self.assertIn("sol_attention_end_percentage: miniMaxSolAttentionEndPercentage.value", payload)
+        self.assertIn("sol_attention_min_tokens: miniMaxSolAttentionMinTokens.value", payload)
+
+    def test_disabled_sol_attention_does_not_change_the_prompt(self):
+        patch = _load_sol_patch()
+        prompt = {
+            "124": {"class_type": "BasicScheduler", "inputs": {"model": ["141", 0]}},
+            "126": {"class_type": "BasicGuider", "inputs": {"model": ["141", 0]}},
+        }
+        result = patch(prompt, {"use_sol_attention": False})
+        self.assertEqual(result, {"enabled": False, "node": ""})
+        self.assertNotIn("9301", prompt)
+
+    def test_enabled_sol_attention_injects_and_connects_the_patch_node(self):
+        patch = _load_sol_patch()
+        prompt = {
+            "124": {"class_type": "BasicScheduler", "inputs": {"model": ["141", 0]}},
+            "126": {"class_type": "BasicGuider", "inputs": {"model": ["141", 0]}},
+        }
+        result = patch(prompt, {
+            "use_sol_attention": True,
+            "sol_attention_tau": 1.2,
+            "sol_attention_start_percentage": 0.2,
+            "sol_attention_end_percentage": 0.9,
+            "sol_attention_min_tokens": 4096,
+        })
+        self.assertTrue(result["enabled"])
+        self.assertEqual(prompt["9301"]["class_type"], "SolAttnPatch")
+        self.assertEqual(prompt["9301"]["inputs"], {
+            "model": ["141", 0],
+            "tau": 1.2,
+            "start_percent": 0.2,
+            "end_percent": 0.9,
+            "min_tokens": 4096,
+        })
+        self.assertEqual(prompt["124"]["inputs"]["model"], ["9301", 0])
+        self.assertEqual(prompt["126"]["inputs"]["model"], ["9301", 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -38502,10 +38502,16 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     const shotPlan = miniMaxH3OfficialShotPlan(cutPlan);
     const rawShots = Array.isArray(parsed?.shots) ? parsed.shots : [];
-    if (rawShots.length !== shotPlan.length) {
+    if (rawShots.length > shotPlan.length) {
       throw new Error(`The LLM returned ${rawShots.length} shot description${rawShots.length === 1 ? "" : "s"}, but the builder expected ${shotPlan.length}.`);
     }
-    return rawShots.map((item, index) => {
+    const normalizedShots = rawShots.slice();
+    if (normalizedShots.length < shotPlan.length) {
+      const missingCount = shotPlan.length - normalizedShots.length;
+      toast(`The LLM returned ${normalizedShots.length} of ${shotPlan.length} shot descriptions; Builder filled ${missingCount} missing shot${missingCount === 1 ? "" : "s"} so the scheduled cuts remain intact.`, true);
+      while (normalizedShots.length < shotPlan.length) normalizedShots.push({});
+    }
+    return normalizedShots.map((item, index) => {
       const description = typeof item === "string" ? item : String(item?.description || item?.text || item?.shot || "").trim();
       if (!description) {
         toast(`Gemma returned a blank description for shot ${index + 1}; Builder filled it from the singer cue map.`, true);
@@ -54156,4 +54162,3 @@ app.registerExtension({
     };
   },
 });
-

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -245,6 +245,11 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   easy_cache_verbose: false,
   sage_attention: "auto",
   use_memory_efficient_sage_attention: false,
+  use_sol_attention: false,
+  sol_attention_tau: 1.3,
+  sol_attention_start_percentage: 0.2,
+  sol_attention_end_percentage: 0.9,
+  sol_attention_min_tokens: 4096,
   enable_fp16_accumulation: true,
   use_loras: false,
   lora_count: 0,
@@ -424,6 +429,11 @@ function cloneMiniMaxH3Settings(value = {}) {
       ? source.sage_attention
       : DEFAULT_MINIMAX_H3_SETTINGS.sage_attention,
     use_memory_efficient_sage_attention: Boolean(source.use_memory_efficient_sage_attention ?? DEFAULT_MINIMAX_H3_SETTINGS.use_memory_efficient_sage_attention),
+    use_sol_attention: Boolean(source.use_sol_attention ?? DEFAULT_MINIMAX_H3_SETTINGS.use_sol_attention),
+    sol_attention_tau: Number.isFinite(Number(source.sol_attention_tau)) ? Math.max(0, Math.min(4, Number(source.sol_attention_tau))) : DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_tau,
+    sol_attention_start_percentage: Number.isFinite(Number(source.sol_attention_start_percentage)) ? Math.max(0, Math.min(1, Number(source.sol_attention_start_percentage))) : DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_start_percentage,
+    sol_attention_end_percentage: Number.isFinite(Number(source.sol_attention_end_percentage)) ? Math.max(0, Math.min(1, Number(source.sol_attention_end_percentage))) : DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_end_percentage,
+    sol_attention_min_tokens: Math.max(0, Math.min(1048576, Math.trunc(Number(source.sol_attention_min_tokens ?? DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_min_tokens) || DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_min_tokens))),
     enable_fp16_accumulation: Boolean(source.enable_fp16_accumulation ?? DEFAULT_MINIMAX_H3_SETTINGS.enable_fp16_accumulation),
     use_loras: loraEnabled,
     lora_count: loraEnabled ? Math.max(0, Math.min(4, Math.trunc(Number(source.lora_count ?? source.loraCount ?? loras.length) || loras.length))) : 0,
@@ -5625,6 +5635,23 @@ function openBuilder(node) {
   const miniMaxEasyCacheVerbose = makeCheckbox("Verbose EasyCache logging", DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_verbose);
   const miniMaxSageAttention = makeSelect(MINIMAX_H3_SAGE_ATTENTION_OPTIONS, DEFAULT_MINIMAX_H3_SETTINGS.sage_attention);
   const miniMaxMemoryEfficientSageAttention = makeCheckbox("Use memory-efficient MiniMax H3 Sage Attention patch", DEFAULT_MINIMAX_H3_SETTINGS.use_memory_efficient_sage_attention);
+  const miniMaxSolAttention = makeCheckbox("Use MiniMax H3 Sol Attention patch", DEFAULT_MINIMAX_H3_SETTINGS.use_sol_attention);
+  const miniMaxSolAttentionTau = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_tau), "number");
+  miniMaxSolAttentionTau.min = "0";
+  miniMaxSolAttentionTau.max = "4";
+  miniMaxSolAttentionTau.step = "0.05";
+  const miniMaxSolAttentionStartPercentage = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_start_percentage), "number");
+  miniMaxSolAttentionStartPercentage.min = "0";
+  miniMaxSolAttentionStartPercentage.max = "1";
+  miniMaxSolAttentionStartPercentage.step = "0.01";
+  const miniMaxSolAttentionEndPercentage = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_end_percentage), "number");
+  miniMaxSolAttentionEndPercentage.min = "0";
+  miniMaxSolAttentionEndPercentage.max = "1";
+  miniMaxSolAttentionEndPercentage.step = "0.01";
+  const miniMaxSolAttentionMinTokens = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.sol_attention_min_tokens), "number");
+  miniMaxSolAttentionMinTokens.min = "0";
+  miniMaxSolAttentionMinTokens.max = "1048576";
+  miniMaxSolAttentionMinTokens.step = "512";
   const miniMaxFp16Accumulation = makeCheckbox("Enable fp16 accumulation", DEFAULT_MINIMAX_H3_SETTINGS.enable_fp16_accumulation);
   const miniMaxEasyCacheNote = document.createElement("div");
   miniMaxEasyCacheNote.textContent = "Bypass sends the diffusion model directly to the scheduler and removes EasyCache from the queued workflow copy.";
@@ -5645,9 +5672,18 @@ function openBuilder(node) {
       miniMaxEasyCacheVerbose.wrapper,
     ]),
     makeSettingsSection("Model Loader", [
-      makeField("Sage Attention", miniMaxSageAttention),
-      miniMaxMemoryEfficientSageAttention.wrapper,
+      makeSettingsSection("Sage Attention", [
+        makeField("Sage Attention", miniMaxSageAttention),
+        miniMaxMemoryEfficientSageAttention.wrapper,
+      ]),
       miniMaxFp16Accumulation.wrapper,
+      makeSettingsSection("Sol Attention", [
+        miniMaxSolAttention.wrapper,
+        makeField("Tau", miniMaxSolAttentionTau),
+        makeField("Start percentage", miniMaxSolAttentionStartPercentage),
+        makeField("End percentage", miniMaxSolAttentionEndPercentage),
+        makeField("Minimum tokens", miniMaxSolAttentionMinTokens),
+      ]),
     ]),
   ], false);
   const miniMaxTextModePanel = makeSettingsPanel([]);
@@ -6794,6 +6830,11 @@ function openBuilder(node) {
       easy_cache_verbose: miniMaxEasyCacheVerbose.input.checked,
       sage_attention: miniMaxSageAttention.value,
       use_memory_efficient_sage_attention: miniMaxMemoryEfficientSageAttention.input.checked,
+      use_sol_attention: miniMaxSolAttention.input.checked,
+      sol_attention_tau: miniMaxSolAttentionTau.value,
+      sol_attention_start_percentage: miniMaxSolAttentionStartPercentage.value,
+      sol_attention_end_percentage: miniMaxSolAttentionEndPercentage.value,
+      sol_attention_min_tokens: miniMaxSolAttentionMinTokens.value,
       enable_fp16_accumulation: miniMaxFp16Accumulation.input.checked,
       use_loras: loraEnabled,
       lora_count: loraCount,
@@ -7427,6 +7468,11 @@ function openBuilder(node) {
     miniMaxEasyCacheVerbose.input.checked = settings.easy_cache_verbose;
     miniMaxSageAttention.value = settings.sage_attention;
     miniMaxMemoryEfficientSageAttention.input.checked = settings.use_memory_efficient_sage_attention;
+    miniMaxSolAttention.input.checked = settings.use_sol_attention;
+    miniMaxSolAttentionTau.value = String(settings.sol_attention_tau);
+    miniMaxSolAttentionStartPercentage.value = String(settings.sol_attention_start_percentage);
+    miniMaxSolAttentionEndPercentage.value = String(settings.sol_attention_end_percentage);
+    miniMaxSolAttentionMinTokens.value = String(settings.sol_attention_min_tokens);
     miniMaxFp16Accumulation.input.checked = settings.enable_fp16_accumulation;
     miniMaxUseLoras.input.checked = settings.use_loras;
     miniMaxLoraCount.value = String(settings.lora_count || 0);


### PR DESCRIPTION
## Summary

- Add optional Kijai Sol Attention support for MiniMax H3 workflows.
- Expose `tau`, start percentage, end percentage, and minimum tokens.
- Add Sol Attention as a separate Advanced Settings block after fp16 accumulation.
- Allow Sol Attention to be used alongside Sage Attention.
- Add regression tests for UI persistence and workflow node injection.

## Validation

- Sol Attention unit tests: 4 passed.
- Python and JavaScript syntax checks passed.
- `git diff --check` passed.