### PR TITLE
Prevent LM Studio vision reasoning exhaustion

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -3327,6 +3327,19 @@ def _lm_studio_context_limit(payload):
     return _normalized_token_limit(configured, 32768, minimum=512)
 
 
+def _lm_studio_reasoning_mode(payload, default=""):
+    payload = payload if isinstance(payload, dict) else {}
+    configured = payload.get("lmstudio_reasoning")
+    if configured in (None, ""):
+        configured = payload.get("lm_studio_reasoning")
+    normalized = str(configured or "").strip().lower()
+    allowed = {"off", "low", "medium", "high", "on"}
+    if normalized in allowed:
+        return normalized
+    fallback = str(default or "").strip().lower()
+    return fallback if fallback in allowed else ""
+
+
 def _lm_studio_api_root(payload):
     base_url = str(payload.get("lmstudio_base_url") or _LM_STUDIO_DEFAULT_BASE_URL).strip().rstrip("/")
     if base_url.lower().endswith("/v1"):
@@ -3356,7 +3369,7 @@ def _lm_studio_native_output_text(data):
     return "\n".join(part.strip() for part in parts if str(part or "").strip()).strip()
 
 
-def _run_lm_studio_native_chat(payload, input_value, temperature, top_p, max_new_tokens, timeout, label):
+def _run_lm_studio_native_chat(payload, input_value, temperature, top_p, max_new_tokens, timeout, label, reasoning_default=""):
     api_root = _lm_studio_api_root(payload)
     model = str(payload.get("lmstudio_model") or payload.get("model_file") or "").strip()
     api_key = str(payload.get("lmstudio_api_key") or "").strip()
@@ -3374,6 +3387,9 @@ def _run_lm_studio_native_chat(payload, input_value, temperature, top_p, max_new
         "store": False,
         "stream": False,
     }
+    reasoning_mode = _lm_studio_reasoning_mode(payload, reasoning_default)
+    if reasoning_mode:
+        body["reasoning"] = reasoning_mode
     if payload.get("seed") is not None:
         body["seed"] = int(payload.get("seed"))
     headers = {"Content-Type": "application/json"}
@@ -3571,6 +3587,7 @@ def _run_lm_studio_vision(payload, instruction_text, pil_images, temperature=0.2
         max_new_tokens,
         payload.get("lmstudio_timeout") or 300,
         "vision ",
+        reasoning_default="off",
     )
 
 

--- a/tests/test_builder_lm_studio_seed_retry.py
+++ b/tests/test_builder_lm_studio_seed_retry.py
@@ -18,9 +18,11 @@ def load_lm_studio_helpers():
         "_normalized_token_limit",
         "_runner_output_token_limit",
         "_lm_studio_context_limit",
+        "_lm_studio_reasoning_mode",
         "_lm_studio_api_root",
         "_lm_studio_native_output_text",
         "_run_lm_studio_native_chat",
+        "_run_lm_studio_vision",
     }
     tree = ast.parse(BUILDER_BACKEND)
     nodes = []
@@ -111,6 +113,94 @@ class LmStudioSeedRetryTests(unittest.TestCase):
         self.assertEqual("Hello from LM Studio", text)
         self.assertEqual(1, urlopen_mock.call_count)
         self.assertNotIn("seed", calls[0])
+        self.assertNotIn("reasoning", calls[0])
+
+    def test_vision_requests_disable_reasoning_by_default(self):
+        calls = []
+
+        def urlopen_side_effect(request, timeout=None):
+            calls.append(json.loads(request.data.decode("utf-8")))
+            return FakeLMStudioResponse(SUCCESS_PAYLOAD)
+
+        run_vision = LM_STUDIO_HELPERS["_run_lm_studio_vision"]
+        LM_STUDIO_HELPERS["_pil_image_to_data_url"] = lambda image: "data:image/jpeg;base64,dGVzdA=="
+        payload = {"lmstudio_base_url": "http://127.0.0.1:1234/v1", "lmstudio_model": "test-model"}
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+            text = run_vision(payload, "describe this image", [object()])
+
+        self.assertEqual("Hello from LM Studio", text)
+        self.assertEqual("off", calls[0]["reasoning"])
+        self.assertEqual("text", calls[0]["input"][0]["type"])
+        self.assertEqual("image", calls[0]["input"][1]["type"])
+
+    def test_explicit_vision_reasoning_mode_overrides_default(self):
+        calls = []
+
+        def urlopen_side_effect(request, timeout=None):
+            calls.append(json.loads(request.data.decode("utf-8")))
+            return FakeLMStudioResponse(SUCCESS_PAYLOAD)
+
+        run_vision = LM_STUDIO_HELPERS["_run_lm_studio_vision"]
+        LM_STUDIO_HELPERS["_pil_image_to_data_url"] = lambda image: "data:image/jpeg;base64,dGVzdA=="
+        payload = {
+            "lmstudio_base_url": "http://127.0.0.1:1234/v1",
+            "lmstudio_model": "test-model",
+            "lmstudio_reasoning": "low",
+        }
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+            run_vision(payload, "describe this image", [object()])
+
+        self.assertEqual("low", calls[0]["reasoning"])
+
+    def test_vision_seed_retry_keeps_reasoning_disabled(self):
+        calls = []
+
+        def urlopen_side_effect(request, timeout=None):
+            body = json.loads(request.data.decode("utf-8"))
+            calls.append(body)
+            if "seed" in body:
+                raise make_http_error(400, {
+                    "error": {
+                        "message": "Unrecognized key(s) in object: 'seed'",
+                        "type": "invalid_request",
+                        "code": "unrecognized_keys",
+                    }
+                })
+            return FakeLMStudioResponse(SUCCESS_PAYLOAD)
+
+        run_vision = LM_STUDIO_HELPERS["_run_lm_studio_vision"]
+        LM_STUDIO_HELPERS["_pil_image_to_data_url"] = lambda image: "data:image/jpeg;base64,dGVzdA=="
+        payload = {
+            "lmstudio_base_url": "http://127.0.0.1:1234/v1",
+            "lmstudio_model": "test-model",
+            "seed": 42,
+        }
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side_effect) as urlopen_mock:
+            text = run_vision(payload, "describe this image", [object()])
+
+        self.assertEqual("Hello from LM Studio", text)
+        self.assertEqual(2, urlopen_mock.call_count)
+        self.assertEqual("off", calls[0]["reasoning"])
+        self.assertEqual("off", calls[1]["reasoning"])
+        self.assertNotIn("seed", calls[1])
+
+    def test_invalid_reasoning_mode_cannot_reach_lm_studio(self):
+        calls = []
+
+        def urlopen_side_effect(request, timeout=None):
+            calls.append(json.loads(request.data.decode("utf-8")))
+            return FakeLMStudioResponse(SUCCESS_PAYLOAD)
+
+        run_chat = LM_STUDIO_HELPERS["_run_lm_studio_native_chat"]
+        payload = {
+            "lmstudio_base_url": "http://127.0.0.1:1234/v1",
+            "lmstudio_model": "test-model",
+            "lmstudio_reasoning": "unsupported",
+        }
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+            run_chat(payload, "hello", 0.7, 0.9, 500, 30, "")
+
+        self.assertNotIn("reasoning", calls[0])
 
     def test_unrelated_bad_request_is_not_treated_as_seed_rejection(self):
         def urlopen_side_effect(request, timeout=None):


### PR DESCRIPTION
## What changed

- Default LM Studio vision requests to `reasoning: "off"` so hybrid reasoning models cannot consume the entire output budget before returning a visible answer.
- Keep text-only LM Studio requests unchanged unless a valid reasoning mode is explicitly supplied.
- Validate explicit reasoning modes against LM Studio's supported values: `off`, `low`, `medium`, `high`, and `on`.
- Preserve the selected reasoning mode when the existing compatibility path retries a request without the `seed` field.
- Add focused regression coverage for vision defaults, text compatibility, explicit overrides, invalid values, and seed retries.

## Why

Fixes #136. Hybrid reasoning models can otherwise spend all `max_output_tokens` on hidden reasoning and return no `message` item, causing Storyboard and other vision batches to stop with `LM Studio vision returned empty text.`

## Impact

The behavior change is scoped to LM Studio vision requests. Built-in GGUF, external LLM API runners, and existing text-only LM Studio requests are unaffected.

## Validation

- `python -B -m py_compile VRGDG_MusicVideoBuilderNodes.py tests/test_builder_lm_studio_seed_retry.py`
- `python -m unittest tests.test_builder_lm_studio_seed_retry tests.test_builder_llm_runner_grok_models tests.test_builder_llm_runner_token_limits -v` (20 passed)
- `git diff --check`