### PR TITLE
Remove unavailable Face Fix batch import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,6 @@ _VRGDG_SUBMODULES = (
     ".VRGDG_SilentAudioRoutes",
     ".VRGDG_UpdateRoutes",
     ".VRGDG_VideoBuilderNodeUI",
-    ".VRGDG_FaceFixBatchNode",
     ".VRGDG_LoraDatasetCreatorNodes",
 )
 


### PR DESCRIPTION
## What changed

Removed the VRGDG_FaceFixBatchNode submodule entry from the package loader.

## Why

The loader referenced a Face Fix Batch module that was not included in the release, causing users to receive a startup import error after updating.

## Impact

The unavailable standalone Batch Workspace is no longer imported. The Music Video Builder's integrated Face Fix remains unchanged and continues using its existing tracked implementation.

## Validation

- Confirmed the PR diff contains only one deletion in __init__.py`n- git diff --check passed
- python -B -m py_compile __init__.py passed