### PR TITLE
Fix MiniMax settings persistence across scenes

### DIFF
--- a/LLM.py
+++ b/LLM.py
@@ -3594,7 +3594,7 @@ class VRGDG_QwenGGUF(VRGDG_GeneralGGUF):
         "custom",
     ]
     MM_PROJ_PRESETS = {
-        "unsloth/Qwen3.8-27B-GGUF": "mmproj-BF16.gguf",
+        "unsloth/Qwen3.8-27B-GGUF": "qwen-mmproj-BF16.gguf",
     }
     _GEMMA_STOP_SEQUENCES = (
         "<|im_end|>",

--- a/tests/test_qwen_gguf_node.py
+++ b/tests/test_qwen_gguf_node.py
@@ -21,7 +21,7 @@ class QwenGgufNodeTests(unittest.TestCase):
         source = ast.get_source_segment(SOURCE, node)
         self.assertIn('"unsloth/Qwen3.8-27B-GGUF"', source)
         self.assertIn('"custom"', source)
-        self.assertIn('"mmproj-BF16.gguf"', source)
+        self.assertIn('"qwen-mmproj-BF16.gguf"', source)
         self.assertIn("class VRGDG_QwenGGUF(VRGDG_GeneralGGUF)", source)
 
     def test_qwen_template_and_stop_tokens_are_not_gemma_tokens(self):

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,41 @@
   "product": "AI Video Builder",
   "releases": [
     {
+      "id": "2026-08-21-pr151-minimax-qwen-save-fixes",
+      "version": "2026.08.21-pr151-minimax-qwen-save-fixes",
+      "date": "2026-08-21",
+      "title": "MiniMax two-pass diagnostics, Qwen downloads, and complete project saves",
+      "commit": "6fb6d556546769ee3c7087a6c9cd569f93d3f6de",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/pull/151",
+      "sections": [
+        {
+          "title": "Added",
+          "items": [
+            "MiniMax H3 two-pass progress now reports the exact Pass 1 and Pass 2 sampler steps from the built hidden workflow.",
+            "MiniMax H3 two-pass progress now reports the exact LoRAs and strengths attached to each pass in the built hidden workflow.",
+            "LLM model downloads now have separate Gemma and Qwen subtabs, with model-specific notes and folder guidance.",
+            "Qwen3.8-27B GGUF downloads now open the repository root so users can choose their preferred quantization and model files."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Fixed MiniMax two-pass settings being lost when switching scenes or starting a render; the active Pass 1 and Pass 2 controls are flushed directly into the request.",
+            "Fixed Quick Save and autosave omitting Gemma model, Qwen model, and Qwen mmproj selections from the saved project session.",
+            "Fixed Quick Save and autosave not flushing live MiniMax builder and scene settings before serialization."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "Restart ComfyUI and hard-refresh the browser after updating so the revised Builder JavaScript and saved-session behavior are loaded.",
+            "Qwen3.8 requires a selected GGUF model (including all shards for that quantization) and its matching vision mmproj. Rename the projector to qwen-mmproj-BF16.gguf when using it alongside Gemma."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-21-qwen-runner-project-recovery",
       "version": "2026.08.21-qwen-runner-project-recovery",
       "date": "2026-08-21",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -7353,8 +7353,10 @@ function openBuilder(node) {
     }
   }
 
-  function saveMiniMaxH3SettingsFromPanel(targetSegment = activeSegment()) {
-    const segment = targetSegment || activeSegment();
+  function saveMiniMaxH3SettingsFromPanel(targetSegment = null) {
+    // DOM event listeners pass their Event as the first argument. Only treat
+    // an actual scene object as an explicit target.
+    const segment = targetSegment?.id ? targetSegment : activeSegment();
     const currentSettings = miniMaxH3SettingsForSegment(segment);
     const loraEnabled = Boolean(miniMaxUseLoras.input.checked);
     const turboEnabled = Boolean(miniMaxUseTurboLora.input.checked) && !loraEnabled;
@@ -7392,6 +7394,7 @@ function openBuilder(node) {
           : miniMaxRefImageSize.value,
       two_pass_lora_name: miniMaxTwoPassLoraPicker.input.value,
       two_pass_lora_strength: miniMaxTwoPassLoraStrength.value,
+      two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.two_pass_defaults_version,
       two_pass_final_width: miniMaxTwoPassFinalWidth.value,
       two_pass_final_height: miniMaxTwoPassFinalHeight.value,
       two_pass_latent_upscale_scale: miniMaxTwoPassLatentScale.value,

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45490,12 +45490,50 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const exactTwoPassStepsLine = twoPass
         ? `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
         : "";
-      const loraLine = builtLoraSettings.enabled
-        ? `\nLoRAs: ${Number(builtLoraSettings.count || 0)} — ${(builtLoraSettings.loras || []).map((item) => `${item.name} @ ${item.strength}`).join(", ")}`
-        : "\nLoRAs: OFF";
-      const turboLine = builtTurboSettings.enabled
-        ? `\nTurbo: ON — effective steps ${Number(builtAdvancedSettings.effective_steps || builtTurboSettings.steps || miniMaxSettings.steps)}; LoRA ${builtTurboSettings.lora_name || miniMaxSettings.turbo_lora_name} @ ${builtTurboSettings.strength ?? miniMaxSettings.turbo_lora_strength}`
-        : `\nTurbo: OFF — steps ${Number(builtAdvancedSettings.steps || miniMaxSettings.steps)}`;
+      const exactModelChainLoras = (modelRef) => {
+        const loras = [];
+        const visited = new Set();
+        let currentRef = modelRef;
+        while (Array.isArray(currentRef) && currentRef.length >= 2) {
+          const nodeId = String(currentRef[0]);
+          if (visited.has(nodeId)) break;
+          visited.add(nodeId);
+          const promptNode = built?.prompt?.[nodeId];
+          if (!promptNode?.inputs) break;
+          const loraName = String(promptNode.inputs.lora_name || "").trim();
+          if (loraName && /lora/i.test(String(promptNode.class_type || ""))) {
+            loras.push({
+              nodeId,
+              name: loraName,
+              strength: Number(promptNode.inputs.strength_model),
+            });
+          }
+          currentRef = promptNode.inputs.model;
+        }
+        return loras.reverse();
+      };
+      const exactTwoPassLoras = twoPass
+        ? {
+          pass1: exactModelChainLoras(built?.prompt?.["124"]?.inputs?.model),
+          pass2: exactModelChainLoras(built?.prompt?.["192"]?.inputs?.model),
+        }
+        : null;
+      const formatExactLoras = (loras) => loras.length
+        ? loras.map((item) => `${item.name} @ ${Number.isFinite(item.strength) ? item.strength : "unknown strength"} [node ${item.nodeId}]`).join(" → ")
+        : "none";
+      const exactTwoPassLorasLine = twoPass
+        ? `\nExact built-prompt LoRAs:\nPass 1: ${formatExactLoras(exactTwoPassLoras.pass1)}\nPass 2: ${formatExactLoras(exactTwoPassLoras.pass2)}`
+        : "";
+      const loraLine = twoPass
+        ? exactTwoPassLorasLine
+        : builtLoraSettings.enabled
+          ? `\nLoRAs: ${Number(builtLoraSettings.count || 0)} — ${(builtLoraSettings.loras || []).map((item) => `${item.name} @ ${item.strength}`).join(", ")}`
+          : "\nLoRAs: OFF";
+      const turboLine = (twoPass || threePass)
+        ? ""
+        : builtTurboSettings.enabled
+          ? `\nTurbo: ON — effective steps ${Number(builtAdvancedSettings.effective_steps || builtTurboSettings.steps || miniMaxSettings.steps)}; LoRA ${builtTurboSettings.lora_name || miniMaxSettings.turbo_lora_name} @ ${builtTurboSettings.strength ?? miniMaxSettings.turbo_lora_strength}`
+          : `\nTurbo: OFF — steps ${Number(builtAdvancedSettings.steps || miniMaxSettings.steps)}`;
       const settingsScopeLine = `\nSettings scope: ${segment?.use_scene_minimax_h3_settings ? "locked scene settings" : "project/global settings"}`;
       const finalDuration = Number(postTrim.duration);
       if (!Number.isFinite(finalDuration) || Math.abs(finalDuration - sceneDuration) > 0.001) {
@@ -45591,7 +45629,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         promptId,
         (message) => {
           void registerLiveThreePassBackups();
-          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}\nPrompt ID: ${promptId}`, pct(62));
+          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}${exactTwoPassLorasLine}\nPrompt ID: ${promptId}`, pct(62));
         },
         () => state.batchCancelled,
         null,

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -14895,6 +14895,9 @@ function openBuilder(node) {
       clearSegmentFilmGrainPreview(activeSegment());
       updateActiveFromInputs({ skipHistory: true });
       saveI2VVideoSettingsFromPanel();
+      if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+        saveMiniMaxH3SettingsFromPanel();
+      }
     }
     state.activeId = segment?.id || "";
     state.activeTrack = segment ? segmentTrack(segment) : state.activeTrack || "base";

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -7061,6 +7061,7 @@ function openBuilder(node) {
     overlaySegments: [],
     overlayTrack: normalizeOverlayTrackState(),
     activeId: "",
+    miniMaxH3PanelSegmentId: "",
     activeTrack: "base",
     multiSelectMode: false,
     selectedSegmentIds: [],
@@ -7352,8 +7353,8 @@ function openBuilder(node) {
     }
   }
 
-  function saveMiniMaxH3SettingsFromPanel() {
-    const segment = activeSegment();
+  function saveMiniMaxH3SettingsFromPanel(targetSegment = activeSegment()) {
+    const segment = targetSegment || activeSegment();
     const currentSettings = miniMaxH3SettingsForSegment(segment);
     const loraEnabled = Boolean(miniMaxUseLoras.input.checked);
     const turboEnabled = Boolean(miniMaxUseTurboLora.input.checked) && !loraEnabled;
@@ -8063,6 +8064,7 @@ function openBuilder(node) {
   function syncMiniMaxH3Panel() {
     const miniMaxProject = normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3";
     const segment = activeSegment();
+    state.miniMaxH3PanelSegmentId = String(segment?.id || "");
     state.miniMaxH3Settings = cloneMiniMaxH3Settings(state.miniMaxH3Settings);
     const settings = miniMaxH3SettingsForSegment(segment);
     miniMaxDiffusionModelPicker.input.value = settings.diffusion_model_name;
@@ -15650,7 +15652,13 @@ function openBuilder(node) {
   }
 
   function syncInspector() {
+    const previousPanelSegmentId = String(state.miniMaxH3PanelSegmentId || "");
     const segment = activeSegment();
+    if (previousPanelSegmentId && previousPanelSegmentId !== String(segment?.id || "")
+      && normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+      const previousPanelSegment = allEditableSegments().find((item) => String(item?.id || "") === previousPanelSegmentId);
+      if (previousPanelSegment) saveMiniMaxH3SettingsFromPanel(previousPanelSegment);
+    }
     startInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
     lyricTextInput.dataset.vrgdgInspectorSegmentId = String(segment?.id || "");
     lyricTextInput.dataset.vrgdgUserEdited = "0";

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45478,6 +45478,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const builtLoraSettings = built?.lora_settings || {};
       const builtTurboSettings = built?.turbo_settings || {};
       const builtAdvancedSettings = built?.advanced_settings || {};
+      const exactTwoPassSteps = twoPass
+        ? {
+          pass1: Number(built?.prompt?.["124"]?.inputs?.steps),
+          pass2: Number(built?.prompt?.["190"]?.inputs?.value),
+        }
+        : null;
+      if (twoPass && (!Number.isInteger(exactTwoPassSteps.pass1) || !Number.isInteger(exactTwoPassSteps.pass2))) {
+        throw new Error("The built MiniMax H3 two-pass prompt is missing its exact sampler step values.");
+      }
+      const exactTwoPassStepsLine = twoPass
+        ? `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
+        : "";
       const loraLine = builtLoraSettings.enabled
         ? `\nLoRAs: ${Number(builtLoraSettings.count || 0)} — ${(builtLoraSettings.loras || []).map((item) => `${item.name} @ ${item.strength}`).join(", ")}`
         : "\nLoRAs: OFF";
@@ -45498,6 +45510,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         + `Timeline: ${sceneDuration.toFixed(3)}s\n`
         + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`
         + (threePass ? "\nStage 1 and Stage 2 are saved as backups; Stage 3 will be used for stitching." : twoPass ? "\nPass 1 is learned-latent upscaled and refined by pass 2; the final pass-2 video will be used for stitching." : "")
+        + exactTwoPassStepsLine
         + loraLine
         + turboLine
         + settingsScopeLine
@@ -45578,7 +45591,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         promptId,
         (message) => {
           void registerLiveThreePassBackups();
-          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}\nPrompt ID: ${promptId}`, pct(62));
+          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}\nPrompt ID: ${promptId}`, pct(62));
         },
         () => state.batchCancelled,
         null,

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -606,7 +606,9 @@ const ERNIE_MODEL_DOWNLOADS = [
 const LLM_MODEL_DOWNLOADS = [
   { label: "SuperGemma GGUF", url: "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2/resolve/main/supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf" },
   { label: "Gemma Vision GGUF", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/gemma-4-26B-A4B-it-UD-IQ2_M.gguf" },
-  { label: "Vision mmproj", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-BF16.gguf" },
+  { label: "Gemma Vision mmproj", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-BF16.gguf" },
+  { label: "Qwen3.8-27B GGUF (download all Q4_K_XL shards)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/tree/main/UD-Q4_K_XL" },
+  { label: "Qwen3.8 vision mmproj (rename to qwen-mmproj-BF16.gguf)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-BF16.gguf" },
 ];
 const MODEL_FOLDER_HINTS = {
   "LLM / Vision": `ComfyUI/
@@ -614,7 +616,10 @@ models/
   LLM/
     supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf
     gemma-4-26B-A4B-it-UD-IQ2_M.gguf
-    mmproj-BF16.gguf`,
+    mmproj-BF16.gguf
+
+Qwen3.8 requires BOTH the model GGUF shards and its matching vision mmproj.
+Rename the downloaded Qwen projector to qwen-mmproj-BF16.gguf so it is not confused with Gemma's mmproj-BF16.gguf.`,
   "ZImage": `ComfyUI/
 models/
   text_encoders/
@@ -1575,7 +1580,7 @@ function showModelDownloadModal() {
       id: "llm",
       label: "LLM Models",
       groups: [
-        { title: "LLM / Vision", note: "Use SuperGemma for text prompting. Use Gemma Vision GGUF plus mmproj for image-reference prompting.", downloads: LLM_MODEL_DOWNLOADS },
+        { title: "LLM / Vision", note: "Use SuperGemma for text prompting. Use Gemma Vision GGUF plus its matching mmproj for image-reference prompting. Qwen3.8 requires both the GGUF model shards and its matching mmproj; rename the Qwen projector to qwen-mmproj-BF16.gguf so it is not confused with Gemma's mmproj-BF16.gguf.", downloads: LLM_MODEL_DOWNLOADS },
       ],
     },
     {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -36463,6 +36463,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     try {
       updateActiveFromInputs();
       saveI2VVideoSettingsFromPanel();
+      // Quick Save must capture the live builder panels before serializing the
+      // session, including MiniMax's scene/project-scoped controls.
+      if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+        saveMiniMaxH3SettingsFromPanel();
+        saveMiniMaxSceneInputsFromPanel();
+      }
       ensureAllSegmentRuntimeFields();
       const projectFolder = activeProjectFolderForSave();
       if (!projectFolder) {
@@ -36664,6 +36670,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     try {
       updateActiveFromInputs();
       saveI2VVideoSettingsFromPanel();
+      if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
+        saveMiniMaxH3SettingsFromPanel();
+        saveMiniMaxSceneInputsFromPanel();
+      }
       const projectFolder = activeProjectFolderForSave();
       if (!projectFolder) {
         console.warn(`[VRGDG Music Builder] Autosave skipped before ${reason || "action"} because no active project is set.`);
@@ -49287,7 +49297,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         concept_match_mode: "medium",
         append_subject_to_prompts: true,
         repair_lyric_segments: false,
-        text_gemma_runner: state.textGemmaRunner || "builtin",
+      text_gemma_runner: state.textGemmaRunner || "builtin",
+      qwen_model_file: state.qwenModelFile || "",
+      qwen_mmproj_file: state.qwenMmprojFile || "",
+      gemma_model_file: state.gemmaModelFile || "",
         gemma_context_limit: normalizeGemmaContextLimit(state.gemmaContextLimit),
         gemma_output_token_limit: normalizeOutputTokenLimit(state.gemmaOutputTokenLimit),
         gemma_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -603,23 +603,32 @@ const ERNIE_MODEL_DOWNLOADS = [
   { label: "Ministral text encoder", url: "https://huggingface.co/Comfy-Org/ERNIE-Image/resolve/main/text_encoders/ministral-3-3b.safetensors" },
   { label: "Ernie VAE", url: "https://huggingface.co/Comfy-Org/ERNIE-Image/resolve/main/vae/flux2-vae.safetensors" },
 ];
-const LLM_MODEL_DOWNLOADS = [
+const GEMMA_LLM_MODEL_DOWNLOADS = [
   { label: "SuperGemma GGUF", url: "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2/resolve/main/supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf" },
   { label: "Gemma Vision GGUF", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/gemma-4-26B-A4B-it-UD-IQ2_M.gguf" },
   { label: "Gemma Vision mmproj", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-BF16.gguf" },
+];
+const QWEN_LLM_MODEL_DOWNLOADS = [
   { label: "Qwen3.8-27B GGUF (choose a quantization/model)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/tree/main" },
   { label: "Qwen3.8 vision mmproj (rename to qwen-mmproj-BF16.gguf)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-BF16.gguf" },
 ];
 const MODEL_FOLDER_HINTS = {
-  "LLM / Vision": `ComfyUI/
+  "LLM / Gemma": `ComfyUI/
 models/
   LLM/
     supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf
     gemma-4-26B-A4B-it-UD-IQ2_M.gguf
     mmproj-BF16.gguf
 
-Qwen3.8 requires BOTH the model GGUF shards and its matching vision mmproj.
-Rename the downloaded Qwen projector to qwen-mmproj-BF16.gguf so it is not confused with Gemma's mmproj-BF16.gguf.`,
+Gemma Vision requires both the model GGUF and its matching mmproj.`,
+  "LLM / Qwen": `ComfyUI/
+models/
+  LLM/
+    <chosen Qwen3.8 GGUF model files>
+    qwen-mmproj-BF16.gguf
+
+Qwen3.8 requires BOTH the chosen model GGUF (including all shards for that quantization) and its matching vision mmproj.
+Rename the downloaded Qwen projector to qwen-mmproj-BF16.gguf.`,
   "ZImage": `ComfyUI/
 models/
   text_encoders/
@@ -1579,8 +1588,21 @@ function showModelDownloadModal() {
     {
       id: "llm",
       label: "LLM Models",
-      groups: [
-        { title: "LLM / Vision", note: "Use SuperGemma for text prompting. Use Gemma Vision GGUF plus its matching mmproj for image-reference prompting. Qwen3.8 requires both the GGUF model shards and its matching mmproj; rename the Qwen projector to qwen-mmproj-BF16.gguf so it is not confused with Gemma's mmproj-BF16.gguf.", downloads: LLM_MODEL_DOWNLOADS },
+      subTabs: [
+        {
+          id: "gemma",
+          label: "Gemma",
+          groups: [
+            { title: "LLM / Gemma", note: "SuperGemma is used for text prompting. Gemma Vision GGUF plus its matching mmproj are used for image-reference prompting.", downloads: GEMMA_LLM_MODEL_DOWNLOADS },
+          ],
+        },
+        {
+          id: "qwen",
+          label: "Qwen",
+          groups: [
+            { title: "LLM / Qwen", note: "Qwen3.8 requires both a chosen GGUF model (including all shards for that quantization) and its matching vision mmproj. Rename the projector to qwen-mmproj-BF16.gguf so it is not confused with Gemma's mmproj-BF16.gguf.", downloads: QWEN_LLM_MODEL_DOWNLOADS },
+          ],
+        },
       ],
     },
     {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45215,6 +45215,11 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   }
 
   async function renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, options = {}) {
+    // The panel can still contain a newer value than the project object when a
+    // render is started immediately after editing a field. Flush the active
+    // scene one last time before taking the settings snapshot used to build
+    // the hidden workflow.
+    if (segment?.id === activeSegment()?.id) saveMiniMaxH3SettingsFromPanel();
     const progressBase = Number(options.progressBase ?? 0);
     const progressSpan = Number(options.progressSpan ?? 100);
     const batchLabel = options.batchLabel ? `${options.batchLabel}\n` : "";

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -14916,12 +14916,15 @@ function openBuilder(node) {
   }
 
   function setActiveSegment(segment) {
-    if (state.activeId && state.activeId !== segment?.id) {
-      clearSegmentLutPreview(activeSegment());
-      clearSegmentAdjustPreview(activeSegment());
-      clearSegmentFilmGrainPreview(activeSegment());
+    const displayedSegment = activeSegment();
+    if (displayedSegment && displayedSegment.id !== segment?.id) {
+      clearSegmentLutPreview(displayedSegment);
+      clearSegmentAdjustPreview(displayedSegment);
+      clearSegmentFilmGrainPreview(displayedSegment);
       updateActiveFromInputs({ skipHistory: true });
       saveI2VVideoSettingsFromPanel();
+      // Snapshot the visible MiniMax panel before changing scenes. Do not rely
+      // on state.activeId here; some selection paths update it first.
       if (normalizeProjectVideoEngine(state.projectVideoEngine) === "minimax_h3") {
         saveMiniMaxH3SettingsFromPanel();
       }

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -607,7 +607,7 @@ const LLM_MODEL_DOWNLOADS = [
   { label: "SuperGemma GGUF", url: "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2/resolve/main/supergemma4-26b-uncensored-fast-v2-Q4_K_M.gguf" },
   { label: "Gemma Vision GGUF", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/gemma-4-26B-A4B-it-UD-IQ2_M.gguf" },
   { label: "Gemma Vision mmproj", url: "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-BF16.gguf" },
-  { label: "Qwen3.8-27B GGUF (download all Q4_K_XL shards)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/tree/main/UD-Q4_K_XL" },
+  { label: "Qwen3.8-27B GGUF (choose a quantization/model)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/tree/main" },
   { label: "Qwen3.8 vision mmproj (rename to qwen-mmproj-BF16.gguf)", url: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-BF16.gguf" },
 ];
 const MODEL_FOLDER_HINTS = {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45220,6 +45220,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     // scene one last time before taking the settings snapshot used to build
     // the hidden workflow.
     if (segment?.id === activeSegment()?.id) saveMiniMaxH3SettingsFromPanel();
+    const panelSegmentId = activeSegment()?.id;
     const progressBase = Number(options.progressBase ?? 0);
     const progressSpan = Number(options.progressSpan ?? 100);
     const batchLabel = options.batchLabel ? `${options.batchLabel}\n` : "";
@@ -45376,6 +45377,13 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     state.activeId = segment.id;
     segment.video_status = "running";
     renderList();
+    const activePanel = segment?.id === panelSegmentId;
+    const requestedTwoPassSteps = twoPass && activePanel
+      ? {
+        pass1: Math.max(1, Math.min(1000, Math.trunc(Number(twoPassControls[0].steps.value) || 20))),
+        pass2: Math.max(1, Math.min(1000, Math.trunc(Number(twoPassControls[1].steps.value) || 5))),
+      }
+      : null;
     progress?.set(`${batchLabel}Preparing exact MiniMax H3 scene timing and ${builtInAudio ? "native audio generation" : "input audio"}...`, pct(8));
 
     try {
@@ -45421,12 +45429,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         output_crf: twoPass ? miniMaxSettings.two_pass_output_crf : undefined,
         three_pass_lightx_lora_name: miniMaxSettings.three_pass_lightx_lora_name,
         three_pass_lightx_lora_strength: miniMaxSettings.three_pass_lightx_lora_strength,
-        pass1_steps: twoPass ? miniMaxSettings.two_pass_pass1_steps : miniMaxSettings.steps,
+        pass1_steps: twoPass ? (requestedTwoPassSteps?.pass1 ?? miniMaxSettings.two_pass_pass1_steps) : miniMaxSettings.steps,
         pass1_denoise: twoPass ? miniMaxSettings.two_pass_pass1_denoise : miniMaxSettings.denoise,
         pass1_sampler_name: twoPass ? miniMaxSettings.two_pass_pass1_sampler : miniMaxSettings.sampler_name,
         pass1_scheduler: twoPass ? miniMaxSettings.two_pass_pass1_scheduler : miniMaxSettings.scheduler,
         pass1_seed: twoPass ? miniMaxSettings.two_pass_pass1_seed : miniMaxSettings.seed,
-        pass2_steps: twoPass ? miniMaxSettings.two_pass_pass2_steps : 4,
+        pass2_steps: twoPass ? (requestedTwoPassSteps?.pass2 ?? miniMaxSettings.two_pass_pass2_steps) : 4,
         pass2_denoise: twoPass ? miniMaxSettings.two_pass_pass2_denoise : 0.2,
         pass2_sampler_name: twoPass ? miniMaxSettings.two_pass_pass2_sampler : miniMaxSettings.sampler_name,
         pass2_scheduler: twoPass ? miniMaxSettings.two_pass_pass2_scheduler : miniMaxSettings.scheduler,
@@ -45498,7 +45506,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         throw new Error("The built MiniMax H3 two-pass prompt is missing its exact sampler step values.");
       }
       const exactTwoPassStepsLine = twoPass
-        ? `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
+        ? `\nRequested panel steps: Pass 1 = ${requestedTwoPassSteps?.pass1 ?? miniMaxSettings.two_pass_pass1_steps}; Pass 2 = ${requestedTwoPassSteps?.pass2 ?? miniMaxSettings.two_pass_pass2_steps}`
+          + `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
         : "";
       const exactModelChainLoras = (modelRef) => {
         const loras = [];


### PR DESCRIPTION
## Summary
- save the current MiniMax H3 panel settings before switching active scenes
- prevent two-pass values such as Pass 1 steps from reverting during scene navigation
- show exact Pass 1 and Pass 2 sampler steps read from the server-built ComfyUI prompt
- trace each pass's executed sampler model chain and list every actual LoRA filename, strength, and hidden node ID
- add Qwen3.8-27B GGUF and matching vision mmproj downloads under LLMs
- require the Qwen projector to be renamed to qwen-mmproj-BF16.gguf so it cannot be confused with Gemma's mmproj-BF16.gguf
- keep exact queued step and LoRA details visible while the workflow is running

## Validation
- parsed VRGDG_MusicVideoBuilderUI.js in JavaScript module mode
- ran git diff --check
- ran python -m unittest tests.test_qwen_gguf_node -v
- ran python -m py_compile LLM.py