### PR TITLE
Fix LTX 2.5 T2V custom audio routing

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -1782,10 +1782,29 @@ def _patch_t2v_api_prompt(prompt, payload):
     tail_loss_frames = _int_payload(payload, "tail_loss_frames", 25, 0, 10000)
     pre_frames = _int_payload(payload, "pre_frames", 50, 0, 10000)
 
-    _patch_ltx_video_model_loader(prompt, payload)
+    is_ltx25 = str(payload.get("ltx_version", "2.3") or "2.3").strip() == "2.5"
+    if is_ltx25:
+        # Keep the proven custom-audio T2V graph and replace only the legacy
+        # diffusion/CLIP pieces, matching the LTX 2.5 I2V and RTV adapters.
+        prompt["938"] = _ltx25_diffusion_loader_node(payload)
+        prompt["937"]["inputs"]["model"] = ["938", 0]
+        prompt.pop("939", None)
+        prompt.pop("271:215", None)
+        prompt["271:216"] = {
+            "inputs": {
+                "clip_name": str(payload.get("clip_name1", "") or ""),
+                "type": "ltxv",
+                "device": "default",
+            },
+            "class_type": "CLIPLoader",
+            "_meta": {"title": "Load LTX 2.5 CLIP"},
+        }
+    else:
+        _patch_ltx_video_model_loader(prompt, payload)
     _set_api_input(prompt, "271:256", "vae_name", str(payload.get("vae_name", "") or ""))
-    _set_api_input(prompt, "271:216", "clip_name1", str(payload.get("clip_name1", "") or ""))
-    _set_api_input(prompt, "271:216", "clip_name2", str(payload.get("clip_name2", "") or ""))
+    if not is_ltx25:
+        _set_api_input(prompt, "271:216", "clip_name1", str(payload.get("clip_name1", "") or ""))
+        _set_api_input(prompt, "271:216", "clip_name2", str(payload.get("clip_name2", "") or ""))
     _set_api_input(prompt, "271:211", "model_name", str(payload.get("upscale_model_name", "") or ""))
     _set_api_input(prompt, "271:254", "vae_name", str(payload.get("audio_vae_name", "") or ""))
 
@@ -3444,13 +3463,11 @@ def _build_i2v_api_prompt(payload):
 
 
 def _build_t2v_api_prompt(payload):
-    version = str(payload.get("ltx_version", "2.5") or "2.5").strip()
-    if version == "2.3":
-        workflow_path, prompt = _load_api_template(_t2v_api_template_path())
-        patched_prompt, output_folder = _patch_t2v_api_prompt(prompt, payload)
-    else:
-        workflow_path, prompt = _load_api_template(_t2v_25_api_template_path())
-        patched_prompt, output_folder = _patch_t2v_25_api_prompt(prompt, payload)
+    # Both versions use the custom-audio T2V graph. LTX 2.5 is adapted in the
+    # patcher by swapping the diffusion and CLIP nodes; the native-audio graph
+    # is intentionally not used by the Video Builder.
+    workflow_path, prompt = _load_api_template(_t2v_api_template_path())
+    patched_prompt, output_folder = _patch_t2v_api_prompt(prompt, payload)
     return {
         "workflow_path": workflow_path,
         "output_folder": output_folder,

--- a/update_notes.json
+++ b/update_notes.json
@@ -15,7 +15,7 @@
           "title": "Added",
           "items": [
             "Added LTX 2.5 as the default LTX engine version, with LTX 2.3 retained as a legacy option for older GGUF and dual-CLIP workflows.",
-            "Added native LTX 2.5 Text to Video with built-in audio and Reference to Video workflow templates, including the LTX 2.5 video VAE, audio VAE, latent spatial upscaler, and required Licon MSR LoRA selections.",
+            "Added LTX 2.5 Text to Video and Reference to Video support using the existing custom/project-audio workflow, including the LTX 2.5 video VAE, audio VAE, latent spatial upscaler, and required Licon MSR LoRA selections.",
             "Added an experimental MiniMax H3 Ref to Video 3 Pass mode. Stage 1 establishes the scene, Stage 2 refines it, and Stage 3 produces the final clip used by timeline stitching.",
             "Added independent three-pass controls for megapixels, steps, denoise, sampler, scheduler, seed, and TE-Speed on every pass, plus a dedicated LightX LoRA and strength control.",
             "Added automatic Stage 1 and Stage 2 backup collection for three-pass renders so intermediate results remain available for review while Stage 3 becomes the selected scene video.",
@@ -30,7 +30,8 @@
             "Storyboard scene defaults, camera motion, character motion, performance direction, visual effects, and cut plans now apply consistently to both MiniMax and LTX projects.",
             "MiniMax two-pass and three-pass progress messages now identify the active stage sequence and explain which intermediate clips are retained and which stage will be used for final stitching.",
             "MiniMax three-pass settings now save immediately, restore with the project session, and expose only controls that affect the selected rendering mode.",
-            "LTX 2.5 generated-audio projects no longer require an external audio file; modes that are only supported by legacy LTX 2.3 are clearly identified in Builder Settings."
+            "LTX 2.5 Text to Video now dynamically swaps the diffusion and CLIP nodes in the proven custom-audio T2V graph instead of forcing the native-audio graph.",
+            "All supported LTX Builder modes preserve supplied project/global or custom scene audio and its SRT timing."
           ]
         },
         {
@@ -44,7 +45,8 @@
             "Fixed LTX prompt generation to return one clean generation-ready prompt without internal headings, metadata labels, duplicated cut instructions, or MiniMax-only formatting.",
             "Fixed Storyboard saves that could appear to fail after the project had already saved successfully because unrelated panel settings were re-normalized afterward.",
             "Fixed side-panel Gemma generation so scenes without a usable image reference fall back to the text-only prompt path instead of failing the request.",
-            "Fixed LTX storyboard scene-beat handoff, singer/lip-sync guidance, and exact-duration cut planning so regenerated prompts preserve the intended performance and editing structure."
+            "Fixed LTX storyboard scene-beat handoff, singer/lip-sync guidance, and exact-duration cut planning so regenerated prompts preserve the intended performance and editing structure.",
+            "Fixed LTX 2.5 Text to Video custom-audio routing without using the legacy GGUF path."
           ]
         },
         {
@@ -53,6 +55,7 @@
             "Restart ComfyUI and hard-refresh the browser after updating so the new Python routes, workflow templates, Builder JavaScript, and Storyboard JavaScript are loaded.",
             "The included workflow templates do not download models. Install the matching LTX 2.5 and MiniMax H3 model files and select them in Builder Settings before rendering.",
             "MiniMax H3 two-pass and three-pass modes currently require Input Audio. Built-in MiniMax audio continues to use the existing one-pass workflow.",
+            "LTX 2.5 Text to Video uses custom/project audio; the native-audio T2V template is not used by the Video Builder.",
             "LTX 2.5 is now the default for new LTX projects. Existing projects retain their saved engine version and settings whenever those values are present.",
             "Three-pass Stage 1 and Stage 2 videos are review backups; Stage 3 is the final scene video used by Render All and timeline stitching."
           ]

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -44387,7 +44387,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       progress?.set(`${batchLabel}Preparing text-to-video render...`, pct(12));
     }
     const videoSettingsForScene = i2vVideoSettingsForSegment(segment);
-    const isLtx25NativeAudio = videoMode === "t2v" && videoSettingsForScene.ltx_version !== "2.3";
+    // LTX 2.5 uses the existing custom/project-audio T2V graph with dynamic
+    // diffusion and CLIP node replacement. Native-audio T2V is not used by
+    // the Video Builder, so all LTX versions follow the same audio path.
+    const isLtx25NativeAudio = false;
     const idLoraContext = isIdLoraMode ? idLoraSceneContext(segment) : null;
     if (isIdLoraMode && idLoraContext?.dialogue) {
       segment.lyric_text = idLoraContext.dialogue;


### PR DESCRIPTION
## Summary

- Keep the existing proven custom/project-audio Text to Video workflow for LTX 2.5.
- Dynamically replace the legacy diffusion and CLIP nodes with the LTX 2.5 diffusion loader and LTX 2.5 CLIP node.
- Preserve custom scene audio, project/global audio, SRT timing, trimming, and audio-driven generation.
- Stop routing LTX 2.5 T2V through the native-audio template.
- Update the user-facing release notes to describe the corrected behavior.

## Validation

- `python -B -m py_compile VRGDG_WorkflowRunnerNodes.py`
- `update_notes.json` parses successfully.

This is a follow-up to the already merged Builder update. Nothing in this PR changes Face Fix files or local configuration files.