### PR TITLE
Fix submodule import error by removing nonexistent VRGDG_FaceFixBatch…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,7 +47,6 @@ _VRGDG_SUBMODULES = (
     ".VRGDG_SilentAudioRoutes",
     ".VRGDG_UpdateRoutes",
     ".VRGDG_VideoBuilderNodeUI",
-    ".VRGDG_FaceFixBatchNode",
     ".VRGDG_LoraDatasetCreatorNodes",
 )
 

--- a/tests/test_init_submodules.py
+++ b/tests/test_init_submodules.py
@@ -1,0 +1,33 @@
+import ast
+import os
+import unittest
+
+
+class InitSubmodulesTests(unittest.TestCase):
+    def test_all_submodules_exist(self):
+        repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        init_py = os.path.join(repo_dir, "__init__.py")
+        self.assertTrue(os.path.isfile(init_py))
+
+        with open(init_py, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Parse _VRGDG_SUBMODULES tuple
+        tree = ast.parse(content)
+        submodules = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "_VRGDG_SUBMODULES":
+                        submodules = [elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)]
+        self.assertIsNotNone(submodules)
+        for modname in submodules:
+            py_file = os.path.join(repo_dir, f"{modname.lstrip('.')}.py")
+            self.assertTrue(
+                os.path.isfile(py_file),
+                f"Submodule '{modname}' referenced in _VRGDG_SUBMODULES does not exist at {py_file}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes:

  1. Removed Non-Existent Submodule: Deleted ".VRGDG_FaceFixBatchNode", from _VRGDG_SUBMODULES in __init__.py:48-53.
  2. Added Unit Test: Created test_init_submodules.py to automatically verify that every registered submodule exists
  on disk.
  3. Verified Locally: The custom node pack now imports cleanly without any missing module errors.
