### PR TITLE
Persist canonical lyrics for story arc generation

### DIFF
--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -669,7 +669,7 @@ def _new_builder_project(payload):
     os.makedirs(_images_folder(target), exist_ok=True)
     os.makedirs(_prompts_folder(target), exist_ok=True)
     os.makedirs(_context_folder(target), exist_ok=True)
-    for filename in ("ConceptPrompts.txt", "I2VMotionNotes.txt", "themestyle.txt", "storyconcept.txt", "subjectsandscenes.txt"):
+    for filename in ("ConceptPrompts.txt", "I2VMotionNotes.txt", "themestyle.txt", "storyconcept.txt", "subjectsandscenes.txt", "full_lyrics.txt"):
         path = os.path.join(_context_folder(target), filename)
         if not os.path.exists(path):
             with open(path, "w", encoding="utf-8") as handle:
@@ -904,6 +904,22 @@ def _prompts_folder(project_folder):
 
 def _context_folder(project_folder):
     return os.path.join(project_folder, "project_context")
+
+
+def _save_canonical_full_lyrics(project_folder, lyrics):
+    """Persist the user's complete source lyrics without timeline reconstruction."""
+    text = str(lyrics or "").strip()
+    if not text:
+        return ""
+    context_folder = _context_folder(project_folder)
+    os.makedirs(context_folder, exist_ok=True)
+    path = os.path.join(context_folder, "full_lyrics.txt")
+    temporary_path = path + ".tmp"
+    with open(temporary_path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.write("\n")
+    os.replace(temporary_path, path)
+    return path
 
 
 _BUILDER_INSTRUCTION_DEFAULTS = {
@@ -8903,6 +8919,13 @@ def _save_builder_session(payload):
         "segments": segments,
     }
 
+    # The complete text pasted into Line Mapper/Auto Build is the project's
+    # canonical lyric source. Never rebuild this file from timestamped scene
+    # notes because those notes legitimately contain detected instrumental gaps
+    # and may split or repeat song sections.
+    lyric_mapper = session.get("lyric_mapper") if isinstance(session.get("lyric_mapper"), dict) else {}
+    full_lyrics_path = _save_canonical_full_lyrics(project_folder, lyric_mapper.get("source_text"))
+
     srt_text = _segments_to_srt(segments)
     _backup_session_file(project_folder)
     with open(_session_path(project_folder), "w", encoding="utf-8") as handle:
@@ -8932,6 +8955,7 @@ def _save_builder_session(payload):
         "images_folder": _images_folder(project_folder),
         "prompts_folder": _prompts_folder(project_folder),
         "context_folder": _context_folder(project_folder),
+        "full_lyrics_path": full_lyrics_path,
         "model_defaults_path": model_defaults_path,
         "scene_notes_path": scene_notes_path,
         "session": session,

--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -1985,10 +1985,11 @@ def _build_story_layer_arc(payload):
                     prompt_creator_lyrics = _clean_scene_text(handle.read(), 40000)
             except OSError:
                 prompt_creator_lyrics = ""
-    # The lyrics currently open in Line Mapping are the live user input and must
-    # win over a potentially stale project_context/full_lyrics.txt file.
-    lyrics = line_mapping_lyrics or prompt_creator_lyrics or timeline_lyrics
-    lyrics_source = "Line Mapping reference lyrics" if line_mapping_lyrics else ("Prompt Creator reference lyrics" if prompt_creator_lyrics else "timeline scene lyrics")
+    # project_context/full_lyrics.txt is the canonical, user-pasted song source.
+    # Timeline lyrics contain detected instrumental gaps and must only be a
+    # fallback when the project has no saved complete lyric text yet.
+    lyrics = prompt_creator_lyrics or line_mapping_lyrics or timeline_lyrics
+    lyrics_source = "project full_lyrics.txt" if prompt_creator_lyrics else ("Line Mapping reference lyrics" if line_mapping_lyrics else "timeline scene lyrics")
     lyric_sections = _parse_story_arc_lyric_sections(
         lyrics,
         collapse_adjacent=not bool(line_mapping_lyrics or prompt_creator_lyrics),
@@ -2052,7 +2053,6 @@ def _build_story_layer_arc(payload):
             "scene_number": normalized["scene_number"],
             "label": normalized["label"],
             "lyric_section": normalized.get("lyric_section", ""),
-            "lyrics": normalized.get("lyrics", "")[:500],
         })
         for subject in normalized.get("subject_refs") or []:
             if not isinstance(subject, dict):

--- a/tests/test_builder_canonical_lyrics.py
+++ b/tests/test_builder_canonical_lyrics.py
@@ -1,0 +1,55 @@
+import ast
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_SOURCE = ROOT / "VRGDG_MusicVideoBuilderNodes.py"
+STORY_SOURCE = ROOT / "VRGDG_StoryboardBuilderNodes.py"
+UI_SOURCE = ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js"
+
+
+def load_save_helper():
+    tree = ast.parse(NODE_SOURCE.read_text(encoding="utf-8"), filename=str(NODE_SOURCE))
+    nodes = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in {"_context_folder", "_save_canonical_full_lyrics"}
+    ]
+    namespace = {"os": os}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(NODE_SOURCE), "exec"), namespace)
+    return namespace["_save_canonical_full_lyrics"]
+
+
+class BuilderCanonicalLyricsTests(unittest.TestCase):
+    def test_canonical_lyrics_are_saved_verbatim_except_outer_whitespace(self):
+        save_lyrics = load_save_helper()
+        lyrics = "[Intro]\nFirst line\n\n[Outro]\nLast line"
+        with tempfile.TemporaryDirectory() as folder:
+            path = save_lyrics(folder, f"\n{lyrics}\n")
+            self.assertEqual(Path(path).read_text(encoding="utf-8"), lyrics + "\n")
+
+    def test_blank_session_value_does_not_erase_existing_canonical_lyrics(self):
+        save_lyrics = load_save_helper()
+        with tempfile.TemporaryDirectory() as folder:
+            path = save_lyrics(folder, "[Verse]\nKeep me")
+            self.assertEqual(save_lyrics(folder, ""), "")
+            self.assertEqual(Path(path).read_text(encoding="utf-8"), "[Verse]\nKeep me\n")
+
+    def test_story_arc_prefers_project_full_lyrics_over_timeline_sections(self):
+        source = STORY_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("lyrics = prompt_creator_lyrics or line_mapping_lyrics or timeline_lyrics", source)
+        arc_start = source.index("def _build_story_layer_arc")
+        compact_start = source.index("compact_scenes.append({", arc_start)
+        compact_block = source[compact_start:source.index("reference_builder =", compact_start)]
+        self.assertNotIn('"lyrics": normalized.get("lyrics"', compact_block)
+
+    def test_auto_build_and_transcription_capture_reference_source(self):
+        source = UI_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("source_text: referenceLyrics", source)
+        self.assertIn("source_text: lyrics", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -24748,6 +24748,12 @@ function openBuilder(node) {
       toast("Load an audio file first.", true);
       return false;
     }
+    if (String(options.referenceLyrics || "").trim()) {
+      state.lyricMapper = normalizeLyricMapper({
+        ...state.lyricMapper,
+        source_text: String(options.referenceLyrics || "").trim(),
+      });
+    }
     let progress = null;
     try {
       progress = createProgressWindow("Creating Scenes From Timestamped Lines");
@@ -24896,6 +24902,10 @@ function openBuilder(node) {
     if (!referenceLyrics) {
       throw new Error("Reference lyrics are required for Transcribe Existing Scenes so lyric lines cannot be silently omitted.");
     }
+    state.lyricMapper = normalizeLyricMapper({
+      ...state.lyricMapper,
+      source_text: referenceLyrics,
+    });
 
     if (runtime.saveTimelineFirst !== false) {
       progress?.set("Saving current scene boundaries...", 5);
@@ -53390,6 +53400,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         lyricsInput.focus();
         return;
       }
+      // Preserve exactly what the user pasted as the project's canonical song
+      // text before timestamping adds instrumental gaps to scene-level notes.
+      state.lyricMapper = normalizeLyricMapper({
+        ...state.lyricMapper,
+        source_text: lyrics,
+      });
       if (!selected.singer) {
         toast("Choose one singer reference image before starting Auto Build.", true);
         return;


### PR DESCRIPTION
## Summary
- Persist the complete user-provided lyrics as `project_context/full_lyrics.txt`.
- Prefer the canonical full lyrics when generating story arcs, with timeline lyrics only as a fallback.
- Preserve the source lyrics from Line Mapper, Auto Build, and transcription flows.
- Add regression tests for canonical lyric persistence and source capture.

This PR contains the canonical-lyrics changes only; the MiniMax two-pass work was merged separately in PR #151.