### PR TITLE
Expose MiniMax multipass reference image sizing

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -232,7 +232,7 @@ def _minimax_h3_2pass_api_template_path():
         os.path.dirname(os.path.abspath(__file__)),
         "Workflows",
         "UsedForUIDoNotTouch",
-        "minimax_ref2video_2pass_audio_driven_api.json",
+        "minimax_audio_driven_builder_latent_upscale_2pass_api.json",
     )
 
 
@@ -3159,69 +3159,136 @@ def _build_minimax_h3_2pass_api_prompt(payload):
     clip_name = str(payload.get("clip_name") or "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors").strip()
     video_vae_name = str(payload.get("video_vae_name") or "minimax_h3_video_vae_fp16.safetensors").strip()
     audio_vae_name = str(payload.get("audio_vae_name") or "minimax_h3_audio_vae_fp32.safetensors").strip()
+    latent_upscaler_name = str(payload.get("latent_upscaler_name") or "minimax_h3_latent_upscaler_3d_bf16.safetensors").strip()
     _require_model_choice(("diffusion_models", "unet"), diffusion_model_name, "MiniMax H3 two-pass diffusion model")
     _require_model_choice(("text_encoders", "clip"), clip_name, "MiniMax H3 two-pass text encoder")
     _require_model_choice("vae", video_vae_name, "MiniMax H3 two-pass video VAE")
     _require_model_choice("vae", audio_vae_name, "MiniMax H3 two-pass audio VAE")
+    _require_model_choice("latent_upscale_models", latent_upscaler_name, "MiniMax H3 learned latent upscaler")
 
     seed = _int_payload(payload, "seed", 69, 0, 0xFFFFFFFFFFFFFFFF)
     pass1_seed = _int_payload(payload, "pass1_seed", seed, 0, 0xFFFFFFFFFFFFFFFF)
     pass2_seed = _int_payload(payload, "pass2_seed", seed, 0, 0xFFFFFFFFFFFFFFFF)
-    aspect_ratio = str(payload.get("aspect_ratio") or "16:9 (Widescreen)").strip()
-    if aspect_ratio not in _MINIMAX_H3_ASPECT_RATIOS:
-        raise ValueError(f"Unsupported MiniMax H3 two-pass aspect ratio: {aspect_ratio}")
+    final_width = _int_payload(payload, "final_width", 1920, 64, 16384)
+    final_height = _int_payload(payload, "final_height", 1080, 64, 16384)
+    latent_scale = _float_payload(payload, "latent_upscale_scale", 2.0, 1.0, 8.0)
 
-    _set_api_input(prompt, "83", "text", video_prompt)
-    # Recent ComfyUI node schemas require these fields explicitly; older
-    # exported API workflows omitted them from the JSON.
-    _set_api_input(prompt, "83", "output_mode", "string")
-    _set_api_input(prompt, "92", "expression", "max(5, round(a * 24)) + (5 - (max(5, round(a * 24)) % 17)) % 17")
-    _set_api_input(prompt, "84", "value", float(timing.workflow_duration_input_seconds))
-    _set_api_input(prompt, "9001", "audio_file", prepared_audio["audio_path"])
-    _set_api_input(prompt, "9001", "seek_seconds", 0)
-    _set_api_input(prompt, "9001", "duration", 0)
-    _set_api_input(prompt, "9000", "image_paths", json.dumps(image_paths, ensure_ascii=False))
-    _set_api_input(prompt, "9000", "video_references", json.dumps(video_references, ensure_ascii=False))
+    _set_api_input(prompt, "138", "value", video_prompt)
+    _set_api_input(prompt, "132", "value", float(timing.workflow_duration_input_seconds))
+    _set_api_input(prompt, "171", "audio_file", prepared_audio["audio_path"])
+    _set_api_input(prompt, "171", "seek_seconds", 0)
+    _set_api_input(prompt, "171", "duration", 0)
+    _set_api_input(prompt, "180", "image_paths", json.dumps(image_paths, ensure_ascii=False))
+    _set_api_input(prompt, "180", "video_references", json.dumps(video_references, ensure_ascii=False))
     ref_image_size = str(payload.get("ref_image_size") or "max").strip().lower()
-    if ref_image_size not in {"match", "max"}:
-        ref_image_size = "max"
-    _set_api_input(prompt, "108", "ref_image_size", ref_image_size)
-    _set_api_input(prompt, "105", "aspect_ratio", aspect_ratio)
-    _set_api_input(prompt, "105", "megapixels", _float_payload(payload, "pass1_megapixels", 0.5, 0.1, 16.0))
-    _set_api_input(prompt, "297", "aspect_ratio", str(payload.get("pass2_aspect_ratio") or aspect_ratio))
-    _set_api_input(prompt, "297", "megapixels", _float_payload(payload, "pass2_megapixels", 1.5, 0.1, 16.0))
-    _set_api_input(prompt, "248", "steps", _int_payload(payload, "pass1_steps", 15, 1, 1000))
-    _set_api_input(prompt, "290", "steps", _int_payload(payload, "pass2_steps", 4, 1, 1000))
-    _set_api_input(prompt, "249", "sampler_name", str(payload.get("pass1_sampler_name") or payload.get("sampler_name") or "euler").strip() or "euler")
-    _set_api_input(prompt, "289", "sampler_name", str(payload.get("pass2_sampler_name") or payload.get("sampler_name") or "euler").strip() or "euler")
-    _set_api_input(prompt, "248", "scheduler", str(payload.get("pass1_scheduler") or payload.get("scheduler") or "beta").strip() or "beta")
-    _set_api_input(prompt, "290", "scheduler", str(payload.get("pass2_scheduler") or payload.get("scheduler") or "beta").strip() or "beta")
-    _set_api_input(prompt, "248", "denoise", _float_payload(payload, "pass1_denoise", 1.0, 0.0, 1.0))
-    _set_api_input(prompt, "290", "denoise", _float_payload(payload, "pass2_denoise", 0.2, 0.0, 1.0))
-    _set_api_input(prompt, "243", "noise_seed", pass1_seed)
-    _set_api_input(prompt, "300", "noise_seed", pass2_seed)
-    _set_api_input(prompt, "9", "unet_name", diffusion_model_name)
-    _set_api_input(prompt, "4", "clip_name", clip_name)
-    _set_api_input(prompt, "5", "vae_name", video_vae_name)
-    _set_api_input(prompt, "6", "vae_name", audio_vae_name)
-    lightx_lora_name = _clean_lora_name(payload.get("two_pass_lora_name", "minimax_h3_turbo_v4_step600_ema.safetensors"))
-    if lightx_lora_name == _NONE_LORA:
-        raise ValueError("A valid Multi-Pass LightX2V LoRA must be selected.")
-    _require_model_choice("loras", lightx_lora_name, "MiniMax H3 two-pass LoRA")
-    _set_api_input(prompt, "187", "model", ["125", 0])
-    _set_api_input(prompt, "187", "lora_name", lightx_lora_name)
-    _set_api_input(prompt, "187", "strength_model", _float_payload(payload, "two_pass_lora_strength", 0.7, -10.0, 10.0))
-    for node_id in ("248", "246", "290", "294"):
-        _set_api_input(prompt, node_id, "model", ["187", 0])
-    if _bool_payload(payload, "use_loras", False):
-        _patch_minimax_h3_loras(prompt, payload)
-        pass1_model = prompt.get("248", {}).get("inputs", {}).get("model")
-        if isinstance(pass1_model, list) and len(pass1_model) == 2:
-            _set_api_input(prompt, "290", "model", list(pass1_model))
-            _set_api_input(prompt, "294", "model", list(pass1_model))
+    _set_api_input(prompt, "136", "ref_image_size", ref_image_size if ref_image_size in {"match", "max"} else "max")
+
+    _set_api_input(prompt, "115", "value", final_width)
+    _set_api_input(prompt, "184", "value", final_height)
+    _set_api_input(prompt, "185", "value", latent_scale)
+    _set_api_input(prompt, "188", "model_name", latent_upscaler_name)
+    _set_api_input(prompt, "188", "device", str(payload.get("latent_upscaler_device") or "cuda"))
+    _set_api_input(prompt, "188", "precision", str(payload.get("latent_upscaler_precision") or "bf16"))
+
+    _set_api_input(prompt, "129", "noise_seed", pass1_seed)
+    _set_api_input(prompt, "211", "noise_seed", pass2_seed)
+    _set_api_input(prompt, "123", "sampler_name", str(payload.get("pass1_sampler_name") or "res_multistep").strip() or "res_multistep")
+    _set_api_input(prompt, "210", "sampler_name", str(payload.get("pass2_sampler_name") or "res_multistep").strip() or "res_multistep")
+    _set_api_input(prompt, "124", "scheduler", str(payload.get("pass1_scheduler") or "simple").strip() or "simple")
+    _set_api_input(prompt, "124", "steps", _int_payload(payload, "pass1_steps", 20, 1, 1000))
+    _set_api_input(prompt, "124", "denoise", _float_payload(payload, "pass1_denoise", 1.0, 0.0, 1.0))
+    _set_api_input(prompt, "192", "scheduler", str(payload.get("pass2_scheduler") or "simple").strip() or "simple")
+    _set_api_input(prompt, "190", "value", _int_payload(payload, "pass2_steps", 5, 1, 1000))
+    _set_api_input(prompt, "191", "value", _float_payload(payload, "pass2_denoise", 0.2, 0.0, 1.0))
+
+    _set_api_input(prompt, "141", "model_name", diffusion_model_name)
+    _set_api_input(prompt, "141", "sage_attention", str(payload.get("sage_attention") or "auto"))
+    _set_api_input(prompt, "141", "enable_fp16_accumulation", _bool_payload(payload, "enable_fp16_accumulation", True))
+    _set_api_input(prompt, "128", "clip_name", clip_name)
+    _set_api_input(prompt, "119", "vae_name", video_vae_name)
+    _set_api_input(prompt, "120", "vae_name", audio_vae_name)
+
+    turbo_lora_name = _clean_lora_name(payload.get("two_pass_lora_name", "minimax_h3_ref2v_turbo_4step_v0.1_comfyui_bf16.safetensors"))
+    if turbo_lora_name == _NONE_LORA:
+        raise ValueError("Select the MiniMax H3 two-pass Turbo LoRA; it is required by this fast workflow.")
+    _require_model_choice("loras", turbo_lora_name, "MiniMax H3 two-pass Turbo LoRA")
+    _set_api_input(prompt, "207", "lora_name", turbo_lora_name)
+    _set_api_input(prompt, "207", "strength_model", _float_payload(payload, "two_pass_lora_strength", 1.0, -10.0, 10.0))
+
+    use_te_speed = _bool_payload(payload, "two_pass_use_te_speed", True)
+    # Bypassing is done by routing the LoRA loader directly from the diffusion
+    # model, so the TE-Speed node is not part of the executed dependency graph.
+    _set_api_input(prompt, "207", "model", ["208", 0] if use_te_speed else ["141", 0])
+    _set_api_input(prompt, "208", "model", ["141", 0])
+    _set_api_input(prompt, "208", "processing_control_value", _float_payload(payload, "te_speed_processing_control", 0.07, 0.0, 1.0))
+    _set_api_input(prompt, "208", "processing_percent_1", _float_payload(payload, "te_speed_start_percent", 0.1, 0.0, 1.0))
+    _set_api_input(prompt, "208", "processing_percent_2", _float_payload(payload, "te_speed_end_percent", 0.9, 0.0, 1.0))
+    _set_api_input(prompt, "208", "mcs", _int_payload(payload, "te_speed_mcs", 2, 1, 64))
+    _set_api_input(prompt, "208", "cache_depth", _float_payload(payload, "te_speed_cache_depth", 0.75, 0.0, 1.0))
+    _set_api_input(prompt, "208", "device", str(payload.get("te_speed_device") or "auto"))
+    pass1_model = ["208", 0] if use_te_speed else ["141", 0]
+    pass2_model = ["207", 0]
+
+    extra_loras = []
+    if _bool_payload(payload, "use_loras", False) or _bool_payload(payload, "use_custom_loras", False):
+        raw_loras = payload.get("loras") if isinstance(payload.get("loras"), list) else []
+        lora_count = _int_payload(payload, "lora_count", len(raw_loras), 0, 4)
+        for item in raw_loras[:lora_count]:
+            if not isinstance(item, dict):
+                continue
+            name = _clean_lora_name(item.get("name") or item.get("lora_name") or item.get("loraName") or _NONE_LORA)
+            if not name or name == _NONE_LORA:
+                continue
+            if not _model_choice_exists("loras", name):
+                raise ValueError(
+                    f"MiniMax extra LoRA '{name}' was not found in ComfyUI/models/loras. "
+                    "Download it, refresh/restart ComfyUI, and select it in MiniMax Video Settings."
+                )
+            apply_to = str(item.get("apply_to") or item.get("applyTo") or "both").strip().lower()
+            if apply_to not in {"both", "pass1", "pass2"}:
+                apply_to = "both"
+            extra_loras.append({
+                "name": name,
+                "strength": _float_payload(item, "strength", 1.0, -10.0, 10.0),
+                "apply_to": apply_to,
+            })
+
+    next_lora_node_id = 9201
+    applied_extra_loras = []
+
+    def add_extra_lora(model_ref, item, target, index):
+        nonlocal next_lora_node_id
+        while str(next_lora_node_id) in prompt:
+            next_lora_node_id += 1
+        node_id = str(next_lora_node_id)
+        next_lora_node_id += 1
+        prompt[node_id] = {
+            "class_type": "LoraLoaderModelOnly",
+            "inputs": {
+                "model": list(model_ref),
+                "lora_name": item["name"],
+                "strength_model": item["strength"],
+            },
+            "_meta": {"title": f"Extra MiniMax LoRA {index} - {target}"},
+        }
+        applied_extra_loras.append({**item, "target": target, "node": node_id})
+        return [node_id, 0]
+
+    for index, item in enumerate(extra_loras, start=1):
+        if item["apply_to"] in {"both", "pass1"}:
+            pass1_model = add_extra_lora(pass1_model, item, "pass1", index)
+        if item["apply_to"] in {"both", "pass2"}:
+            pass2_model = add_extra_lora(pass2_model, item, "pass2", index)
+
+    for node_id in ("124", "126"):
+        _set_api_input(prompt, node_id, "model", list(pass1_model))
+    for node_id in ("192", "193"):
+        _set_api_input(prompt, node_id, "model", list(pass2_model))
+
+    _set_api_input(prompt, "183", "upscale_method", str(payload.get("final_resize_method") or "nvidia_rtx_vsr"))
+    _set_api_input(prompt, "142", "crf", _int_payload(payload, "output_crf", 19, 0, 100))
     output_folder, filename_prefix = _minimax_h3_output_location(project_folder, scene_number)
-    _set_api_input(prompt, "298", "filename_prefix", f"{filename_prefix}_stage1")
-    _set_api_input(prompt, "299", "filename_prefix", f"{filename_prefix}_stage2")
+    _set_api_input(prompt, "142", "filename_prefix", f"{filename_prefix}_stage2")
     return {
         "workflow_path": workflow_path,
         "output_folder": output_folder,
@@ -3232,7 +3299,15 @@ def _build_minimax_h3_2pass_api_prompt(payload):
         "prepared_audio": prepared_audio,
         "post_render_trim": {"start": timing.final_trim_start_seconds, "duration": timing.final_trim_duration_seconds},
         "reference_inputs": {"image_count": len(image_paths), "video_count": len(video_references)},
-        "two_pass": {"pass1_steps": prompt["248"]["inputs"]["steps"], "pass2_steps": prompt["290"]["inputs"]["steps"]},
+        "two_pass": {
+            "pass1_steps": prompt["124"]["inputs"]["steps"],
+            "pass2_steps": prompt["190"]["inputs"]["value"],
+            "final_width": final_width,
+            "final_height": final_height,
+            "latent_upscale_scale": latent_scale,
+            "te_speed_enabled": use_te_speed,
+            "extra_loras": applied_extra_loras,
+        },
     }
 
 

--- a/Workflows/UsedForUIDoNotTouch/minimax_audio_driven_builder_latent_upscale_2pass_api.json
+++ b/Workflows/UsedForUIDoNotTouch/minimax_audio_driven_builder_latent_upscale_2pass_api.json
@@ -1,0 +1,616 @@
+{
+  "115": {
+    "inputs": {
+      "value": 1920
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "BUILDER INPUT - Desired Final Width"
+    }
+  },
+  "119": {
+    "inputs": {
+      "vae_name": "minimax_h3_video_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Video VAE"
+    }
+  },
+  "120": {
+    "inputs": {
+      "vae_name": "minimax_h3_audio_vae_fp32.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Audio VAE"
+    }
+  },
+  "122": {
+    "inputs": {
+      "samples": [
+        "194",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode - Two-Pass Refined Upscaled Latent"
+    }
+  },
+  "123": {
+    "inputs": {
+      "sampler_name": "res_multistep"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "124": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": 20,
+      "denoise": 1,
+      "model": [
+        "208",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "BasicScheduler"
+    }
+  },
+  "125": {
+    "inputs": {
+      "noise": [
+        "129",
+        0
+      ],
+      "guider": [
+        "126",
+        0
+      ],
+      "sampler": [
+        "123",
+        0
+      ],
+      "sigmas": [
+        "124",
+        0
+      ],
+      "latent_image": [
+        "172",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "Low Resolution Generation"
+    }
+  },
+  "126": {
+    "inputs": {
+      "model": [
+        "208",
+        0
+      ],
+      "conditioning": [
+        "136",
+        0
+      ]
+    },
+    "class_type": "BasicGuider",
+    "_meta": {
+      "title": "Basic Guider"
+    }
+  },
+  "128": {
+    "inputs": {
+      "clip_name": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "129": {
+    "inputs": {
+      "noise_seed": 910588682130454
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "BUILDER INPUT - Seed"
+    }
+  },
+  "131": {
+    "inputs": {
+      "expression": "max(5, round(a * 24)) + (5 - (max(5, round(a * 24)) % 17)) % 17",
+      "values.a": [
+        "132",
+        0
+      ]
+    },
+    "class_type": "ComfyMathExpression",
+    "_meta": {
+      "title": "H3 Duration To Valid Frame Count"
+    }
+  },
+  "132": {
+    "inputs": {
+      "value": 8
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "BUILDER INPUT - Duration"
+    }
+  },
+  "136": {
+    "inputs": {
+      "prompt": [
+        "138",
+        0
+      ],
+      "width": [
+        "186",
+        1
+      ],
+      "height": [
+        "187",
+        1
+      ],
+      "length": [
+        "131",
+        1
+      ],
+      "ref_image_size": "max",
+      "clip": [
+        "128",
+        0
+      ],
+      "vae": [
+        "119",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ],
+      "ref_images.ref_image_0": [
+        "180",
+        0
+      ],
+      "ref_images.ref_image_1": [
+        "180",
+        1
+      ],
+      "ref_images.ref_image_2": [
+        "180",
+        2
+      ],
+      "ref_images.ref_image_3": [
+        "180",
+        3
+      ],
+      "ref_images.ref_image_4": [
+        "180",
+        4
+      ],
+      "ref_images.ref_image_5": [
+        "180",
+        5
+      ],
+      "ref_images.ref_image_6": [
+        "180",
+        6
+      ],
+      "ref_images.ref_image_7": [
+        "180",
+        7
+      ],
+      "ref_images.ref_image_8": [
+        "180",
+        8
+      ],
+      "ref_videos.ref_video_0": [
+        "180",
+        9
+      ],
+      "ref_videos.ref_video_1": [
+        "180",
+        10
+      ],
+      "ref_videos.ref_video_2": [
+        "180",
+        11
+      ],
+      "ref_video_audios.ref_video_audio_0": [
+        "180",
+        12
+      ],
+      "ref_video_audios.ref_video_audio_1": [
+        "180",
+        13
+      ],
+      "ref_video_audios.ref_video_audio_2": [
+        "180",
+        14
+      ],
+      "ref_audios.ref_audio_0": [
+        "171",
+        0
+      ]
+    },
+    "class_type": "MiniMaxH3ReferenceToVideo",
+    "_meta": {
+      "title": "MiniMax H3 Reference to Video"
+    }
+  },
+  "138": {
+    "inputs": {
+      "value": "Generate an 8-second 16:9 photorealistic cinematic video.\n\nImage 1: character appearance and clothing reference. Preserve the woman’s exact facial features, long wavy black hair, smoky dark eye makeup, nose ring, layered necklaces, black leather jacket, black lace-up crop top, ripped black jeans with chains, and black platform boots throughout the entire video.\n\n[0s–2.5s]\nExtreme close-up of the woman’s face as she stands motionless in the middle of a modern city street during daytime. Frame from forehead to just below the lips. She looks directly into the camera with a calm, intense expression. Natural daylight reflects softly in her eyes; a light breeze moves a few strands of her black hair. The distant city background is heavily blurred with moving traffic and pedestrians far behind her. Camera makes a very subtle slow push toward her face.\n\n[2.5s–5s]\nHard cut to an upper-body medium shot, framed from her head to just below her waist. She remains in exactly the same position in the street, facing camera. Her black leather jacket, lace-up crop top, layered necklaces, and chains are clearly visible. She slightly shifts her shoulders and tilts her chin upward while maintaining the same confident expression. Cars pass in the distant background without approaching her. Camera stays mostly locked with slight natural cinematic movement.\n\n[5s–8s]\nHard cut to a full-body shot showing her from head to boots, centered in the middle of the city street. Preserve the same direction, lighting, street position, clothing, hairstyle, and accessories. Her ripped black jeans, hanging chains, and platform boots are fully visible. She stands with her feet slightly apart and arms relaxed at her sides. The camera slowly pulls backward, revealing more buildings, parked cars, traffic signals, and the broad daytime street around her. End with her still centered and staring directly into the lens.\n\nAudio: Native city ambience throughout: distant engines, tires on pavement, occasional faint horn, pedestrian movement, and a soft daytime urban breeze. A low, restrained cinematic bass pulse begins at 0s. Add subtle hard-cut impact sounds exactly at 2.5s and 5s. No dialogue. Music builds slightly during the final pullback, then ends cleanly at 8s.\n\nContinuity: The woman must remain the same person from Image 1 in every shot. Preserve her exact face, skin tone, long wavy black hairstyle, makeup, nose ring, necklaces, leather jacket, black lace-up crop top, ripped black jeans, chains, body proportions, and platform boots. She remains in the same physical spot and orientation in the street across all three cuts; only the camera framing changes."
+    },
+    "class_type": "PrimitiveStringMultiline",
+    "_meta": {
+      "title": "BUILDER INPUT - Prompt"
+    }
+  },
+  "141": {
+    "inputs": {
+      "model_name": "minimax_h3_ref2va_pruned_int8_convrot.safetensors",
+      "weight_dtype": "default",
+      "compute_dtype": "default",
+      "patch_cublaslinear": false,
+      "sage_attention": "auto",
+      "enable_fp16_accumulation": true
+    },
+    "class_type": "DiffusionModelLoaderKJ",
+    "_meta": {
+      "title": "Diffusion Model Loader KJ"
+    }
+  },
+  "142": {
+    "inputs": {
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "MiniMaxH3_Builder_LearnedLatentUpscale_1080p",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true,
+      "images": [
+        "183",
+        0
+      ],
+      "audio": [
+        "172",
+        1
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "BUILDER OUTPUT - Learned Latent Upscaled 1080p Video"
+    }
+  },
+  "171": {
+    "inputs": {
+      "audio_file": "Z:\\TOSHARE\\ComfyUI_windows_portable\\ComfyUI\\input\\Circle of Flames 88888.mp3",
+      "seek_seconds": 0,
+      "duration": 0
+    },
+    "class_type": "VHS_LoadAudio",
+    "_meta": {
+      "title": "BUILDER INPUT - Custom Source Audio Path"
+    }
+  },
+  "172": {
+    "inputs": {
+      "av_latent": [
+        "136",
+        1
+      ],
+      "source_audio": [
+        "171",
+        0
+      ],
+      "audio_vae": [
+        "120",
+        0
+      ]
+    },
+    "class_type": "VRGDG_MiniMaxH3AudioDrive",
+    "_meta": {
+      "title": "LOCK SOURCE AUDIO - GENERATE VIDEO ONLY"
+    }
+  },
+  "180": {
+    "inputs": {
+      "image_paths": "[]",
+      "video_references": "[]"
+    },
+    "class_type": "VRGDG_MiniMaxH3ReferenceMediaFromPaths",
+    "_meta": {
+      "title": "BUILDER INPUTS - Ordered H3 Reference Images And Videos"
+    }
+  },
+  "181": {
+    "inputs": {
+      "av_latent": [
+        "125",
+        0
+      ]
+    },
+    "class_type": "MiniMaxH3AVLatentSeparateT8",
+    "_meta": {
+      "title": "PASS 1 OUTPUT - Separate Video and Audio Latents"
+    }
+  },
+  "182": {
+    "inputs": {
+      "scale": [
+        "185",
+        0
+      ],
+      "latent": [
+        "181",
+        0
+      ],
+      "upscale_model": [
+        "188",
+        0
+      ]
+    },
+    "class_type": "VRGDG_MiniMaxH3LearnedLatentUpscale",
+    "_meta": {
+      "title": "LEARNED UPSCALE - MiniMax H3"
+    }
+  },
+  "183": {
+    "inputs": {
+      "width": [
+        "115",
+        0
+      ],
+      "height": [
+        "184",
+        0
+      ],
+      "upscale_method": "nvidia_rtx_vsr",
+      "keep_proportion": "crop",
+      "pad_color": "0, 0, 0",
+      "crop_position": "center",
+      "divisible_by": 0,
+      "device": "cpu",
+      "image": [
+        "122",
+        0
+      ]
+    },
+    "class_type": "ImageResizeKJv2",
+    "_meta": {
+      "title": "Final Center Crop - Exact 1920x1080"
+    }
+  },
+  "184": {
+    "inputs": {
+      "value": 1080
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "BUILDER INPUT - Desired Final Height"
+    }
+  },
+  "185": {
+    "inputs": {
+      "value": 2
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "BUILDER INPUT - Learned Latent Upscale Scale"
+    }
+  },
+  "186": {
+    "inputs": {
+      "expression": "max(32, ceil((a / b) / 32) * 32)",
+      "values.a": [
+        "115",
+        0
+      ],
+      "values.b": [
+        "185",
+        0
+      ]
+    },
+    "class_type": "ComfyMathExpression",
+    "_meta": {
+      "title": "AUTO - Aligned First Pass Width"
+    }
+  },
+  "187": {
+    "inputs": {
+      "expression": "max(32, ceil((a / b) / 32) * 32)",
+      "values.a": [
+        "184",
+        0
+      ],
+      "values.b": [
+        "185",
+        0
+      ]
+    },
+    "class_type": "ComfyMathExpression",
+    "_meta": {
+      "title": "AUTO - Aligned First Pass Height"
+    }
+  },
+  "188": {
+    "inputs": {
+      "model_name": "minimax_h3_latent_upscaler_3d_bf16.safetensors",
+      "device": "cuda",
+      "precision": "bf16"
+    },
+    "class_type": "VRGDG_MiniMaxH3LatentUpscaleModelLoader",
+    "_meta": {
+      "title": "BUILDER INPUT - MiniMax H3 Latent Upscale Model"
+    }
+  },
+  "189": {
+    "inputs": {
+      "original_av_latent": [
+        "125",
+        0
+      ],
+      "upscaled_video_latent": [
+        "182",
+        0
+      ]
+    },
+    "class_type": "VRGDG_MiniMaxH3ReplaceUpscaledVideoLatent",
+    "_meta": {
+      "title": "PASS 2 - Restore Upscaled Video into Locked AV Latent"
+    }
+  },
+  "190": {
+    "inputs": {
+      "value": 5
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "BUILDER INPUT - Refinement Schedule Steps"
+    }
+  },
+  "191": {
+    "inputs": {
+      "value": 0.2
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "BUILDER INPUT - Refinement Denoise"
+    }
+  },
+  "192": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": [
+        "190",
+        0
+      ],
+      "denoise": [
+        "191",
+        0
+      ],
+      "model": [
+        "207",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "PASS 2 - Adjustable Refinement Scheduler"
+    }
+  },
+  "193": {
+    "inputs": {
+      "model": [
+        "207",
+        0
+      ],
+      "conditioning": [
+        "136",
+        0
+      ]
+    },
+    "class_type": "BasicGuider",
+    "_meta": {
+      "title": "PASS 2 - Basic Guider"
+    }
+  },
+  "194": {
+    "inputs": {
+      "noise": [
+        "211",
+        0
+      ],
+      "guider": [
+        "193",
+        0
+      ],
+      "sampler": [
+        "210",
+        0
+      ],
+      "sigmas": [
+        "192",
+        0
+      ],
+      "latent_image": [
+        "189",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "PASS 2 - High Resolution Refinement"
+    }
+  },
+  "207": {
+    "inputs": {
+      "lora_name": "minimax_h3_ref2v_turbo_4step_v0.1_comfyui_bf16.safetensors",
+      "strength_model": 1,
+      "model": [
+        "208",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "Load LoRA"
+    }
+  },
+  "208": {
+    "inputs": {
+      "processing_control_value": 0.07,
+      "processing_percent_1": 0.1,
+      "processing_percent_2": 0.9,
+      "mcs": 2,
+      "device": "auto",
+      "cache_depth": 0.75,
+      "model": [
+        "141",
+        0
+      ]
+    },
+    "class_type": "TESpeedMiniMaxH3",
+    "_meta": {
+      "title": "TE-Speed-MiniMaxH3 (OSS)"
+    }
+  },
+  "210": {
+    "inputs": {
+      "sampler_name": "res_multistep"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "BUILDER INPUT - Pass 2 Sampler"
+    }
+  },
+  "211": {
+    "inputs": {
+      "noise_seed": 910588682130454
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "BUILDER INPUT - Pass 2 Seed"
+    }
+  }
+}

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -255,21 +255,35 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   turbo_lora_name: "minimax_h3_turbo_4step_ema_ckpt850.safetensors",
   turbo_lora_strength: 1,
   ref_image_size: "max",
-  two_pass_lora_name: "minimax_h3_turbo_v4_step600_ema.safetensors",
-  two_pass_lora_strength: 0.7,
+  two_pass_lora_name: "minimax_h3_ref2v_turbo_4step_v0.1_comfyui_bf16.safetensors",
+  two_pass_lora_strength: 1,
+  two_pass_defaults_version: 1,
+  two_pass_final_width: 1920,
+  two_pass_final_height: 1080,
+  two_pass_latent_upscale_scale: 2,
+  two_pass_latent_upscaler_name: "minimax_h3_latent_upscaler_3d_bf16.safetensors",
+  two_pass_use_te_speed: true,
+  two_pass_te_speed_processing_control: 0.07,
+  two_pass_te_speed_start_percent: 0.1,
+  two_pass_te_speed_end_percent: 0.9,
+  two_pass_te_speed_mcs: 2,
+  two_pass_te_speed_cache_depth: 0.75,
+  two_pass_te_speed_device: "auto",
+  two_pass_final_resize_method: "nvidia_rtx_vsr",
+  two_pass_output_crf: 19,
   three_pass_lightx_lora_name: "minimax_h3_fl2v_lightx2v_turbo_4step_v0.1_comfy_resized_avg_rank_21_bf16.safetensors",
   three_pass_lightx_lora_strength: 0.5,
   two_pass_pass1_megapixels: 0.5,
-  two_pass_pass1_steps: 15,
+  two_pass_pass1_steps: 20,
   two_pass_pass1_denoise: 1,
-  two_pass_pass1_sampler: "euler",
-  two_pass_pass1_scheduler: "beta",
+  two_pass_pass1_sampler: "res_multistep",
+  two_pass_pass1_scheduler: "simple",
   two_pass_pass1_seed: 69,
   two_pass_pass2_megapixels: 1.5,
-  two_pass_pass2_steps: 4,
+  two_pass_pass2_steps: 5,
   two_pass_pass2_denoise: 0.2,
-  two_pass_pass2_sampler: "euler",
-  two_pass_pass2_scheduler: "beta",
+  two_pass_pass2_sampler: "res_multistep",
+  two_pass_pass2_scheduler: "simple",
   two_pass_pass2_seed: 69,
   three_pass_pass1_megapixels: 0.4,
   three_pass_pass1_steps: 20,
@@ -412,6 +426,7 @@ function normalizeMiniMaxH3VideoPurpose(value) {
 
 function cloneMiniMaxH3Settings(value = {}) {
   const source = value && typeof value === "object" ? value : {};
+  const hasCurrentTwoPassDefaults = Number(source.two_pass_defaults_version || 0) >= 1;
   const sourceLoras = Array.isArray(source.loras)
     ? source.loras
     : Array.from({ length: 4 }, (_, index) => ({
@@ -422,6 +437,9 @@ function cloneMiniMaxH3Settings(value = {}) {
     .map((item) => ({
       name: String(item?.name || item?.lora_name || item?.loraName || "").trim(),
       strength: Math.max(-10, Math.min(10, Number(item?.strength ?? item?.strength_model ?? item?.strengthModel ?? 1))),
+      apply_to: ["both", "pass1", "pass2"].includes(String(item?.apply_to || item?.applyTo || "both"))
+        ? String(item?.apply_to || item?.applyTo || "both")
+        : "both",
     }))
     .filter((item) => item.name && item.name !== "[none]")
     .slice(0, 4);
@@ -474,6 +492,33 @@ function cloneMiniMaxH3Settings(value = {}) {
     ref_image_size: ["match", "max"].includes(String(source.ref_image_size || "").trim().toLowerCase())
       ? String(source.ref_image_size).trim().toLowerCase()
       : DEFAULT_MINIMAX_H3_SETTINGS.ref_image_size,
+    two_pass_final_width: Math.max(64, Math.min(16384, Math.trunc(Number(source.two_pass_final_width ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_width)))),
+    two_pass_final_height: Math.max(64, Math.min(16384, Math.trunc(Number(source.two_pass_final_height ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_height)))),
+    two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.two_pass_defaults_version,
+    two_pass_latent_upscale_scale: Math.max(1, Math.min(8, Number(hasCurrentTwoPassDefaults
+      ? (source.two_pass_latent_upscale_scale ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscale_scale)
+      : DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscale_scale))),
+    two_pass_latent_upscaler_name: String(source.two_pass_latent_upscaler_name || DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name),
+    two_pass_use_te_speed: Boolean(source.two_pass_use_te_speed ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_use_te_speed),
+    two_pass_te_speed_processing_control: Math.max(0, Math.min(1, Number(source.two_pass_te_speed_processing_control ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_processing_control))),
+    two_pass_te_speed_start_percent: Math.max(0, Math.min(1, Number(source.two_pass_te_speed_start_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_start_percent))),
+    two_pass_te_speed_end_percent: Math.max(0, Math.min(1, Number(source.two_pass_te_speed_end_percent ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_end_percent))),
+    two_pass_te_speed_mcs: Math.max(1, Math.min(64, Math.trunc(Number(source.two_pass_te_speed_mcs ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_mcs)))),
+    two_pass_te_speed_cache_depth: Math.max(0, Math.min(1, Number(source.two_pass_te_speed_cache_depth ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_cache_depth))),
+    two_pass_te_speed_device: String(source.two_pass_te_speed_device || DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_device),
+    two_pass_final_resize_method: String(source.two_pass_final_resize_method || DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_resize_method),
+    two_pass_output_crf: Math.max(0, Math.min(100, Math.trunc(Number(source.two_pass_output_crf ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_output_crf)))),
+    ...Object.fromEntries([1, 2].flatMap((pass) => {
+      const prefix = `two_pass_pass${pass}_`;
+      const defaults = DEFAULT_MINIMAX_H3_SETTINGS;
+      return [
+        [`${prefix}steps`, Math.max(1, Math.min(1000, Math.trunc(Number(hasCurrentTwoPassDefaults ? source[`${prefix}steps`] : defaults[`${prefix}steps`]) || defaults[`${prefix}steps`])))],
+        [`${prefix}denoise`, Math.max(0, Math.min(1, Number(hasCurrentTwoPassDefaults ? (source[`${prefix}denoise`] ?? defaults[`${prefix}denoise`]) : defaults[`${prefix}denoise`])))],
+        [`${prefix}sampler`, String(hasCurrentTwoPassDefaults ? (source[`${prefix}sampler`] || defaults[`${prefix}sampler`]) : defaults[`${prefix}sampler`])],
+        [`${prefix}scheduler`, String(hasCurrentTwoPassDefaults ? (source[`${prefix}scheduler`] || defaults[`${prefix}scheduler`]) : defaults[`${prefix}scheduler`])],
+        [`${prefix}seed`, hasCurrentTwoPassDefaults && Number.isFinite(Number(source[`${prefix}seed`])) ? Number(source[`${prefix}seed`]) : defaults[`${prefix}seed`]],
+      ];
+    })),
     ...Object.fromEntries([1, 2, 3].flatMap((pass) => {
       const prefix = `three_pass_pass${pass}_`;
       const defaults = DEFAULT_MINIMAX_H3_SETTINGS;
@@ -2921,11 +2966,12 @@ function openBuilder(node) {
       const behind = Math.max(0, Number(payload.behind || 0));
       const wrongBranch = Boolean(payload.expected_branch) && payload.branch !== payload.expected_branch;
       const isOutdated = Boolean(payload.outdated);
-      if (isOutdated) {
+      // A feature/PR branch is a local development checkout, not an outdated
+      // production checkout. Only offer the main-branch updater while we are
+      // actually on the branch it is designed to fast-forward.
+      if (isOutdated && !wrongBranch) {
         const countText = `${behind} commit${behind === 1 ? "" : "s"} behind`;
-        const reason = wrongBranch
-          ? `currently on ${payload.branch || "a detached checkout"}`
-          : countText;
+        const reason = countText;
         setUpdateStatusAppearance(
           "outdated",
           `AI Video Builder build ${installed} — Update available (${reason}; latest ${latest})`,
@@ -5635,11 +5681,17 @@ function openBuilder(node) {
     strength.min = "-10";
     strength.max = "10";
     strength.step = "0.01";
+    const applyTo = makeSelect([
+      { value: "both", label: "Both passes" },
+      { value: "pass1", label: "Pass 1 only" },
+      { value: "pass2", label: "Pass 2 only" },
+    ], "both");
+    const applyToField = makeField("2-pass target", applyTo);
     const row = document.createElement("div");
-    row.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) 92px;gap:8px;";
-    row.append(makeField(`MiniMax LoRA ${slot}`, picker.wrapper), makeField("Strength", strength));
+    row.style.cssText = "display:grid;grid-template-columns:minmax(0,1fr) 92px minmax(120px,0.45fr);gap:8px;";
+    row.append(makeField(`MiniMax LoRA ${slot}`, picker.wrapper), makeField("Strength", strength), applyToField);
     miniMaxLoraRows.append(row);
-    miniMaxLoraSlots.push({ row, picker, strength });
+    miniMaxLoraSlots.push({ row, picker, strength, applyTo, applyToField });
   }
   const miniMaxLoraNote = document.createElement("div");
   miniMaxLoraNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.4;";
@@ -5773,10 +5825,6 @@ function openBuilder(node) {
   });
   const twoPassControls = [1, 2].map((pass) => {
     const prefix = `two_pass_pass${pass}_`;
-    const megapixels = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}megapixels`]), "number");
-    megapixels.min = "0.1";
-    megapixels.max = "16";
-    megapixels.step = "0.1";
     const steps = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}steps`]), "number");
     steps.min = "1";
     steps.max = "1000";
@@ -5790,22 +5838,85 @@ function openBuilder(node) {
     const seed = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}seed`]), "number");
     seed.step = "1";
     const section = makeSettingsSection(`Pass ${pass}`, [
-      makeField("Resolution (megapixels)", megapixels),
       makeField("Steps", steps),
       makeField("Sampler", sampler),
       makeField("Scheduler", scheduler),
       makeField("Denoise", denoise),
       makeField("Seed", seed),
     ], pass === 1);
-    return { prefix, megapixels, steps, denoise, sampler, scheduler, seed, section };
+    return { prefix, steps, denoise, sampler, scheduler, seed, section };
   });
+  const miniMaxTwoPassFinalWidth = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_width), "number");
+  miniMaxTwoPassFinalWidth.min = "64";
+  miniMaxTwoPassFinalWidth.max = "16384";
+  miniMaxTwoPassFinalWidth.step = "1";
+  const miniMaxTwoPassFinalHeight = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_height), "number");
+  miniMaxTwoPassFinalHeight.min = "64";
+  miniMaxTwoPassFinalHeight.max = "16384";
+  miniMaxTwoPassFinalHeight.step = "1";
+  const miniMaxTwoPassLatentScale = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscale_scale), "number");
+  miniMaxTwoPassLatentScale.min = "1";
+  miniMaxTwoPassLatentScale.max = "8";
+  miniMaxTwoPassLatentScale.step = "0.1";
+  const miniMaxTwoPassRefImageSize = makeSelect([
+    { value: "max", label: "max" },
+    { value: "match", label: "match" },
+  ], DEFAULT_MINIMAX_H3_SETTINGS.ref_image_size);
+  const miniMaxThreePassRefImageSize = makeSelect([
+    { value: "max", label: "max" },
+    { value: "match", label: "match" },
+  ], DEFAULT_MINIMAX_H3_SETTINGS.ref_image_size);
+  const miniMaxTwoPassLatentUpscalerPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
+  const miniMaxTwoPassUseTeSpeed = makeCheckbox("Use TE-Speed-MiniMaxH3 (OSS)", DEFAULT_MINIMAX_H3_SETTINGS.two_pass_use_te_speed);
+  const miniMaxTwoPassTeProcessingControl = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_processing_control), "number");
+  miniMaxTwoPassTeProcessingControl.min = "0"; miniMaxTwoPassTeProcessingControl.max = "1"; miniMaxTwoPassTeProcessingControl.step = "0.01";
+  const miniMaxTwoPassTeStart = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_start_percent), "number");
+  miniMaxTwoPassTeStart.min = "0"; miniMaxTwoPassTeStart.max = "1"; miniMaxTwoPassTeStart.step = "0.01";
+  const miniMaxTwoPassTeEnd = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_end_percent), "number");
+  miniMaxTwoPassTeEnd.min = "0"; miniMaxTwoPassTeEnd.max = "1"; miniMaxTwoPassTeEnd.step = "0.01";
+  const miniMaxTwoPassTeMcs = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_mcs), "number");
+  miniMaxTwoPassTeMcs.min = "1"; miniMaxTwoPassTeMcs.max = "64"; miniMaxTwoPassTeMcs.step = "1";
+  const miniMaxTwoPassTeCacheDepth = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_cache_depth), "number");
+  miniMaxTwoPassTeCacheDepth.min = "0"; miniMaxTwoPassTeCacheDepth.max = "1"; miniMaxTwoPassTeCacheDepth.step = "0.01";
+  const miniMaxTwoPassTeDevice = makeSelect(["auto", "cuda", "cpu"], DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_device);
+  const miniMaxTwoPassResizeMethod = makeSelect(["nvidia_rtx_vsr", "lanczos", "bicubic", "bilinear", "nearest-exact"], DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_resize_method);
+  const miniMaxTwoPassOutputCrf = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_output_crf), "number");
+  miniMaxTwoPassOutputCrf.min = "0"; miniMaxTwoPassOutputCrf.max = "100"; miniMaxTwoPassOutputCrf.step = "1";
+  const miniMaxTwoPassSpeedNote = document.createElement("div");
+  miniMaxTwoPassSpeedNote.textContent = "The selected Turbo LoRA is applied ONLY to pass 2 and makes the refinement pass MUCH faster. TE-Speed is separate optional acceleration for the model path; uncheck it to bypass the OSS speed node completely.";
+  miniMaxTwoPassSpeedNote.style.cssText = "font-size:11px;color:#facc15;line-height:1.45;";
+  const miniMaxTwoPassLatentScaleNote = document.createElement("div");
+  miniMaxTwoPassLatentScaleNote.textContent = "Learned latent scale controls how much the pass-one video latent is enlarged before pass two. A value of 2 doubles its latent width and height. Keep this at 2 for the supplied upscaler; final width and height remain the actual requested output size.";
+  miniMaxTwoPassLatentScaleNote.style.cssText = "font-size:11px;color:#a1a1aa;line-height:1.45;";
   const miniMaxTwoPassSettings = makeSettingsSection("Two-Pass Settings", [
-    document.createTextNode("These controls apply when Ref to Video 2 Pass is selected. Defaults match the imported workflow."),
+    miniMaxTwoPassSpeedNote,
+    makeField("Final width", miniMaxTwoPassFinalWidth),
+    makeField("Final height", miniMaxTwoPassFinalHeight),
+    makeField("Reference image sizing", miniMaxTwoPassRefImageSize, "Controls the MiniMax H3 reference-conditioning image-size mode. Default: max."),
+    makeField("Latent upscaler model", miniMaxTwoPassLatentUpscalerPicker.wrapper),
+    miniMaxTwoPassUseTeSpeed.wrapper,
     ...twoPassControls.map((item) => item.section),
+    makeSettingsSection("TE-Speed Advanced", [
+      makeField("Processing control", miniMaxTwoPassTeProcessingControl),
+      makeField("Start percent", miniMaxTwoPassTeStart),
+      makeField("End percent", miniMaxTwoPassTeEnd),
+      makeField("MCS", miniMaxTwoPassTeMcs),
+      makeField("Cache depth", miniMaxTwoPassTeCacheDepth),
+      makeField("Device", miniMaxTwoPassTeDevice),
+    ], false),
+    makeSettingsSection("Latent Upscale Advanced", [
+      miniMaxTwoPassLatentScaleNote,
+      makeField("Learned latent scale", miniMaxTwoPassLatentScale),
+    ], false),
+    makeSettingsSection("Output Advanced", [
+      makeField("Final resize method", miniMaxTwoPassResizeMethod),
+      makeField("Output CRF", miniMaxTwoPassOutputCrf),
+    ], false),
   ], false);
   miniMaxTwoPassSettings.style.display = "none";
   const miniMaxThreePassSettings = makeSettingsSection("Three-Pass Experimental Settings", [
     document.createTextNode("These controls apply when Ref to Video 3 Pass is selected. Defaults match the imported workflow."),
+    makeField("Reference image sizing", miniMaxThreePassRefImageSize, "Controls the MiniMax H3 reference-conditioning image-size mode. Default: max."),
     ...threePassControls.map((item) => item.section),
   ], false);
   miniMaxThreePassSettings.style.display = "none";
@@ -5840,8 +5951,8 @@ function openBuilder(node) {
   miniMaxTwoPassLoraStrength.min = "-10";
   miniMaxTwoPassLoraStrength.max = "10";
   miniMaxTwoPassLoraStrength.step = "0.01";
-  const miniMaxTwoPassLoraSection = makeSettingsSection("2-Pass LoRA", [
-    makeField("2-pass LoRA", miniMaxTwoPassLoraPicker.wrapper),
+  const miniMaxTwoPassLoraSection = makeSettingsSection("Pass 2 Turbo LoRA", [
+    makeField("Pass 2 Turbo LoRA", miniMaxTwoPassLoraPicker.wrapper),
     makeField("Strength", miniMaxTwoPassLoraStrength),
   ]);
   const miniMaxThreePassLoraPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.three_pass_lightx_lora_name);
@@ -7068,6 +7179,7 @@ function openBuilder(node) {
       .map((slot) => ({
         name: String(slot.picker.input.value || "").trim(),
         strength: Math.max(-10, Math.min(10, Number(slot.strength.value || 1))),
+        apply_to: slot.applyTo.value,
       }))
       .filter((item) => item.name && item.name !== "[none]");
     const settings = cloneMiniMaxH3Settings({
@@ -7088,13 +7200,29 @@ function openBuilder(node) {
       steps: miniMaxSteps.value,
       steps_before_turbo: turboEnabled ? currentSettings.steps_before_turbo : miniMaxSteps.value,
       denoise: miniMaxDenoise.value,
-      ref_image_size: miniMaxRefImageSize.value,
+      ref_image_size: state.miniMaxH3ThreePassEnabled
+        ? miniMaxThreePassRefImageSize.value
+        : state.miniMaxH3TwoPassEnabled
+          ? miniMaxTwoPassRefImageSize.value
+          : miniMaxRefImageSize.value,
       two_pass_lora_name: miniMaxTwoPassLoraPicker.input.value,
       two_pass_lora_strength: miniMaxTwoPassLoraStrength.value,
+      two_pass_final_width: miniMaxTwoPassFinalWidth.value,
+      two_pass_final_height: miniMaxTwoPassFinalHeight.value,
+      two_pass_latent_upscale_scale: miniMaxTwoPassLatentScale.value,
+      two_pass_latent_upscaler_name: miniMaxTwoPassLatentUpscalerPicker.input.value,
+      two_pass_use_te_speed: miniMaxTwoPassUseTeSpeed.input.checked,
+      two_pass_te_speed_processing_control: miniMaxTwoPassTeProcessingControl.value,
+      two_pass_te_speed_start_percent: miniMaxTwoPassTeStart.value,
+      two_pass_te_speed_end_percent: miniMaxTwoPassTeEnd.value,
+      two_pass_te_speed_mcs: miniMaxTwoPassTeMcs.value,
+      two_pass_te_speed_cache_depth: miniMaxTwoPassTeCacheDepth.value,
+      two_pass_te_speed_device: miniMaxTwoPassTeDevice.value,
+      two_pass_final_resize_method: miniMaxTwoPassResizeMethod.value,
+      two_pass_output_crf: miniMaxTwoPassOutputCrf.value,
       three_pass_lightx_lora_name: miniMaxThreePassLoraPicker.input.value,
       three_pass_lightx_lora_strength: miniMaxThreePassLoraStrength.value,
       ...Object.fromEntries(twoPassControls.flatMap((control) => [
-        [`${control.prefix}megapixels`, control.megapixels.value],
         [`${control.prefix}steps`, control.steps.value],
         [`${control.prefix}denoise`, control.denoise.value],
         [`${control.prefix}sampler`, control.sampler.value],
@@ -7769,12 +7897,26 @@ function openBuilder(node) {
     miniMaxSteps.value = String(settings.steps);
     miniMaxDenoise.value = String(settings.denoise);
     miniMaxRefImageSize.value = settings.ref_image_size;
+    miniMaxTwoPassRefImageSize.value = settings.ref_image_size;
+    miniMaxThreePassRefImageSize.value = settings.ref_image_size;
     miniMaxTwoPassLoraPicker.input.value = settings.two_pass_lora_name;
     miniMaxTwoPassLoraStrength.value = String(settings.two_pass_lora_strength);
+    miniMaxTwoPassFinalWidth.value = String(settings.two_pass_final_width);
+    miniMaxTwoPassFinalHeight.value = String(settings.two_pass_final_height);
+    miniMaxTwoPassLatentScale.value = String(settings.two_pass_latent_upscale_scale);
+    miniMaxTwoPassLatentUpscalerPicker.input.value = settings.two_pass_latent_upscaler_name;
+    miniMaxTwoPassUseTeSpeed.input.checked = Boolean(settings.two_pass_use_te_speed);
+    miniMaxTwoPassTeProcessingControl.value = String(settings.two_pass_te_speed_processing_control);
+    miniMaxTwoPassTeStart.value = String(settings.two_pass_te_speed_start_percent);
+    miniMaxTwoPassTeEnd.value = String(settings.two_pass_te_speed_end_percent);
+    miniMaxTwoPassTeMcs.value = String(settings.two_pass_te_speed_mcs);
+    miniMaxTwoPassTeCacheDepth.value = String(settings.two_pass_te_speed_cache_depth);
+    miniMaxTwoPassTeDevice.value = settings.two_pass_te_speed_device;
+    miniMaxTwoPassResizeMethod.value = settings.two_pass_final_resize_method;
+    miniMaxTwoPassOutputCrf.value = String(settings.two_pass_output_crf);
     miniMaxThreePassLoraPicker.input.value = settings.three_pass_lightx_lora_name;
     miniMaxThreePassLoraStrength.value = String(settings.three_pass_lightx_lora_strength);
     twoPassControls.forEach((control) => {
-      control.megapixels.value = String(settings[`${control.prefix}megapixels`]);
       control.steps.value = String(settings[`${control.prefix}steps`]);
       control.denoise.value = String(settings[`${control.prefix}denoise`]);
       control.sampler.value = settings[`${control.prefix}sampler`];
@@ -7814,6 +7956,7 @@ function openBuilder(node) {
       slot.row.style.display = settings.use_loras && index < Number(settings.lora_count || 0) ? "grid" : "none";
       slot.picker.input.value = item.name || slot.picker.input.value || "[none]";
       slot.strength.value = String(item.strength ?? slot.strength.value ?? 1);
+      slot.applyTo.value = ["both", "pass1", "pass2"].includes(item.apply_to) ? item.apply_to : "both";
     });
     miniMaxUseTurboLora.input.checked = settings.use_turbo_lora;
     miniMaxTurboLoraPicker.input.value = settings.turbo_lora_name;
@@ -7866,6 +8009,17 @@ function openBuilder(node) {
     const twoPass = Boolean(state.miniMaxH3TwoPassEnabled) && mode === "reference_to_video";
     const threePass = Boolean(state.miniMaxH3ThreePassEnabled) && mode === "reference_to_video";
     const hideMultiPassIgnoredSettings = twoPass || threePass;
+    miniMaxLoraSlots.forEach((slot) => {
+      slot.applyToField.style.display = twoPass ? "flex" : "none";
+      slot.row.style.gridTemplateColumns = twoPass
+        ? "minmax(0,1fr) 92px minmax(120px,0.45fr)"
+        : "minmax(0,1fr) 92px";
+    });
+    if (twoPass) {
+      miniMaxLoraNote.textContent = settings.use_loras
+        ? "Extra LoRAs are ON. Each can target pass 1, pass 2, or both. The required Turbo LoRA remains separate and pass-2-only."
+        : "Optional extra LoRAs are OFF. Enable them, choose a count, then select the target pass for each LoRA.";
+    }
     miniMaxMegapixelsField.style.display = hideMultiPassIgnoredSettings ? "none" : "";
     miniMaxSeedField.style.display = hideMultiPassIgnoredSettings ? "none" : "";
     miniMaxSamplerSettings.style.display = hideMultiPassIgnoredSettings ? "none" : "";
@@ -44905,17 +45059,28 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         ref_image_size: miniMaxSettings.ref_image_size,
         two_pass_lora_name: miniMaxSettings.two_pass_lora_name,
         two_pass_lora_strength: miniMaxSettings.two_pass_lora_strength,
+        final_width: twoPass ? miniMaxSettings.two_pass_final_width : undefined,
+        final_height: twoPass ? miniMaxSettings.two_pass_final_height : undefined,
+        latent_upscale_scale: twoPass ? miniMaxSettings.two_pass_latent_upscale_scale : undefined,
+        latent_upscaler_name: twoPass ? miniMaxSettings.two_pass_latent_upscaler_name : undefined,
+        two_pass_use_te_speed: twoPass ? miniMaxSettings.two_pass_use_te_speed : undefined,
+        te_speed_processing_control: twoPass ? miniMaxSettings.two_pass_te_speed_processing_control : undefined,
+        te_speed_start_percent: twoPass ? miniMaxSettings.two_pass_te_speed_start_percent : undefined,
+        te_speed_end_percent: twoPass ? miniMaxSettings.two_pass_te_speed_end_percent : undefined,
+        te_speed_mcs: twoPass ? miniMaxSettings.two_pass_te_speed_mcs : undefined,
+        te_speed_cache_depth: twoPass ? miniMaxSettings.two_pass_te_speed_cache_depth : undefined,
+        te_speed_device: twoPass ? miniMaxSettings.two_pass_te_speed_device : undefined,
+        final_resize_method: twoPass ? miniMaxSettings.two_pass_final_resize_method : undefined,
+        output_crf: twoPass ? miniMaxSettings.two_pass_output_crf : undefined,
         three_pass_lightx_lora_name: miniMaxSettings.three_pass_lightx_lora_name,
         three_pass_lightx_lora_strength: miniMaxSettings.three_pass_lightx_lora_strength,
         pass1_steps: twoPass ? miniMaxSettings.two_pass_pass1_steps : miniMaxSettings.steps,
         pass1_denoise: twoPass ? miniMaxSettings.two_pass_pass1_denoise : miniMaxSettings.denoise,
-        pass1_megapixels: twoPass ? miniMaxSettings.two_pass_pass1_megapixels : 0.5,
         pass1_sampler_name: twoPass ? miniMaxSettings.two_pass_pass1_sampler : miniMaxSettings.sampler_name,
         pass1_scheduler: twoPass ? miniMaxSettings.two_pass_pass1_scheduler : miniMaxSettings.scheduler,
         pass1_seed: twoPass ? miniMaxSettings.two_pass_pass1_seed : miniMaxSettings.seed,
         pass2_steps: twoPass ? miniMaxSettings.two_pass_pass2_steps : 4,
         pass2_denoise: twoPass ? miniMaxSettings.two_pass_pass2_denoise : 0.2,
-        pass2_megapixels: twoPass ? miniMaxSettings.two_pass_pass2_megapixels : 1.5,
         pass2_sampler_name: twoPass ? miniMaxSettings.two_pass_pass2_sampler : miniMaxSettings.sampler_name,
         pass2_scheduler: twoPass ? miniMaxSettings.two_pass_pass2_scheduler : miniMaxSettings.scheduler,
         pass2_seed: twoPass ? miniMaxSettings.two_pass_pass2_seed : miniMaxSettings.seed,
@@ -44995,7 +45160,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         `${batchLabel}${threePass ? "Queueing MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)..." : twoPass ? "Queueing MiniMax H3 2 Pass (Stage 1 → Stage 2)..." : "Queueing MiniMax H3..."}\n`
         + `Timeline: ${sceneDuration.toFixed(3)}s\n`
         + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`
-        + (threePass ? "\nStage 1 and Stage 2 are saved as backups; Stage 3 will be used for stitching." : twoPass ? "\nStage 1 is saved as a backup; Stage 2 will be used for stitching." : "")
+        + (threePass ? "\nStage 1 and Stage 2 are saved as backups; Stage 3 will be used for stitching." : twoPass ? "\nPass 1 is learned-latent upscaled and refined by pass 2; the final pass-2 video will be used for stitching." : "")
         + loraLine
         + turboLine
         + settingsScopeLine
@@ -45186,7 +45351,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         await autoSaveSessionQuiet(options.autoSaveReason || "MiniMax H3 scene video complete");
       }
       progress?.set(
-        `${batchLabel}${threePass ? "MiniMax H3 3 Pass complete — Stage 3 selected; Stage 1 and Stage 2 backups saved." : twoPass ? "MiniMax H3 2 Pass complete — Stage 2 selected; Stage 1 backup saved." : "MiniMax H3 scene ready."}\n${segment.video_path}\n`
+        `${batchLabel}${threePass ? "MiniMax H3 3 Pass complete — Stage 3 selected; Stage 1 and Stage 2 backups saved." : twoPass ? "MiniMax H3 learned-latent 2 Pass complete — final pass-2 video selected." : "MiniMax H3 scene ready."}\n${segment.video_path}\n`
         + `Exact duration: ${finalDuration.toFixed(3)}s`,
         pct(100),
       );
@@ -55714,6 +55879,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     setMiniMaxOptions(miniMaxClipPicker, data.clip, DEFAULT_MINIMAX_H3_SETTINGS.clip_name);
     setMiniMaxOptions(miniMaxVideoVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name);
     setMiniMaxOptions(miniMaxAudioVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name);
+    setMiniMaxOptions(miniMaxTwoPassLatentUpscalerPicker, data.upscale_models, DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
     saveMiniMaxH3SettingsFromPanel();
     setOptions(fluxUnetPicker, data.unets, ["flux\\flux-2-klein-4b-fp8.safetensors", "flux-2-klein-4b-fp8.safetensors"]);
     setOptions(fluxClipPicker, data.clip, ["qwen_3_4b.safetensors", "flux\\qwen_3_4b.safetensors"]);
@@ -55841,7 +56007,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     saveMiniMaxH3SettingsFromPanel();
     autoSaveSessionQuiet("MiniMax H3 project settings").catch(() => null);
   };
-  for (const picker of [miniMaxDiffusionModelPicker, miniMaxClipPicker, miniMaxVideoVaePicker, miniMaxAudioVaePicker]) {
+  for (const picker of [miniMaxDiffusionModelPicker, miniMaxClipPicker, miniMaxVideoVaePicker, miniMaxAudioVaePicker, miniMaxTwoPassLatentUpscalerPicker]) {
     wireSearchablePicker(picker, saveMiniMaxH3SettingsFromPanel);
     picker.input.addEventListener("change", persistMiniMaxSettings);
   }
@@ -55856,6 +56022,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     slot.picker.input.addEventListener("change", persistMiniMaxSettings);
     slot.strength.addEventListener("input", saveMiniMaxH3SettingsFromPanel);
     slot.strength.addEventListener("change", persistMiniMaxSettings);
+    slot.applyTo.addEventListener("change", persistMiniMaxSettings);
   }
   for (const control of [
     miniMaxAspectRatio,
@@ -55882,8 +56049,21 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     miniMaxTurboLoraStrength,
     miniMaxTwoPassLoraStrength,
     miniMaxThreePassLoraStrength,
+    miniMaxTwoPassFinalWidth,
+    miniMaxTwoPassFinalHeight,
+    miniMaxTwoPassRefImageSize,
+    miniMaxThreePassRefImageSize,
+    miniMaxTwoPassLatentScale,
+    miniMaxTwoPassUseTeSpeed.input,
+    miniMaxTwoPassTeProcessingControl,
+    miniMaxTwoPassTeStart,
+    miniMaxTwoPassTeEnd,
+    miniMaxTwoPassTeMcs,
+    miniMaxTwoPassTeCacheDepth,
+    miniMaxTwoPassTeDevice,
+    miniMaxTwoPassResizeMethod,
+    miniMaxTwoPassOutputCrf,
     ...twoPassControls.flatMap((pass) => [
-      pass.megapixels,
       pass.steps,
       pass.denoise,
       pass.sampler,


### PR DESCRIPTION
# What changed

- Exposed MiniMax H3 reference image sizing in the two-pass builder settings.
- Exposed the same setting in the three-pass experimental settings.
- Both selectors offer `max` and `match`, default to `max`, and write to the existing `ref_image_size` backend input.

# Validation

- JavaScript ES-module syntax validation with `node --check`
- `git diff --check`
