### PR TITLE
Keep scene beats visual-only and preserve builder edits

### DIFF
--- a/VRGDG_MiniMaxH3LatentUpscaler.py
+++ b/VRGDG_MiniMaxH3LatentUpscaler.py
@@ -17,6 +17,13 @@ import comfy.nested_tensor
 MODEL_TYPE = "VRGDG_MINIMAX_H3_LATENT_UPSCALE_MODEL"
 _BACKEND_MODULE_NAME = "_vrgdg_minimax_h3_learned_upscale_backend"
 _MODEL_CACHE = {}
+_LATENT_UPSCALE_FOLDER = "latent_upscale_models"
+
+if _LATENT_UPSCALE_FOLDER not in folder_paths.folder_names_and_paths:
+    folder_paths.add_model_folder_path(
+        _LATENT_UPSCALE_FOLDER,
+        os.path.join(folder_paths.models_dir, _LATENT_UPSCALE_FOLDER),
+    )
 
 
 def _backend_path():
@@ -68,6 +75,26 @@ def _resolve_model_path(model_name):
             f"Registered model folders: {searched}"
         )
     return os.path.abspath(path)
+
+
+def _resolve_registered_model_path(model_name):
+    """Resolve an H3 checkpoint across every registered model directory."""
+    requested = str(model_name or "").strip()
+    if not requested or requested.startswith("["):
+        raise FileNotFoundError("No MiniMax H3 latent-upscale model was selected.")
+    for root in folder_paths.get_folder_paths(_LATENT_UPSCALE_FOLDER):
+        candidate = os.path.abspath(os.path.join(str(root), requested))
+        if os.path.isfile(candidate):
+            return candidate
+    # ComfyUI's resolver also understands configured secondary paths and
+    # subfolder names.  Keep this fallback for custom folder-path providers.
+    resolved = folder_paths.get_full_path(_LATENT_UPSCALE_FOLDER, requested)
+    if resolved and os.path.isfile(resolved):
+        return os.path.abspath(resolved)
+    raise FileNotFoundError(
+        f"MiniMax H3 latent-upscale model '{requested}' was not found in registered "
+        f"latent_upscale_models folders: {folder_paths.get_folder_paths(_LATENT_UPSCALE_FOLDER)}"
+    )
 
 
 def _load_model(model_name, device_name, precision):
@@ -138,6 +165,47 @@ class VRGDG_MiniMaxH3LatentUpscaleModelLoader:
                 "No models were found in ComfyUI's registered latent_upscale_models folders."
             )
         return (_load_model(model_name, device, precision),)
+
+
+class VRGDG_MiniMaxH3UltimateUpscaleParams:
+    """Reliable H3 parameter node for the upstream MMH3 Ultimate Upscale node.
+
+    The upstream parameter node builds its Combo options from only one model
+    directory at import time.  This node resolves all registered directories
+    at execution time and emits the absolute checkpoint path in the shared
+    parameter dictionary, so the upstream processor can load the chosen file
+    regardless of which ComfyUI model path contains it.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        models = _model_choices()
+        if not models:
+            models = ["[no MiniMax H3 models found in registered latent_upscale_models folders]"]
+        return {
+            "required": {
+                "model_name": (models,),
+                "width": ("INT", {"default": 1280, "min": 64, "max": 4096, "step": 32}),
+                "height": ("INT", {"default": 704, "min": 64, "max": 4096, "step": 32}),
+                "device": (["cuda", "cpu"], {"default": "cuda"}),
+                "precision": (["bf16", "fp16", "fp32"], {"default": "bf16"}),
+            }
+        }
+
+    RETURN_TYPES = ("H3_UPSCALE_PARAM",)
+    RETURN_NAMES = ("latent_upscale_param",)
+    FUNCTION = "create"
+    CATEGORY = "VRGDG/Video/MiniMax H3"
+
+    def create(self, model_name, width, height, device, precision):
+        path = _resolve_registered_model_path(model_name)
+        return ({
+            "model_name": path,
+            "width": int(round(int(width) / 32.0)) * 32,
+            "height": int(round(int(height) / 32.0)) * 32,
+            "device": device,
+            "precision": precision,
+        },)
 
 
 class VRGDG_MiniMaxH3LearnedLatentUpscale:
@@ -261,12 +329,14 @@ class VRGDG_MiniMaxH3ReplaceUpscaledVideoLatent:
 
 NODE_CLASS_MAPPINGS = {
     "VRGDG_MiniMaxH3LatentUpscaleModelLoader": VRGDG_MiniMaxH3LatentUpscaleModelLoader,
+    "VRGDG_MiniMaxH3UltimateUpscaleParams": VRGDG_MiniMaxH3UltimateUpscaleParams,
     "VRGDG_MiniMaxH3LearnedLatentUpscale": VRGDG_MiniMaxH3LearnedLatentUpscale,
     "VRGDG_MiniMaxH3ReplaceUpscaledVideoLatent": VRGDG_MiniMaxH3ReplaceUpscaledVideoLatent,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "VRGDG_MiniMaxH3LatentUpscaleModelLoader": "Load MiniMax H3 Learned Latent Upscaler",
+    "VRGDG_MiniMaxH3UltimateUpscaleParams": "MiniMax H3 Ultimate Upscale Params (VRGDG)",
     "VRGDG_MiniMaxH3LearnedLatentUpscale": "MiniMax H3 Learned Latent Upscale",
     "VRGDG_MiniMaxH3ReplaceUpscaledVideoLatent": "MiniMax H3 Replace with Upscaled Video Latent",
 }

--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -9119,6 +9119,21 @@ def _save_builder_session_unlocked(payload):
     session_path = _session_path(project_folder)
     if isinstance(payload.get("project_context_files"), dict):
         session["project_context_files"] = dict(payload["project_context_files"])
+    incoming_revision = int(session.get("builder_save_revision") or 0)
+    if incoming_revision > 0 and os.path.isfile(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8-sig") as handle:
+                existing_session = json.load(handle)
+            existing_revision = int(existing_session.get("builder_save_revision") or 0) if isinstance(existing_session, dict) else 0
+            if existing_revision > incoming_revision:
+                print(
+                    "[VRGDG Music Builder] Ignored stale session snapshot: "
+                    f"incoming revision {incoming_revision} < saved revision {existing_revision}."
+                )
+                session = existing_session
+                segments = session.get("segments", []) if isinstance(session.get("segments"), list) else []
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            print(f"[VRGDG Music Builder] Save revision check skipped: {exc}")
     # Autosave requests can race a reference-builder panel update. If the
     # incoming snapshot has a null catalog, retain the last known catalog
     # instead of turning a valid project into a prompt-only project.

--- a/VRGDG_MusicVideoBuilderNodes.py
+++ b/VRGDG_MusicVideoBuilderNodes.py
@@ -9116,11 +9116,6 @@ def _save_builder_session_unlocked(payload):
     segments = session.get("segments", [])
     if not isinstance(segments, list):
         segments = []
-    # A stale browser inspector/autosave must never be able to erase most of a
-    # populated transcription in one ordinary save. Preserve blanked lyric
-    # fields when the incoming session contains the same scene IDs but suddenly
-    # loses at least half of two or more existing lyric lines. A deliberate bulk
-    # clearing tool can opt out explicitly; normal one-line edits remain valid.
     session_path = _session_path(project_folder)
     if isinstance(payload.get("project_context_files"), dict):
         session["project_context_files"] = dict(payload["project_context_files"])
@@ -9136,52 +9131,6 @@ def _save_builder_session_unlocked(payload):
                 session["flux_reference_builder"] = previous_refs
         except Exception as exc:
             print(f"[VRGDG Music Builder] Previous reference-builder state could not be recovered: {exc}")
-    if not bool(session.get("allow_bulk_lyric_clear")) and os.path.isfile(session_path):
-        try:
-            with open(session_path, "r", encoding="utf-8-sig") as handle:
-                existing_session = json.load(handle)
-            existing_segments = existing_session.get("segments", []) if isinstance(existing_session, dict) else []
-            existing_by_id = {
-                str(item.get("id") or "").strip(): item
-                for item in existing_segments
-                if isinstance(item, dict) and str(item.get("id") or "").strip()
-            }
-            matched = [
-                (item, existing_by_id.get(str(item.get("id") or "").strip()))
-                for item in segments
-                if isinstance(item, dict)
-            ]
-            matched = [(incoming, existing) for incoming, existing in matched if isinstance(existing, dict)]
-            existing_nonblank = [
-                (incoming, existing)
-                for incoming, existing in matched
-                if str(existing.get("lyric_text") or "").strip()
-            ]
-            erased = [
-                (incoming, existing)
-                for incoming, existing in existing_nonblank
-                if not str(incoming.get("lyric_text") or "").strip()
-            ]
-            catastrophic = (
-                len(existing_nonblank) >= 2
-                and len(erased) >= 2
-                and len(erased) * 2 >= len(existing_nonblank)
-            )
-            if catastrophic:
-                lyric_fields = (
-                    "lyric_text", "lyric_no_lip_sync", "lyric_section",
-                    "lyric_singers", "performance_mode", "no_character_present",
-                )
-                for incoming, existing in erased:
-                    for key in lyric_fields:
-                        if key in existing:
-                            incoming[key] = existing[key]
-                print(
-                    "[VRGDG Music Builder] Prevented accidental bulk lyric clearing: "
-                    f"restored {len(erased)} of {len(existing_nonblank)} populated scene lines."
-                )
-        except Exception as exc:
-            print(f"[VRGDG Music Builder] Lyric save safety check skipped: {exc}")
     overlay_segments = session.get("overlay_segments", [])
     if not isinstance(overlay_segments, list):
         overlay_segments = []

--- a/VRGDG_StoryboardBuilderNodes.py
+++ b/VRGDG_StoryboardBuilderNodes.py
@@ -2395,6 +2395,56 @@ def _parse_flf_endpoint_json(text):
     return json.loads(candidate)
 
 
+_SCENE_BEAT_AUDIO_LANGUAGE = re.compile(
+    r"\b(?:lip[\s-]?sync(?:ing)?|sings?|singing|sang|lyrics?|lyric|"
+    r"vocals?|vocalizing|vocalizes?|rapping|raps?|music|instrumental|"
+    r"performing vocals?)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _scene_beat_has_audio_language(text):
+    """Return whether a narrative scene beat leaks performance/audio metadata."""
+    return bool(_SCENE_BEAT_AUDIO_LANGUAGE.search(str(text or "")))
+
+
+def _strip_scene_beat_audio_language(text):
+    """Remove common performance phrasing from a beat as a final safety net.
+
+    Scene beats are consumed as visual story guidance. Audio/performance metadata
+    belongs to the video-prompt stage and must never become part of this field.
+    """
+    cleaned = _clean_scene_text(text, 1800)
+    if not cleaned:
+        return ""
+    # Preserve the useful visual clause in constructions such as:
+    # "Singer visibly sings ... as her fingertips trace ...".
+    cleaned = re.sub(
+        r"\b(?:the\s+)?(?:singer|performer|vocalist)\s+(?:visibly\s+)?"
+        r"(?:sings?|sang|is\s+singing|performs?)\b"
+        r"(?:\s+(?:through|during|over)\s+[^,.;!?]+)?\s+as\s+",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"\b(?:while|as)\s+(?:she|he|they|the\s+(?:singer|performer|vocalist))\s+"
+        r"(?:sings?|sang|is\s+singing|performs?)\b\s*[,]?\s*",
+        "while ",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    # Drop any residual sentence that is solely an audio/performance aside.
+    sentences = re.split(r"(?<=[.!?])\s+", cleaned)
+    sentences = [
+        sentence for sentence in sentences
+        if not _scene_beat_has_audio_language(sentence)
+    ]
+    cleaned = " ".join(sentences)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip(" \t\n,;:-")
+    return cleaned
+
+
 def _build_story_layer_scene_beat(payload):
     scene_bundle = payload.get("storyboard_payload") or payload.get("scene_bundle") or payload.get("gpt_payload")
     if not isinstance(scene_bundle, dict):
@@ -2499,8 +2549,8 @@ def _build_story_layer_scene_beat(payload):
         "Rules:\n"
         "- Use the Song Story Brief and User Story Arc as continuity anchors.\n"
         "- Use the selected scene lyrics, lyric section, subject details, location details, vocal status, and no-character flag.\n"
-        "- Vocal casting is absolute: follow the Performer assignment exactly. Only names in its singing list may sing. Every name in its silent list must remain visibly present but silent. Never write that both/all visible subjects sing unless both/all are explicitly in the singing list. If the singing list has one name, use singular wording: that performer sings; the other subject does not sing.\n"
-        "- This request creates a narrative Scene Story Beat, not the final still-image prompt. Ignore any Image Prep instruction saying that subjects must be silent or that singing must not be mentioned. For this beat, use the Performer assignment: if one performer is assigned, that performer visibly sings while every other visible subject remains silent.\n"
+        "- This request creates a visual narrative Scene Story Beat only. Do not mention singing, lyrics, vocals, rapping, lip-sync, music, instrumental sections, dialogue delivery, or any other audio/performance metadata. Do not describe whether a subject is silent or vocal. Show the story through visible action, posture, expression, blocking, props, environment, and emotional stakes.\n"
+        "- Performer and vocal assignments are downstream video-prompt metadata, not content for this beat; never copy those assignments into the story_beat.\n"
         "- The existing scene story beat, if present in the selected scene JSON, is stale draft text being replaced. Do not copy, preserve, or treat it as a fact; the Performer assignment and current scene data override it.\n"
         "- Scene defaults are authoritative when supplied: use the selected shot, camera motion/camera-flow direction, character motion, performance direction, and facial direction to shape the beat. Do not replace them with generic actions.\n"
         "- Treat the selected scene location_ref as the required physical setting for this scene.\n"
@@ -2527,18 +2577,13 @@ def _build_story_layer_scene_beat(payload):
         f"CURRENT scene lyric text (main authority):\n{current_lyrics or '[none]'}\n\n"
         f"Next scene lyric text:\n{next_lyrics or '[none]'}\n\n"
         f"Scene defaults and motion direction (authoritative when supplied):\n{json.dumps(scene_defaults, ensure_ascii=False, indent=2)}\n\n"
-        f"Assigned singing performers (the only subjects allowed to sing):\n{json.dumps(assigned_performers, ensure_ascii=False)}\n\n"
-        f"Performer assignment contract:\n{json.dumps({'singing': assigned_performers, 'silent': silent_performers}, ensure_ascii=False, indent=2)}\n\n"
+        "Performance assignment metadata (do not mention this in the story beat):\n"
+        f"{json.dumps({'singing': assigned_performers, 'silent': silent_performers}, ensure_ascii=False, indent=2)}\n\n"
         f"Mapped extras and exact scene roles:\n{json.dumps(extra_subjects, ensure_ascii=False, indent=2) if extra_subjects else '[none]'}\n\n"
         "Selected scene JSON:\n"
         + json.dumps(scene, ensure_ascii=False, indent=2)
         + "\n\nFINAL SCENE-BEAT OVERRIDE — FOLLOW THIS LAST:\n"
-        + f"This is a narrative scene beat, not an Image Prep still-image prompt. Assigned singing performers: {json.dumps(assigned_performers, ensure_ascii=False)}. Assigned silent visible subjects: {json.dumps(silent_performers, ensure_ascii=False)}. "
-        + (f"Only {assigned_performers[0]} visibly sings the current lyric; every other visible subject is silent. Do not write that both subjects sing."
-           if len(assigned_performers) == 1 else
-           "No mapped subject sings; keep all visible subjects silent."
-           if not assigned_performers else
-           f"Only these performers visibly sing: {', '.join(assigned_performers)}; every other visible subject is silent.")
+        + "Return only visual story information: setting, visible actions, blocking, props, facial emotion, atmosphere, symbolism, and continuity. Exclude all audio, lyric, vocal, singing, lip-sync, and performance-delivery language."
     )
     from .VRGDG_MusicVideoBuilderNodes import _run_builder_text_llm
 
@@ -2596,6 +2641,36 @@ def _build_story_layer_scene_beat(payload):
         text = re.sub(r"^\s*(scene\s+story\s+beat|story\s+beat|beat)\s*:\s*", "", _clean_scene_text(text, 1800), flags=re.I)
     if not text:
         raise ValueError("Gemma returned an empty scene story beat.")
+    if _scene_beat_has_audio_language(text):
+        repair_instruction = (
+            "Rewrite this scene story beat as visual narrative guidance only. Preserve its setting, visible actions, props, emotion, symbolism, and continuity. "
+            "Remove every reference to singing, lyrics, vocals, rapping, lip-sync, music, instrumental sections, dialogue delivery, or audio/performance metadata. "
+            "Do not replace those references with a statement that the subject is silent; simply describe the visible action. Output one concise paragraph only, with no label or bullets.\n\n"
+            f"Original scene beat:\n{text}"
+        )
+        repaired_text, repair_info = _run_builder_text_llm(
+            payload,
+            repair_instruction,
+            temperature=0.10,
+            top_p=0.80,
+            max_new_tokens=300,
+            label="Storyboard Scene Beat Audio Language Repair Gemma",
+            preserve_paragraphs=True,
+        )
+        repaired_text = re.sub(r"^\s*(scene\s+story\s+beat|story\s+beat|beat)\s*:\s*", "", _clean_scene_text(repaired_text, 1800), flags=re.I)
+        if repaired_text and not _scene_beat_has_audio_language(repaired_text):
+            text = repaired_text
+            run_info = {
+                **run_info,
+                "audio_language_repaired": True,
+                "audio_language_repair_runner": repair_info.get("runner", ""),
+                "audio_language_repair_model": repair_info.get("used_model", ""),
+            }
+        else:
+            text = _strip_scene_beat_audio_language(text)
+            run_info = {**run_info, "audio_language_repaired": True, "audio_language_repair_fallback": True}
+    else:
+        text = _strip_scene_beat_audio_language(text)
     location_context = _storyboard_scene_location_context(scene)
     drift_terms = _storyboard_location_drift_terms(text, location_context)
     if drift_terms:
@@ -2677,6 +2752,9 @@ def _build_story_layer_scene_beat(payload):
             "extra_mapping_repair_runner": repair_info.get("runner", ""),
             "extra_mapping_repair_model": repair_info.get("used_model", ""),
         }
+    text = _strip_scene_beat_audio_language(text)
+    if not text:
+        raise ValueError("Scene beat became empty after removing audio/performance language.")
     return {
         "story_beat": text,
         **flf_fields,

--- a/VRGDG_VideoCompareNode.py
+++ b/VRGDG_VideoCompareNode.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import time
 import uuid
 
 import folder_paths
@@ -117,6 +118,34 @@ def _ensure_video_compare_routes():
     if server_instance is None or getattr(server_instance, "_vrgdg_compare_routes", False):
         return
 
+    @server_instance.routes.post("/vrgdg/video_compare/upload")
+    async def vrgdg_video_compare_upload(request):
+        try:
+            reader = await request.multipart()
+            saved_path = ""
+            async for part in reader:
+                if part.name != "video" or not part.filename:
+                    continue
+                safe_name = os.path.basename(str(part.filename)).replace(" ", "_")
+                extension = os.path.splitext(safe_name)[1].lower()
+                if extension not in _VIDEO_EXTENSIONS:
+                    raise ValueError("Unsupported video type. Use MP4, MOV, WebM, MKV, AVI, or M4V.")
+                upload_dir = folder_paths.get_input_directory()
+                os.makedirs(upload_dir, exist_ok=True)
+                saved_path = os.path.join(upload_dir, f"vrgdg_compare_{time.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}_{safe_name}")
+                with open(saved_path, "wb") as handle:
+                    while True:
+                        chunk = await part.read_chunk(size=1024 * 1024)
+                        if not chunk:
+                            break
+                        handle.write(chunk)
+                break
+            if not saved_path:
+                raise ValueError("No video file was selected.")
+            return web.json_response({"ok": True, "path": saved_path, "name": os.path.basename(saved_path)})
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+
     @server_instance.routes.post("/vrgdg/video_compare/save_recording")
     async def vrgdg_video_compare_save_recording(request):
         temporary_path = ""
@@ -226,7 +255,9 @@ class VRGDG_VideoCompareSlider:
                     "VHS_FILENAMES",
                     {"tooltip": "Legacy: connect a Filenames output for the processed video."},
                 ),
-            }
+
+                "before_selected": ("STRING", {"default": "", "tooltip": "Video selected with the Choose Before Video button."}),
+                "after_selected": ("STRING", {"default": "", "tooltip": "Video selected with the Choose After Video button."}),            }
         }
 
     RETURN_TYPES = ("VHS_FILENAMES", "VHS_FILENAMES")
@@ -248,9 +279,11 @@ class VRGDG_VideoCompareSlider:
         after_images=None,
         before_video=None,
         after_video=None,
+        before_selected="",
+        after_selected="",
     ):
-        before_path = _write_image_batch_video(before_images, "before", 24.0) if before_images is not None else _resolve_video_path(before_video, "Before")
-        after_path = _write_image_batch_video(after_images, "after", 24.0) if after_images is not None else _resolve_video_path(after_video, "After")
+        before_path = _write_image_batch_video(before_images, "before", 24.0) if before_images is not None else _resolve_video_path(before_selected or before_video, "Before")
+        after_path = _write_image_batch_video(after_images, "after", 24.0) if after_images is not None else _resolve_video_path(after_selected or after_video, "After")
         return {
             "ui": {
                 "compare_videos": [

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3339,6 +3339,206 @@ def _build_minimax_h3_2pass_api_prompt(payload):
     }
 
 
+def _build_minimax_h3_advanced_2pass_api_prompt(payload):
+    """Build the MMH3 tiled/chunked advanced two-pass API prompt.
+
+    The established two-pass adapter supplies the model, reference, audio,
+    timing, LoRA, and sampler branches.  This adapter replaces its whole-frame
+    learned-upscale/refinement tail with Comfyui-MMH3-UltimateUpscale and gives
+    each pass an independent ResolutionSelector.
+    """
+    try:
+        mappings = _get_comfy_node_mappings()
+    except Exception as exc:
+        raise ValueError(
+            "Could not inspect ComfyUI custom-node registrations. Restart ComfyUI "
+            "after installing Comfyui-MMH3-UltimateUpscale."
+        ) from exc
+    required_nodes = (
+        "MMH3UltimateUpscale",
+        "VRGDG_MiniMaxH3UltimateUpscaleParams",
+        "MMH3TemporalSplitParams",
+        "MMH3SpatialSplitParams",
+    )
+    missing_nodes = [name for name in required_nodes if name not in mappings]
+    if missing_nodes:
+        raise ValueError(
+            "MiniMax H3 2 Pass Advanced requires the latest "
+            "Comfyui-MMH3-UltimateUpscale custom nodes. Missing: "
+            + ", ".join(missing_nodes)
+            + ". Install or update the repository, then restart ComfyUI."
+        )
+
+    base_payload = dict(payload)
+    # The shared adapter validates and configures this same learned-upscaler
+    # checkpoint, Turbo LoRA, references, source audio, and exact timing.
+    base_payload.setdefault("final_width", 1920)
+    base_payload.setdefault("final_height", 1080)
+    base_payload.setdefault("latent_upscale_scale", 2.0)
+    base_payload.setdefault("pass2_steps", 1)
+    base_payload.setdefault("pass2_denoise", 0.2)
+    base_payload.setdefault("pass2_sampler_name", "sa_solver")
+    base_payload.setdefault("pass2_scheduler", "simple")
+    result = _build_minimax_h3_2pass_api_prompt(base_payload)
+    prompt = result["prompt"]
+
+    aspect_ratio = str(payload.get("aspect_ratio") or "16:9 (Widescreen)").strip()
+    if aspect_ratio not in _MINIMAX_H3_ASPECT_RATIOS:
+        raise ValueError(f"Unsupported MiniMax H3 advanced two-pass aspect ratio: {aspect_ratio}")
+    pass1_megapixels = _float_payload(payload, "advanced_pass1_megapixels", 0.4, 0.1, 16.0)
+    pass2_megapixels = _float_payload(payload, "advanced_pass2_megapixels", 2.0, 0.1, 16.0)
+    if pass2_megapixels < pass1_megapixels:
+        raise ValueError("2 Pass Advanced Pass 2 resolution must be at least Pass 1 resolution.")
+
+    tile_size_mode = str(payload.get("advanced_tile_size_mode") or "specific_size").strip().lower()
+    if tile_size_mode not in {"specific_size", "rows_cols"}:
+        tile_size_mode = "specific_size"
+    tile_width = _int_payload(payload, "advanced_tile_width", 448, 32, 16384)
+    tile_height = _int_payload(payload, "advanced_tile_height", 448, 32, 16384)
+    grid_rows = _int_payload(payload, "advanced_grid_rows", 3, 1, 9)
+    grid_cols = _int_payload(payload, "advanced_grid_cols", 5, 1, 9)
+    chunk_length = _int_payload(payload, "advanced_chunk_length", 68, 17, 100000)
+    temporal_overlap = _int_payload(payload, "advanced_temporal_overlap", 17, 0, 100000)
+    anchor_strength = _float_payload(payload, "advanced_anchor_strength", 0.999, 0.0, 1.0)
+    spatial_w_overlap = _int_payload(payload, "advanced_spatial_w_overlap", 128, 0, 16384)
+    spatial_h_overlap = _int_payload(payload, "advanced_spatial_h_overlap", 128, 0, 16384)
+    fade_width = _int_payload(payload, "advanced_fade_width", 32, 0, 16384)
+    fade_height = _int_payload(payload, "advanced_fade_height", 32, 0, 16384)
+    min_tile_size = _int_payload(payload, "advanced_min_tile_size", 256, 0, 16384)
+    overlap_mode = str(payload.get("advanced_overlap_mode") or "earlier").strip().lower()
+    overlap_blend = str(payload.get("advanced_overlap_blend") or "linear").strip().lower()
+    if overlap_mode not in {"earlier", "later"}:
+        overlap_mode = "earlier"
+    if overlap_blend not in {"linear", "smoothstep", "overwrite", "midpoint"}:
+        overlap_blend = "linear"
+    if chunk_length % 17 or temporal_overlap % 17:
+        raise ValueError("MMH3 chunk length and temporal overlap must be multiples of 17 frames.")
+    if temporal_overlap >= chunk_length:
+        raise ValueError("MMH3 temporal overlap must be smaller than chunk length.")
+    for label, value in (
+        ("tile width", tile_width), ("tile height", tile_height),
+        ("spatial width overlap", spatial_w_overlap),
+        ("spatial height overlap", spatial_h_overlap),
+        ("fade width", fade_width), ("fade height", fade_height),
+        ("minimum tile size", min_tile_size),
+    ):
+        if value % 32:
+            raise ValueError(f"MMH3 {label} must be a multiple of 32 pixels; got {value}.")
+
+    # Independent target resolutions for the generation and tiled refinement.
+    prompt["9300"] = {
+        "class_type": "ResolutionSelector",
+        "inputs": {"aspect_ratio": aspect_ratio, "megapixels": pass1_megapixels, "multiple": 32},
+        "_meta": {"title": "2 Pass Advanced - Pass 1 Resolution"},
+    }
+    prompt["9301"] = {
+        "class_type": "ResolutionSelector",
+        "inputs": {"aspect_ratio": aspect_ratio, "megapixels": pass2_megapixels, "multiple": 32},
+        "_meta": {"title": "2 Pass Advanced - Pass 2 Resolution"},
+    }
+    _set_api_input(prompt, "136", "width", ["9300", 0])
+    _set_api_input(prompt, "136", "height", ["9300", 1])
+
+    pass2_conditioning = copy.deepcopy(prompt["136"])
+    pass2_conditioning["inputs"]["width"] = ["9301", 0]
+    pass2_conditioning["inputs"]["height"] = ["9301", 1]
+    pass2_conditioning["_meta"] = {"title": "2 Pass Advanced - Final Resolution Conditioning"}
+    prompt["9302"] = pass2_conditioning
+
+    prompt["9303"] = {
+        "class_type": "VRGDG_MiniMaxH3UltimateUpscaleParams",
+        "inputs": {
+            "model_name": str(payload.get("latent_upscaler_name") or "minimax_h3_latent_upscaler_3d_bf16.safetensors"),
+            "width": ["9301", 0],
+            "height": ["9301", 1],
+            "device": str(payload.get("advanced_upscaler_device") or "cuda"),
+            "precision": str(payload.get("advanced_upscaler_precision") or "bf16"),
+        },
+        "_meta": {"title": "2 Pass Advanced - H3 Learned Latent Upscale"},
+    }
+    prompt["9304"] = {
+        "class_type": "MMH3TemporalSplitParams",
+        "inputs": {
+            "chunk_length": chunk_length,
+            "temporal_overlap": temporal_overlap,
+            "anchor_strength": anchor_strength,
+        },
+        "_meta": {"title": "2 Pass Advanced - Temporal Chunks"},
+    }
+    prompt["9305"] = {
+        "class_type": "MMH3SpatialSplitParams",
+        "inputs": {
+            "upscale_width": ["9301", 0],
+            "upscale_height": ["9301", 1],
+            "tile_size_mode": tile_size_mode,
+            "tile_width": tile_width,
+            "tile_height": tile_height,
+            "grid_rows": grid_rows,
+            "grid_cols": grid_cols,
+            "spatial_w_overlap": spatial_w_overlap,
+            "spatial_h_overlap": spatial_h_overlap,
+            "fade_width": fade_width,
+            "fade_height": fade_height,
+            "min_tile_size": min_tile_size,
+            "overlap_mode": overlap_mode,
+            "overlap_blend": overlap_blend,
+        },
+        "_meta": {"title": "2 Pass Advanced - Spatial Tiles"},
+    }
+    pass2_model_ref = copy.deepcopy(prompt["192"]["inputs"]["model"])
+    prompt["9306"] = {
+        "class_type": "MMH3UltimateUpscale",
+        "inputs": {
+            "model": pass2_model_ref,
+            "conditioning": ["9302", 0],
+            "latent": ["125", 0],
+            "noise": ["211", 0],
+            "sampler": ["210", 0],
+            "sigmas": ["192", 0],
+            "cfg": 1.0,
+            "latent_upscale_param": ["9303", 0],
+            "temporal_split_param": ["9304", 0],
+            "spatial_split_param": ["9305", 0],
+        },
+        "_meta": {"title": "2 Pass Advanced - MMH3 Ultimate Upscale"},
+    }
+    _set_api_input(prompt, "122", "samples", ["9306", 0])
+    _set_api_input(prompt, "142", "images", ["122", 0])
+
+    # Expose Pass 1 as a reviewable backup while Pass 2 remains the final clip.
+    prompt["9307"] = {
+        "class_type": "VAEDecode",
+        "inputs": {"samples": ["125", 0], "vae": ["119", 0]},
+        "_meta": {"title": "2 Pass Advanced - Decode Pass 1 Preview"},
+    }
+    pass1_output = copy.deepcopy(prompt["142"])
+    pass1_output["inputs"]["images"] = ["9307", 0]
+    pass1_output["inputs"]["filename_prefix"] = str(prompt["142"]["inputs"]["filename_prefix"]).replace("_stage2", "_stage1")
+    pass1_output["_meta"] = {"title": "2 Pass Advanced - Pass 1 Backup"}
+    prompt["9308"] = pass1_output
+    prompt["142"]["inputs"]["filename_prefix"] = str(prompt["142"]["inputs"]["filename_prefix"]).replace("_stage2", "_advanced_stage2")
+
+    # Remove the original whole-frame upscale/refinement tail now replaced by MMH3.
+    for node_id in ("115", "181", "182", "183", "184", "185", "186", "187", "188", "189", "193", "194"):
+        prompt.pop(node_id, None)
+
+    result["prompt"] = prompt
+    result["advanced_two_pass"] = {
+        "pass1_megapixels": pass1_megapixels,
+        "pass2_megapixels": pass2_megapixels,
+        "vram_preset": str(payload.get("advanced_vram_preset") or "12gb"),
+        "tile_size_mode": tile_size_mode,
+        "tile_width": tile_width,
+        "tile_height": tile_height,
+        "grid_rows": grid_rows,
+        "grid_cols": grid_cols,
+        "chunk_length": chunk_length,
+        "temporal_overlap": temporal_overlap,
+    }
+    result.pop("two_pass", None)
+    return result
+
+
 def _remap_api_prompt_references(prompt, prefix):
     """Copy an API prompt under collision-free IDs and rewrite socket links."""
     mapping = {str(node_id): f"{prefix}{str(node_id).replace(':', '_')}" for node_id in prompt}
@@ -5254,6 +5454,18 @@ def _ensure_workflow_runner_routes():
             return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
         try:
             result = _build_minimax_h3_2pass_api_prompt(payload)
+        except Exception as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        return web.json_response({"ok": True, **result})
+
+    @server_instance.routes.post("/vrgdg/workflow_runner/build_minimax_h3_advanced_2pass_prompt")
+    async def vrgdg_workflow_runner_build_minimax_h3_advanced_2pass_prompt(request):
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
+        try:
+            result = _build_minimax_h3_advanced_2pass_api_prompt(payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3427,7 +3427,16 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
             raise ValueError(f"MMH3 {label} must be a multiple of 32 pixels; got {value}.")
 
     def resolved_dimensions(target_megapixels):
-        ratio_width, ratio_height = _MINIMAX_H3_ASPECT_RATIOS[aspect_ratio]
+        ratio_width, ratio_height = {
+            "1:1 (Square)": (1, 1),
+            "2:3 (Portrait Photo)": (2, 3),
+            "3:2 (Photo)": (3, 2),
+            "3:4 (Portrait Standard)": (3, 4),
+            "4:3 (Standard)": (4, 3),
+            "9:16 (Portrait Widescreen)": (9, 16),
+            "16:9 (Widescreen)": (16, 9),
+            "21:9 (Ultrawide)": (21, 9),
+        }[aspect_ratio]
         scale = math.sqrt(target_megapixels * 1024 * 1024 / (ratio_width * ratio_height))
         return (
             round(ratio_width * scale / 32) * 32,

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3,6 +3,7 @@ import base64
 import hashlib
 import importlib
 import json
+import math
 import os
 import random
 import re
@@ -3425,6 +3426,17 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
         if value % 32:
             raise ValueError(f"MMH3 {label} must be a multiple of 32 pixels; got {value}.")
 
+    def resolved_dimensions(target_megapixels):
+        ratio_width, ratio_height = _MINIMAX_H3_ASPECT_RATIOS[aspect_ratio]
+        scale = math.sqrt(target_megapixels * 1024 * 1024 / (ratio_width * ratio_height))
+        return (
+            round(ratio_width * scale / 32) * 32,
+            round(ratio_height * scale / 32) * 32,
+        )
+
+    pass1_width, pass1_height = resolved_dimensions(pass1_megapixels)
+    pass2_width, pass2_height = resolved_dimensions(pass2_megapixels)
+
     # Independent target resolutions for the generation and tiled refinement.
     prompt["9300"] = {
         "class_type": "ResolutionSelector",
@@ -3526,6 +3538,10 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
     result["advanced_two_pass"] = {
         "pass1_megapixels": pass1_megapixels,
         "pass2_megapixels": pass2_megapixels,
+        "pass1_width": pass1_width,
+        "pass1_height": pass1_height,
+        "pass2_width": pass2_width,
+        "pass2_height": pass2_height,
         "vram_preset": str(payload.get("advanced_vram_preset") or "12gb"),
         "tile_size_mode": tile_size_mode,
         "tile_width": tile_width,
@@ -3537,6 +3553,29 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
     }
     result.pop("two_pass", None)
     return result
+
+
+def _save_minimax_h3_advanced_2pass_debug_workflow(result, payload):
+    """Persist the exact generated API graph for inspection before execution."""
+    output_folder = os.path.abspath(str(result.get("output_folder") or "").strip())
+    if not output_folder:
+        return ""
+    os.makedirs(output_folder, exist_ok=True)
+    scene_number = _int_payload(payload, "scene_number", 1, 1, 999999)
+    debug_path = os.path.join(
+        output_folder,
+        f"scene_{scene_number:04d}_minimax_h3_advanced_2pass_api.json",
+    )
+    snapshot = {
+        "workflow_type": "minimax_h3_advanced_2pass",
+        "source_template": result.get("workflow_path", ""),
+        "advanced_two_pass": result.get("advanced_two_pass", {}),
+        "prompt": result.get("prompt", {}),
+    }
+    with open(debug_path, "w", encoding="utf-8") as handle:
+        json.dump(snapshot, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return debug_path
 
 
 def _remap_api_prompt_references(prompt, prefix):
@@ -5466,6 +5505,7 @@ def _ensure_workflow_runner_routes():
             return web.json_response({"ok": False, "error": "Invalid JSON body."}, status=400)
         try:
             result = _build_minimax_h3_advanced_2pass_api_prompt(payload)
+            result["debug_workflow_path"] = _save_minimax_h3_advanced_2pass_debug_workflow(result, payload)
         except Exception as exc:
             return web.json_response({"ok": False, "error": str(exc)}, status=400)
         return web.json_response({"ok": True, **result})

--- a/tests/test_builder_minimax_advanced_two_pass.py
+++ b/tests/test_builder_minimax_advanced_two_pass.py
@@ -1,0 +1,114 @@
+import ast
+import copy
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+RUNNER_SOURCE = (ROOT / "VRGDG_WorkflowRunnerNodes.py").read_text(encoding="utf-8")
+
+
+class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
+    def test_former_three_pass_button_is_advanced_two_pass(self):
+        self.assertIn('makeButton("Ref to Video\\n2 Pass Advanced")', BUILDER_SOURCE)
+        self.assertIn(
+            '"/vrgdg/workflow_runner/build_minimax_h3_advanced_2pass_prompt"',
+            BUILDER_SOURCE,
+        )
+
+    def test_vram_presets_match_mmh3_starting_points(self):
+        for text in (
+            '"8gb": { tile: 352, chunk: 51 }',
+            '"12gb": { tile: 448, chunk: 68 }',
+            '"16gb": { tile: 544, chunk: 119 }',
+            '"24gb": { tile: 672, chunk: 153 }',
+        ):
+            self.assertIn(text, BUILDER_SOURCE)
+        self.assertIn('advanced_two_pass_pass2_steps: 1', BUILDER_SOURCE)
+        self.assertIn('advanced_two_pass_pass2_sampler: "sa_solver"', BUILDER_SOURCE)
+        self.assertIn('advanced_two_pass_pass2_scheduler: "simple"', BUILDER_SOURCE)
+
+    def test_resolutions_are_visible_and_expert_controls_are_collapsed(self):
+        self.assertIn('"Pass 1 resolution (megapixels)"', BUILDER_SOURCE)
+        self.assertIn('"Pass 2 resolution (megapixels)"', BUILDER_SOURCE)
+        self.assertIn('makeSettingsSection("Pass Sampling (Advanced)"', BUILDER_SOURCE)
+        self.assertIn('makeSettingsSection("Hidden MMH3 Advanced Settings"', BUILDER_SOURCE)
+
+    def test_hidden_prompt_uses_independent_resolutions_and_mmh3_nodes(self):
+        start = RUNNER_SOURCE.index("def _build_minimax_h3_advanced_2pass_api_prompt")
+        end = RUNNER_SOURCE.index("def _remap_api_prompt_references", start)
+        source = RUNNER_SOURCE[start:end]
+        self.assertEqual(source.count('"class_type": "ResolutionSelector"'), 2)
+        for node_type in (
+            "VRGDG_MiniMaxH3UltimateUpscaleParams",
+            "MMH3TemporalSplitParams",
+            "MMH3SpatialSplitParams",
+            "MMH3UltimateUpscale",
+        ):
+            self.assertIn(f'"class_type": "{node_type}"', source)
+        self.assertIn('_set_api_input(prompt, "122", "samples", ["9306", 0])', source)
+
+    def test_existing_two_pass_route_is_preserved(self):
+        self.assertIn(
+            '@server_instance.routes.post("/vrgdg/workflow_runner/build_minimax_h3_2pass_prompt")',
+            RUNNER_SOURCE,
+        )
+        self.assertIn(
+            '@server_instance.routes.post("/vrgdg/workflow_runner/build_minimax_h3_advanced_2pass_prompt")',
+            RUNNER_SOURCE,
+        )
+
+    def test_generated_advanced_graph_has_no_dangling_node_links(self):
+        module = ast.parse(RUNNER_SOURCE)
+        function = next(
+            node for node in module.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_build_minimax_h3_advanced_2pass_api_prompt"
+        )
+        namespace = {
+            "copy": copy,
+            "_MINIMAX_H3_ASPECT_RATIOS": {"16:9 (Widescreen)"},
+            "_get_comfy_node_mappings": lambda: {
+                name: object() for name in (
+                    "MMH3UltimateUpscale",
+                    "VRGDG_MiniMaxH3UltimateUpscaleParams",
+                    "MMH3TemporalSplitParams",
+                    "MMH3SpatialSplitParams",
+                )
+            },
+            "_int_payload": lambda payload, key, default, low, high: max(low, min(high, int(payload.get(key, default)))),
+            "_float_payload": lambda payload, key, default, low, high: max(low, min(high, float(payload.get(key, default)))),
+        }
+
+        def set_api_input(prompt, node_id, input_name, value):
+            prompt[str(node_id)]["inputs"][input_name] = value
+
+        template_path = ROOT / "Workflows" / "UsedForUIDoNotTouch" / "minimax_audio_driven_builder_latent_upscale_2pass_api.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        namespace["_set_api_input"] = set_api_input
+        namespace["_build_minimax_h3_2pass_api_prompt"] = lambda payload: {
+            "prompt": copy.deepcopy(template),
+            "two_pass": {},
+        }
+        exec(compile(ast.Module(body=[function], type_ignores=[]), "advanced_two_pass", "exec"), namespace)
+        result = namespace["_build_minimax_h3_advanced_2pass_api_prompt"]({})
+        prompt = result["prompt"]
+        self.assertEqual(prompt["136"]["inputs"]["width"], ["9300", 0])
+        self.assertEqual(prompt["9302"]["inputs"]["width"], ["9301", 0])
+        self.assertEqual(prompt["9306"]["inputs"]["model"], prompt["192"]["inputs"]["model"])
+        self.assertEqual(prompt["142"]["inputs"]["images"], ["122", 0])
+        self.assertEqual(prompt["9308"]["inputs"]["images"], ["9307", 0])
+
+        dangling = []
+        for node_id, node in prompt.items():
+            for input_name, value in (node.get("inputs") or {}).items():
+                if isinstance(value, list) and len(value) == 2 and isinstance(value[1], int):
+                    if str(value[0]) not in prompt:
+                        dangling.append((node_id, input_name, value[0]))
+        self.assertEqual(dangling, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_advanced_two_pass.py
+++ b/tests/test_builder_minimax_advanced_two_pass.py
@@ -1,6 +1,7 @@
 import ast
 import copy
 import json
+import math
 import unittest
 from pathlib import Path
 
@@ -31,8 +32,8 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
         self.assertIn('advanced_two_pass_pass2_scheduler: "simple"', BUILDER_SOURCE)
 
     def test_resolutions_are_visible_and_expert_controls_are_collapsed(self):
-        self.assertIn('"Pass 1 resolution (megapixels)"', BUILDER_SOURCE)
-        self.assertIn('"Pass 2 resolution (megapixels)"', BUILDER_SOURCE)
+        self.assertIn('"Pass 1 resolution"', BUILDER_SOURCE)
+        self.assertIn('"Pass 2 resolution"', BUILDER_SOURCE)
         self.assertIn('makeSettingsSection("Pass Sampling (Advanced)"', BUILDER_SOURCE)
         self.assertIn('makeSettingsSection("Hidden MMH3 Advanced Settings"', BUILDER_SOURCE)
 
@@ -69,7 +70,8 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
         )
         namespace = {
             "copy": copy,
-            "_MINIMAX_H3_ASPECT_RATIOS": {"16:9 (Widescreen)"},
+            "math": math,
+            "_MINIMAX_H3_ASPECT_RATIOS": {"16:9 (Widescreen)": (16, 9)},
             "_get_comfy_node_mappings": lambda: {
                 name: object() for name in (
                     "MMH3UltimateUpscale",
@@ -100,6 +102,13 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
         self.assertEqual(prompt["9306"]["inputs"]["model"], prompt["192"]["inputs"]["model"])
         self.assertEqual(prompt["142"]["inputs"]["images"], ["122", 0])
         self.assertEqual(prompt["9308"]["inputs"]["images"], ["9307", 0])
+
+        result = namespace["_build_minimax_h3_advanced_2pass_api_prompt"]({
+            "advanced_pass1_megapixels": 0.4,
+            "advanced_pass2_megapixels": 2.1,
+        })
+        self.assertEqual(result["advanced_two_pass"]["pass2_width"], 1984)
+        self.assertEqual(result["advanced_two_pass"]["pass2_height"], 1120)
 
         dangling = []
         for node_id, node in prompt.items():

--- a/tests/test_builder_save_order.py
+++ b/tests/test_builder_save_order.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+NODES = (ROOT / "VRGDG_MusicVideoBuilderNodes.py").read_text(encoding="utf-8")
+
+
+class BuilderSaveOrderTests(unittest.TestCase):
+    def test_all_session_saves_use_ordered_save_queue(self):
+        self.assertIn("let builderSessionSaveQueue = Promise.resolve();", UI)
+        self.assertIn("function saveBuilderSessionJson(payload", UI)
+        self.assertEqual(UI.count('postJson("/vrgdg/music_builder/save_session"'), 1)
+        self.assertIn('saveBuilderSessionJson({', UI)
+
+    def test_manual_performer_assignment_autosaves(self):
+        self.assertIn('autoSaveSessionQuiet("performer assignment changed")', UI)
+        self.assertIn("performer_scene_map", UI)
+
+    def test_bulk_lyric_restore_does_not_override_user_edits(self):
+        self.assertNotIn("Prevented accidental bulk lyric clearing", NODES)
+        self.assertNotIn("if not bool(session.get(\"allow_bulk_lyric_clear\"))", NODES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_save_order.py
+++ b/tests/test_builder_save_order.py
@@ -11,6 +11,7 @@ class BuilderSaveOrderTests(unittest.TestCase):
     def test_all_session_saves_use_ordered_save_queue(self):
         self.assertIn("let builderSessionSaveQueue = Promise.resolve();", UI)
         self.assertIn("function saveBuilderSessionJson(payload", UI)
+        self.assertIn("builder_save_revision: revision", UI)
         self.assertEqual(UI.count('postJson("/vrgdg/music_builder/save_session"'), 1)
         self.assertIn('saveBuilderSessionJson({', UI)
 
@@ -21,6 +22,14 @@ class BuilderSaveOrderTests(unittest.TestCase):
     def test_bulk_lyric_restore_does_not_override_user_edits(self):
         self.assertNotIn("Prevented accidental bulk lyric clearing", NODES)
         self.assertNotIn("if not bool(session.get(\"allow_bulk_lyric_clear\"))", NODES)
+
+    def test_stale_backend_snapshot_is_rejected(self):
+        self.assertIn("Ignored stale session snapshot", NODES)
+        self.assertIn("existing_revision > incoming_revision", NODES)
+
+    def test_storyboard_prompt_apply_preserves_live_lyrics(self):
+        self.assertIn("lyricTextBySegmentId", UI)
+        self.assertIn("Storyboard prompt/beat application is allowed to update visual fields", UI)
 
 
 if __name__ == "__main__":

--- a/tests/test_storyboard_scene_beat_audio_language.py
+++ b/tests/test_storyboard_scene_beat_audio_language.py
@@ -1,0 +1,37 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = ROOT / "VRGDG_StoryboardBuilderNodes.py"
+SOURCE = SOURCE_PATH.read_text(encoding="utf-8")
+
+
+class StoryboardSceneBeatAudioLanguageTests(unittest.TestCase):
+    def test_scene_beat_prompt_is_visual_only(self):
+        self.assertIn("visual narrative Scene Story Beat only", SOURCE)
+        self.assertIn("never copy those assignments into the story_beat", SOURCE)
+        self.assertIn("Exclude all audio, lyric, vocal, singing, lip-sync", SOURCE)
+
+    def test_scene_beat_has_output_guard_and_repair(self):
+        self.assertIn("_scene_beat_has_audio_language(text)", SOURCE)
+        self.assertIn('label="Storyboard Scene Beat Audio Language Repair Gemma"', SOURCE)
+        self.assertIn("_strip_scene_beat_audio_language(text)", SOURCE)
+
+    def test_example_beat_language_is_detected(self):
+        pattern = re.compile(
+            r"\b(?:lip[\s-]?sync(?:ing)?|sings?|singing|sang|lyrics?|lyric|"
+            r"vocals?|vocalizing|vocalizes?|rapping|raps?|music|instrumental|"
+            r"performing vocals?)\b",
+            re.IGNORECASE,
+        )
+        example = (
+            "At the monumental white marble arch, Singer visibly sings through "
+            "the instrumental opening as her fingertips trace gray veining."
+        )
+        self.assertIsNotNone(pattern.search(example))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,47 @@
   "product": "AI Video Builder",
   "releases": [
     {
+      "id": "2026-08-26-pr159-minimax-h3-advanced-upscale-and-video-compare",
+      "version": "2026.08.26-pr159-minimax-h3-advanced-upscale-and-video-compare",
+      "date": "2026-08-26",
+      "title": "MiniMax H3 Advanced 2-Pass Upscaling and Video Compare",
+      "commit": "8ec51ae",
+      "restart_required": true,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/pull/159",
+      "sections": [
+        {
+          "title": "Added",
+          "items": [
+            "Added MiniMax H3 2 Pass Advanced with MMH3 temporal chunking, spatial tiling, VRAM presets, independent Pass 1 and Pass 2 resolution controls, and advanced sampler settings.",
+            "Added exact generated API workflow snapshots so users can inspect the hidden graph, node connections, and resolved target dimensions for each advanced render.",
+            "Added direct before-and-after video upload, fullscreen comparison, zoom controls, and selected-file support to Video Compare."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Advanced resolution controls now offer 1K, 2K, and 4K long-edge presets while retaining custom megapixel control for experienced users.",
+            "Advanced MiniMax progress now reports the exact Pass 1 and Pass 2 dimensions sent to the workflow and the saved API snapshot path.",
+            "H3 latent upscaler model selection now resolves registered model directories reliably instead of depending on one custom-node folder."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Fixed the advanced workflow resolution diagnostic that could fail with a set-object indexing error."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "Restart ComfyUI and hard-refresh the browser after updating so the revised Python workflow route and Builder JavaScript are loaded.",
+            "MiniMax H3 2 Pass Advanced requires the latest Comfyui-MMH3-UltimateUpscale custom nodes and the required H3 diffusion, VAE, Turbo LoRA, and latent upscaler model files.",
+            "The API workflow snapshot is written beside the scene output as scene_####_minimax_h3_advanced_2pass_api.json."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-08-23-pr158-reference-cues-and-project-save-reliability",
       "version": "2026.08.23-pr158-reference-cues-and-project-save-reliability",
       "date": "2026-08-23",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -326,12 +326,14 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   advanced_two_pass_upscaler_device: "cuda",
   advanced_two_pass_upscaler_precision: "bf16",
   advanced_two_pass_pass1_megapixels: 0.4,
+  advanced_two_pass_pass1_resolution_preset: "custom",
   advanced_two_pass_pass1_steps: 20,
   advanced_two_pass_pass1_denoise: 1,
   advanced_two_pass_pass1_sampler: "euler",
   advanced_two_pass_pass1_scheduler: "beta",
   advanced_two_pass_pass1_seed: 69,
   advanced_two_pass_pass2_megapixels: 2,
+  advanced_two_pass_pass2_resolution_preset: "custom",
   advanced_two_pass_pass2_steps: 1,
   advanced_two_pass_pass2_denoise: 0.2,
   advanced_two_pass_pass2_sampler: "sa_solver",
@@ -570,6 +572,12 @@ function cloneMiniMaxH3Settings(value = {}) {
     advanced_two_pass_upscaler_precision: ["fp32", "fp16", "bf16"].includes(String(source.advanced_two_pass_upscaler_precision || "").toLowerCase())
       ? String(source.advanced_two_pass_upscaler_precision).toLowerCase()
       : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_precision,
+    advanced_two_pass_pass1_resolution_preset: ["custom", "1k", "2k", "4k"].includes(String(source.advanced_two_pass_pass1_resolution_preset || "").toLowerCase())
+      ? String(source.advanced_two_pass_pass1_resolution_preset).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_pass1_resolution_preset,
+    advanced_two_pass_pass2_resolution_preset: ["custom", "1k", "2k", "4k"].includes(String(source.advanced_two_pass_pass2_resolution_preset || "").toLowerCase())
+      ? String(source.advanced_two_pass_pass2_resolution_preset).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_pass2_resolution_preset,
     advanced_two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_defaults_version,
     ...Object.fromEntries([1, 2].flatMap((pass) => {
       const prefix = `advanced_two_pass_pass${pass}_`;
@@ -6058,12 +6066,33 @@ function openBuilder(node) {
     "linear_quadratic",
     "kl_optimal",
   ];
+  const advancedResolutionPresets = [
+    { value: "custom", label: "Custom megapixels" },
+    { value: "1k", label: "1K (long edge)" },
+    { value: "2k", label: "2K (long edge)" },
+    { value: "4k", label: "4K (long edge)" },
+  ];
+  const advancedPresetMegapixels = (preset, aspectRatio) => {
+    const match = String(aspectRatio || "16:9").match(/(\d+)\s*:\s*(\d+)/);
+    const ratioWidth = Number(match?.[1] || 16);
+    const ratioHeight = Number(match?.[2] || 9);
+    const longEdge = { "1k": 1024, "2k": 2048, "4k": 4096 }[String(preset || "").toLowerCase()];
+    if (!longEdge) return null;
+    const scale = longEdge / Math.max(ratioWidth, ratioHeight);
+    const width = Math.round(ratioWidth * scale / 32) * 32;
+    const height = Math.round(ratioHeight * scale / 32) * 32;
+    return Number(((width * height) / 1048576).toFixed(4));
+  };
   const advancedTwoPassControls = [1, 2].map((pass) => {
     const prefix = `advanced_two_pass_pass${pass}_`;
     const megapixels = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}megapixels`]), "number");
     megapixels.min = "0.1";
     megapixels.max = "16";
     megapixels.step = "0.1";
+    const resolutionPreset = makeSelect(
+      advancedResolutionPresets,
+      DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}resolution_preset`] || "custom",
+    );
     const steps = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}steps`]), "number");
     steps.min = "1";
     steps.max = "1000";
@@ -6076,13 +6105,26 @@ function openBuilder(node) {
     const scheduler = makeSelect(threePassSchedulerOptions, DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}scheduler`]);
     const seed = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}seed`]), "number");
     seed.step = "1";
-    const resolutionField = makeField(
-      pass === 1 ? "Pass 1 resolution (megapixels)" : "Pass 2 resolution (megapixels)",
-      megapixels,
+    const resolutionField = makeSettingsSection(
+      pass === 1 ? "Pass 1 resolution" : "Pass 2 resolution",
+      [
+        makeField("Resolution preset", resolutionPreset),
+        makeField("Custom megapixels", megapixels),
+      ],
+      false,
+    );
+    const syncResolutionPreset = () => {
+      const resolved = advancedPresetMegapixels(resolutionPreset.value, miniMaxAspectRatio.value);
+      megapixels.disabled = Boolean(resolved);
+      if (resolved !== null) megapixels.value = String(resolved);
+    };
+    resolutionPreset.addEventListener("change", syncResolutionPreset);
+    miniMaxAspectRatio.addEventListener("change", syncResolutionPreset);
+    syncResolutionPreset();
+    resolutionField.title =
       pass === 1
         ? "Base-generation resolution before MMH3 upscale."
-        : "Target latent resolution produced by the MMH3 tiled upscale pass.",
-    );
+        : "Target latent resolution produced by the MMH3 tiled upscale pass.";
     const samplingFields = [
       makeField("Steps", steps),
       makeField("Sampler", sampler),
@@ -6090,7 +6132,7 @@ function openBuilder(node) {
       makeField("Denoise", denoise),
       makeField("Seed", seed),
     ];
-    return { prefix, megapixels, steps, denoise, sampler, scheduler, seed, resolutionField, samplingFields };
+    return { prefix, megapixels, resolutionPreset, syncResolutionPreset, steps, denoise, sampler, scheduler, seed, resolutionField, samplingFields };
   });
   const miniMaxAdvancedSamplingFields = makeSettingsSection("Pass Sampling (Advanced)", [
     ...advancedTwoPassControls.map((control, index) => makeSettingsSection(
@@ -7617,6 +7659,7 @@ function openBuilder(node) {
         [`${control.prefix}seed`, control.seed.value],
       ])),
       ...Object.fromEntries(advancedTwoPassControls.flatMap((control) => [
+        [`${control.prefix}resolution_preset`, control.resolutionPreset.value],
         [`${control.prefix}megapixels`, control.megapixels.value],
         [`${control.prefix}steps`, control.steps.value],
         [`${control.prefix}denoise`, control.denoise.value],
@@ -8335,7 +8378,9 @@ function openBuilder(node) {
       control.seed.value = String(settings[`${control.prefix}seed`]);
     });
     advancedTwoPassControls.forEach((control) => {
+      control.resolutionPreset.value = settings[`${control.prefix}resolution_preset`] || "custom";
       control.megapixels.value = String(settings[`${control.prefix}megapixels`]);
+      control.syncResolutionPreset();
       control.steps.value = String(settings[`${control.prefix}steps`]);
       control.denoise.value = String(settings[`${control.prefix}denoise`]);
       control.sampler.value = settings[`${control.prefix}sampler`];
@@ -46061,6 +46106,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const builtLoraSettings = built?.lora_settings || {};
       const builtTurboSettings = built?.turbo_settings || {};
       const builtAdvancedSettings = built?.advanced_settings || {};
+      const builtAdvancedResolution = built?.advanced_two_pass || {};
+      const debugWorkflowPath = String(built?.debug_workflow_path || "").trim();
       const exactTwoPassSteps = (twoPass || threePass)
         ? {
           pass1: Number(built?.prompt?.["124"]?.inputs?.steps),
@@ -46073,6 +46120,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const exactTwoPassStepsLine = (twoPass || threePass)
         ? `\nRequested panel steps: Pass 1 = ${requestedTwoPassSteps?.pass1 ?? (threePass ? miniMaxSettings.advanced_two_pass_pass1_steps : miniMaxSettings.two_pass_pass1_steps)}; Pass 2 = ${requestedTwoPassSteps?.pass2 ?? (threePass ? miniMaxSettings.advanced_two_pass_pass2_steps : miniMaxSettings.two_pass_pass2_steps)}`
           + `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
+        : "";
+      const exactAdvancedResolutionLine = threePass
+        ? `\nBuilt Pass 1 target: ${builtAdvancedResolution.pass1_width || "?"}×${builtAdvancedResolution.pass1_height || "?"} (${builtAdvancedResolution.pass1_megapixels ?? "?"} MP); Pass 2 target: ${builtAdvancedResolution.pass2_width || "?"}×${builtAdvancedResolution.pass2_height || "?"} (${builtAdvancedResolution.pass2_megapixels ?? "?"} MP)`
+          + (debugWorkflowPath ? `\nAPI workflow snapshot: ${debugWorkflowPath}` : "")
         : "";
       const exactModelChainLoras = (modelRef) => {
         const loras = [];
@@ -46212,7 +46263,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         promptId,
         (message) => {
           void registerLiveThreePassBackups();
-          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced (Base → MMH3 tiled upscale)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}${exactTwoPassLorasLine}\nPrompt ID: ${promptId}`, pct(62));
+          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced (Base → MMH3 tiled upscale)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}${exactAdvancedResolutionLine}${exactTwoPassLorasLine}\nPrompt ID: ${promptId}`, pct(62));
         },
         () => state.batchCancelled,
         null,
@@ -46322,7 +46373,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         await autoSaveSessionQuiet(options.autoSaveReason || "MiniMax H3 scene video complete");
       }
       progress?.set(
-        `${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced complete — MMH3 Pass 2 selected; Pass 1 backup saved." : twoPass ? "MiniMax H3 learned-latent 2 Pass complete — final pass-2 video selected." : "MiniMax H3 scene ready."}\n${segment.video_path}\n`
+        `${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced complete — MMH3 Pass 2 selected; Pass 1 backup saved." : twoPass ? "MiniMax H3 learned-latent 2 Pass complete — final pass-2 video selected." : "MiniMax H3 scene ready."}${exactAdvancedResolutionLine}\n${segment.video_path}\n`
         + `Exact duration: ${finalDuration.toFixed(3)}s`,
         pct(100),
       );

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2338,6 +2338,19 @@ async function postJson(url, payload, timeoutMs = 120000) {
   }
 }
 
+// Session snapshots must commit in the same order they were created. Lyric
+// edits and performer assignments can trigger autosave while Quick Save is
+// also in flight; without this queue an older snapshot can finish last and
+// restore stale lyrics/cast assignments.
+let builderSessionSaveQueue = Promise.resolve();
+
+function saveBuilderSessionJson(payload, timeoutMs = 60000) {
+  const save = () => postJson("/vrgdg/music_builder/save_session", payload, timeoutMs);
+  const result = builderSessionSaveQueue.then(save, save);
+  builderSessionSaveQueue = result.catch(() => null);
+  return result;
+}
+
 const GEMMA_VIDEO_PROMPT_TIMEOUT_MS = 600000;
 const GEMMA_VIDEO_ENHANCE_TIMEOUT_MS = 300000;
 
@@ -31619,6 +31632,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
           if (present.size) refs.subject_scene_map[segment.id] = Array.from(present);
           syncPerformerInspectorForSegment(segment);
           renderMapping();
+          autoSaveSessionQuiet("performer assignment changed").catch(() => null);
         };
         const selectedPerformerIds = Array.from(performerSelect.selectedOptions || []).map((option) => option.value);
         const performerPreview = markVisualPicker(makeMappingPreview(subjectPreviewItems(new Set(selectedPerformerIds)), "Choose singer / speaker"));
@@ -31637,6 +31651,7 @@ Chrome vault corridor: A sealed industrial passage...</pre>
             if (present.size) refs.subject_scene_map[segment.id] = Array.from(present);
             syncPerformerInspectorForSegment(segment);
             renderMapping();
+            autoSaveSessionQuiet("performer assignment changed").catch(() => null);
           },
         });
         performerPanel.append(performerTitle, performerSelect, performerPreview);
@@ -36550,7 +36565,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         return null;
       }
       await persistIngredientsSheetImages(projectFolder);
-      const data = await postJson("/vrgdg/music_builder/save_session", {
+      const data = await saveBuilderSessionJson({
         audio_path: audioInput.value,
         project_folder: projectFolder,
         session: currentSessionData(),
@@ -36718,7 +36733,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const projectFolder = activeProjectFolderForSave();
     if (!projectFolder) throw new Error("Create or load a project before rendering scene videos.");
     await persistIngredientsSheetImages(projectFolder);
-    const data = await postJson("/vrgdg/music_builder/save_session", {
+    const data = await saveBuilderSessionJson({
       audio_path: audioInput.value,
       project_folder: projectFolder,
       session: currentSessionData(),
@@ -36754,7 +36769,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         return false;
       }
       await persistIngredientsSheetImages(projectFolder);
-      const data = await postJson("/vrgdg/music_builder/save_session", {
+      const data = await saveBuilderSessionJson({
         audio_path: audioInput.value,
         project_folder: projectFolder,
         session: currentSessionData(),

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -292,11 +292,11 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   three_pass_pass1_scheduler: "beta",
   three_pass_pass1_seed: 69,
   three_pass_pass1_te_speed: true,
-  three_pass_pass2_megapixels: 1,
-  three_pass_pass2_steps: 5,
+  three_pass_pass2_megapixels: 2,
+  three_pass_pass2_steps: 1,
   three_pass_pass2_denoise: 0.2,
-  three_pass_pass2_sampler: "euler",
-  three_pass_pass2_scheduler: "beta",
+  three_pass_pass2_sampler: "sa_solver",
+  three_pass_pass2_scheduler: "simple",
   three_pass_pass2_seed: 69,
   three_pass_pass2_te_speed: false,
   three_pass_pass3_megapixels: 2,
@@ -306,6 +306,37 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   three_pass_pass3_scheduler: "beta",
   three_pass_pass3_seed: 69,
   three_pass_pass3_te_speed: false,
+  advanced_two_pass_vram_preset: "12gb",
+  advanced_two_pass_defaults_version: 1,
+  advanced_two_pass_tile_size_mode: "specific_size",
+  advanced_two_pass_tile_width: 448,
+  advanced_two_pass_tile_height: 448,
+  advanced_two_pass_grid_rows: 3,
+  advanced_two_pass_grid_cols: 5,
+  advanced_two_pass_chunk_length: 68,
+  advanced_two_pass_temporal_overlap: 17,
+  advanced_two_pass_anchor_strength: 0.999,
+  advanced_two_pass_spatial_w_overlap: 128,
+  advanced_two_pass_spatial_h_overlap: 128,
+  advanced_two_pass_fade_width: 32,
+  advanced_two_pass_fade_height: 32,
+  advanced_two_pass_min_tile_size: 256,
+  advanced_two_pass_overlap_mode: "earlier",
+  advanced_two_pass_overlap_blend: "linear",
+  advanced_two_pass_upscaler_device: "cuda",
+  advanced_two_pass_upscaler_precision: "bf16",
+  advanced_two_pass_pass1_megapixels: 0.4,
+  advanced_two_pass_pass1_steps: 20,
+  advanced_two_pass_pass1_denoise: 1,
+  advanced_two_pass_pass1_sampler: "euler",
+  advanced_two_pass_pass1_scheduler: "beta",
+  advanced_two_pass_pass1_seed: 69,
+  advanced_two_pass_pass2_megapixels: 2,
+  advanced_two_pass_pass2_steps: 1,
+  advanced_two_pass_pass2_denoise: 0.2,
+  advanced_two_pass_pass2_sampler: "sa_solver",
+  advanced_two_pass_pass2_scheduler: "simple",
+  advanced_two_pass_pass2_seed: 69,
 };
 
 const MINIMAX_H3_CONTINUITY_OPTIONS = [
@@ -427,6 +458,7 @@ function normalizeMiniMaxH3VideoPurpose(value) {
 function cloneMiniMaxH3Settings(value = {}) {
   const source = value && typeof value === "object" ? value : {};
   const hasCurrentTwoPassDefaults = Number(source.two_pass_defaults_version || 0) >= 1;
+  const hasCurrentAdvancedTwoPassDefaults = Number(source.advanced_two_pass_defaults_version || 0) >= 1;
   const sourceLoras = Array.isArray(source.loras)
     ? source.loras
     : Array.from({ length: 4 }, (_, index) => ({
@@ -508,6 +540,49 @@ function cloneMiniMaxH3Settings(value = {}) {
     two_pass_te_speed_device: String(source.two_pass_te_speed_device || DEFAULT_MINIMAX_H3_SETTINGS.two_pass_te_speed_device),
     two_pass_final_resize_method: String(source.two_pass_final_resize_method || DEFAULT_MINIMAX_H3_SETTINGS.two_pass_final_resize_method),
     two_pass_output_crf: Math.max(0, Math.min(100, Math.trunc(Number(source.two_pass_output_crf ?? DEFAULT_MINIMAX_H3_SETTINGS.two_pass_output_crf)))),
+    advanced_two_pass_vram_preset: ["8gb", "12gb", "16gb", "24gb", "custom"].includes(String(source.advanced_two_pass_vram_preset || "").toLowerCase())
+      ? String(source.advanced_two_pass_vram_preset).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_vram_preset,
+    advanced_two_pass_tile_size_mode: ["specific_size", "rows_cols"].includes(String(source.advanced_two_pass_tile_size_mode || "").toLowerCase())
+      ? String(source.advanced_two_pass_tile_size_mode).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_tile_size_mode,
+    advanced_two_pass_tile_width: Math.max(32, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_tile_width ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_tile_width)))),
+    advanced_two_pass_tile_height: Math.max(32, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_tile_height ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_tile_height)))),
+    advanced_two_pass_grid_rows: Math.max(1, Math.min(9, Math.trunc(Number(source.advanced_two_pass_grid_rows ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_grid_rows)))),
+    advanced_two_pass_grid_cols: Math.max(1, Math.min(9, Math.trunc(Number(source.advanced_two_pass_grid_cols ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_grid_cols)))),
+    advanced_two_pass_chunk_length: Math.max(17, Math.min(100000, Math.trunc(Number(source.advanced_two_pass_chunk_length ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_chunk_length)))),
+    advanced_two_pass_temporal_overlap: Math.max(0, Math.min(100000, Math.trunc(Number(source.advanced_two_pass_temporal_overlap ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_temporal_overlap)))),
+    advanced_two_pass_anchor_strength: Math.max(0, Math.min(1, Number(source.advanced_two_pass_anchor_strength ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_anchor_strength))),
+    advanced_two_pass_spatial_w_overlap: Math.max(0, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_spatial_w_overlap ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_spatial_w_overlap)))),
+    advanced_two_pass_spatial_h_overlap: Math.max(0, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_spatial_h_overlap ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_spatial_h_overlap)))),
+    advanced_two_pass_fade_width: Math.max(0, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_fade_width ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_fade_width)))),
+    advanced_two_pass_fade_height: Math.max(0, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_fade_height ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_fade_height)))),
+    advanced_two_pass_min_tile_size: Math.max(0, Math.min(16384, Math.trunc(Number(source.advanced_two_pass_min_tile_size ?? DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_min_tile_size)))),
+    advanced_two_pass_overlap_mode: ["earlier", "later"].includes(String(source.advanced_two_pass_overlap_mode || "").toLowerCase())
+      ? String(source.advanced_two_pass_overlap_mode).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_overlap_mode,
+    advanced_two_pass_overlap_blend: ["linear", "smoothstep", "overwrite", "midpoint"].includes(String(source.advanced_two_pass_overlap_blend || "").toLowerCase())
+      ? String(source.advanced_two_pass_overlap_blend).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_overlap_blend,
+    advanced_two_pass_upscaler_device: ["cuda", "cpu"].includes(String(source.advanced_two_pass_upscaler_device || "").toLowerCase())
+      ? String(source.advanced_two_pass_upscaler_device).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_device,
+    advanced_two_pass_upscaler_precision: ["fp32", "fp16", "bf16"].includes(String(source.advanced_two_pass_upscaler_precision || "").toLowerCase())
+      ? String(source.advanced_two_pass_upscaler_precision).toLowerCase()
+      : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_precision,
+    advanced_two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_defaults_version,
+    ...Object.fromEntries([1, 2].flatMap((pass) => {
+      const prefix = `advanced_two_pass_pass${pass}_`;
+      const defaults = DEFAULT_MINIMAX_H3_SETTINGS;
+      return [
+        [`${prefix}megapixels`, Math.max(0.1, Math.min(16, Number(source[`${prefix}megapixels`] ?? defaults[`${prefix}megapixels`])))],
+        [`${prefix}steps`, Math.max(1, Math.min(1000, Math.trunc(Number(source[`${prefix}steps`] ?? defaults[`${prefix}steps`]) || defaults[`${prefix}steps`])))],
+        [`${prefix}denoise`, Math.max(0, Math.min(1, Number(source[`${prefix}denoise`] ?? defaults[`${prefix}denoise`])))],
+        [`${prefix}sampler`, String(source[`${prefix}sampler`] || defaults[`${prefix}sampler`])],
+        [`${prefix}scheduler`, String(source[`${prefix}scheduler`] || defaults[`${prefix}scheduler`])],
+        [`${prefix}seed`, Number.isFinite(Number(source[`${prefix}seed`])) ? Number(source[`${prefix}seed`]) : defaults[`${prefix}seed`]],
+      ];
+    })),
     ...Object.fromEntries([1, 2].flatMap((pass) => {
       const prefix = `two_pass_pass${pass}_`;
       const defaults = DEFAULT_MINIMAX_H3_SETTINGS;
@@ -523,13 +598,13 @@ function cloneMiniMaxH3Settings(value = {}) {
       const prefix = `three_pass_pass${pass}_`;
       const defaults = DEFAULT_MINIMAX_H3_SETTINGS;
       return [
-        [`${prefix}megapixels`, Math.max(0.1, Number(source[`${prefix}megapixels`] ?? defaults[`${prefix}megapixels`]))],
-        [`${prefix}steps`, Math.max(1, Math.min(1000, Math.trunc(Number(source[`${prefix}steps`] ?? defaults[`${prefix}steps`]) || defaults[`${prefix}steps`])))],
-        [`${prefix}denoise`, Math.max(0, Math.min(1, Number(source[`${prefix}denoise`] ?? defaults[`${prefix}denoise`])) )],
-        [`${prefix}sampler`, String(source[`${prefix}sampler`] || defaults[`${prefix}sampler`])],
-        [`${prefix}scheduler`, String(source[`${prefix}scheduler`] || defaults[`${prefix}scheduler`])],
-        [`${prefix}seed`, Number.isFinite(Number(source[`${prefix}seed`])) ? Number(source[`${prefix}seed`]) : defaults[`${prefix}seed`]],
-        [`${prefix}te_speed`, Boolean(source[`${prefix}te_speed`] ?? defaults[`${prefix}te_speed`])],
+        [`${prefix}megapixels`, Math.max(0.1, Number(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}megapixels`] ?? defaults[`${prefix}megapixels`]) : defaults[`${prefix}megapixels`]))],
+        [`${prefix}steps`, Math.max(1, Math.min(1000, Math.trunc(Number(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}steps`] ?? defaults[`${prefix}steps`]) : defaults[`${prefix}steps`]) || defaults[`${prefix}steps`])))],
+        [`${prefix}denoise`, Math.max(0, Math.min(1, Number(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}denoise`] ?? defaults[`${prefix}denoise`]) : defaults[`${prefix}denoise`])) )],
+        [`${prefix}sampler`, String(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}sampler`] || defaults[`${prefix}sampler`]) : defaults[`${prefix}sampler`])],
+        [`${prefix}scheduler`, String(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}scheduler`] || defaults[`${prefix}scheduler`]) : defaults[`${prefix}scheduler`])],
+        [`${prefix}seed`, hasCurrentAdvancedTwoPassDefaults && Number.isFinite(Number(source[`${prefix}seed`])) ? Number(source[`${prefix}seed`]) : defaults[`${prefix}seed`]],
+        [`${prefix}te_speed`, Boolean(hasCurrentAdvancedTwoPassDefaults ? (source[`${prefix}te_speed`] ?? defaults[`${prefix}te_speed`]) : defaults[`${prefix}te_speed`])],
       ];
     })),
   };
@@ -556,6 +631,8 @@ const MINIMAX_H3_MODEL_DOWNLOADS = [
   { label: "Video VAE", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/vae/minimax_h3_video_vae_fp16.safetensors" },
   { label: "Audio VAE", url: "https://huggingface.co/Comfy-Org/MiniMax-H3/blob/main/vae/minimax_h3_audio_vae_fp32.safetensors" },
   { label: "Kijai MiniMax H3 LoRAs", url: "https://huggingface.co/Kijai/MiniMax-H3_comfy/tree/main/loras" },
+  { label: "MMH3 Ultimate Upscale custom nodes", url: "https://github.com/bbaudio-2025/Comfyui-MMH3-UltimateUpscale" },
+  { label: "MiniMax H3 latent upscaler models", url: "https://github.com/LBH-123-AI/Comfyui_Minimax_h3_latent_Upscaler" },
 ];
 const ZIMAGE_MODEL_DOWNLOADS = [
   { label: "Z-Image Turbo", url: "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors" },
@@ -5821,8 +5898,8 @@ function openBuilder(node) {
   applyCompactButtonLabel(miniMaxTwoPassButton, "Ref to Video\n2 Pass", { noMap: true, minWidth: 0, padding: "7px 6px", title: "Reference-to-Video two-pass upscale workflow" });
   miniMaxTwoPassButton.dataset.minimaxH3TwoPass = "true";
   miniMaxModeChooser.append(miniMaxTwoPassButton);
-  const miniMaxThreePassButton = makeButton("Ref to Video\n3 Pass");
-  applyCompactButtonLabel(miniMaxThreePassButton, "Ref to Video\n3 Pass", { noMap: true, minWidth: 0, padding: "7px 6px", title: "Reference-to-Video experimental three-pass workflow" });
+  const miniMaxThreePassButton = makeButton("Ref to Video\n2 Pass Advanced");
+  applyCompactButtonLabel(miniMaxThreePassButton, "Ref to Video\n2 Pass Advanced", { noMap: true, minWidth: 0, padding: "7px 6px", title: "MMH3 tiled and temporally chunked two-pass upscale workflow" });
   miniMaxThreePassButton.dataset.minimaxH3ThreePass = "true";
   miniMaxModeChooser.append(miniMaxThreePassButton);
   const miniMaxDiffusionModelPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.diffusion_model_name);
@@ -5968,6 +6045,7 @@ function openBuilder(node) {
     "dpmpp_3m_sde",
     "uni_pc",
     "deis",
+    "sa_solver",
   ];
   const threePassSchedulerOptions = [
     "beta",
@@ -5980,8 +6058,8 @@ function openBuilder(node) {
     "linear_quadratic",
     "kl_optimal",
   ];
-  const threePassControls = [1, 2, 3].map((pass) => {
-    const prefix = `three_pass_pass${pass}_`;
+  const advancedTwoPassControls = [1, 2].map((pass) => {
+    const prefix = `advanced_two_pass_pass${pass}_`;
     const megapixels = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}megapixels`]), "number");
     megapixels.min = "0.1";
     megapixels.max = "16";
@@ -5998,18 +6076,29 @@ function openBuilder(node) {
     const scheduler = makeSelect(threePassSchedulerOptions, DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}scheduler`]);
     const seed = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}seed`]), "number");
     seed.step = "1";
-    const teSpeed = makeCheckbox("Use TE-Speed-MiniMaxH3 (OSS)", DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}te_speed`]);
-    const section = makeSettingsSection(`Pass ${pass}`, [
-      makeField("Resolution (megapixels)", megapixels),
+    const resolutionField = makeField(
+      pass === 1 ? "Pass 1 resolution (megapixels)" : "Pass 2 resolution (megapixels)",
+      megapixels,
+      pass === 1
+        ? "Base-generation resolution before MMH3 upscale."
+        : "Target latent resolution produced by the MMH3 tiled upscale pass.",
+    );
+    const samplingFields = [
       makeField("Steps", steps),
       makeField("Sampler", sampler),
       makeField("Scheduler", scheduler),
       makeField("Denoise", denoise),
       makeField("Seed", seed),
-      teSpeed.wrapper,
-    ], pass === 1);
-    return { prefix, megapixels, steps, denoise, sampler, scheduler, seed, teSpeed, section };
+    ];
+    return { prefix, megapixels, steps, denoise, sampler, scheduler, seed, resolutionField, samplingFields };
   });
+  const miniMaxAdvancedSamplingFields = makeSettingsSection("Pass Sampling (Advanced)", [
+    ...advancedTwoPassControls.map((control, index) => makeSettingsSection(
+      index === 0 ? "Pass 1 — Base Generation" : "Pass 2 — MMH3 Tiled Refinement",
+      control.samplingFields,
+      false,
+    )),
+  ], false);
   const twoPassControls = [1, 2].map((pass) => {
     const prefix = `two_pass_pass${pass}_`;
     const steps = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[`${prefix}steps`]), "number");
@@ -6101,10 +6190,71 @@ function openBuilder(node) {
     ], false),
   ], false);
   miniMaxTwoPassSettings.style.display = "none";
-  const miniMaxThreePassSettings = makeSettingsSection("Three-Pass Experimental Settings", [
-    document.createTextNode("These controls apply when Ref to Video 3 Pass is selected. Defaults match the imported workflow."),
+  const miniMaxAdvancedVramPreset = makeSelect([
+    { value: "8gb", label: "8 GB — 352px tiles / 51 frames" },
+    { value: "12gb", label: "12 GB — 448px tiles / 68 frames" },
+    { value: "16gb", label: "16 GB — 544px tiles / 119 frames" },
+    { value: "24gb", label: "24 GB — 672px tiles / 153 frames" },
+    { value: "custom", label: "Custom — keep advanced values" },
+  ], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_vram_preset);
+  const miniMaxAdvancedTileSizeMode = makeSelect([
+    { value: "specific_size", label: "Specific tile width / height" },
+    { value: "rows_cols", label: "Auto equal tiles by rows / columns" },
+  ], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_tile_size_mode);
+  const makeMiniMaxAdvancedNumber = (key, min, max, step) => {
+    const input = makeInput(String(DEFAULT_MINIMAX_H3_SETTINGS[key]), "number");
+    input.min = String(min); input.max = String(max); input.step = String(step);
+    return input;
+  };
+  const miniMaxAdvancedTileWidth = makeMiniMaxAdvancedNumber("advanced_two_pass_tile_width", 32, 16384, 32);
+  const miniMaxAdvancedTileHeight = makeMiniMaxAdvancedNumber("advanced_two_pass_tile_height", 32, 16384, 32);
+  const miniMaxAdvancedGridRows = makeMiniMaxAdvancedNumber("advanced_two_pass_grid_rows", 1, 9, 1);
+  const miniMaxAdvancedGridCols = makeMiniMaxAdvancedNumber("advanced_two_pass_grid_cols", 1, 9, 1);
+  const miniMaxAdvancedChunkLength = makeMiniMaxAdvancedNumber("advanced_two_pass_chunk_length", 17, 100000, 17);
+  const miniMaxAdvancedTemporalOverlap = makeMiniMaxAdvancedNumber("advanced_two_pass_temporal_overlap", 0, 100000, 17);
+  const miniMaxAdvancedAnchorStrength = makeMiniMaxAdvancedNumber("advanced_two_pass_anchor_strength", 0, 1, 0.001);
+  const miniMaxAdvancedSpatialWOverlap = makeMiniMaxAdvancedNumber("advanced_two_pass_spatial_w_overlap", 0, 16384, 32);
+  const miniMaxAdvancedSpatialHOverlap = makeMiniMaxAdvancedNumber("advanced_two_pass_spatial_h_overlap", 0, 16384, 32);
+  const miniMaxAdvancedFadeWidth = makeMiniMaxAdvancedNumber("advanced_two_pass_fade_width", 0, 16384, 32);
+  const miniMaxAdvancedFadeHeight = makeMiniMaxAdvancedNumber("advanced_two_pass_fade_height", 0, 16384, 32);
+  const miniMaxAdvancedMinTileSize = makeMiniMaxAdvancedNumber("advanced_two_pass_min_tile_size", 0, 16384, 32);
+  const miniMaxAdvancedOverlapMode = makeSelect(["earlier", "later"], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_overlap_mode);
+  const miniMaxAdvancedOverlapBlend = makeSelect(["linear", "smoothstep", "overwrite", "midpoint"], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_overlap_blend);
+  const miniMaxAdvancedUpscalerDevice = makeSelect(["cuda", "cpu"], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_device);
+  const miniMaxAdvancedUpscalerPrecision = makeSelect(["bf16", "fp16", "fp32"], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_precision);
+  const miniMaxAdvancedLatentUpscalerPicker = makeSearchableLoraPicker(DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
+  const miniMaxAdvancedUseTeSpeed = makeCheckbox("Use TE-Speed-MiniMaxH3 on Pass 1", DEFAULT_MINIMAX_H3_SETTINGS.two_pass_use_te_speed);
+  const miniMaxAdvancedDependencyNote = document.createElement("div");
+  miniMaxAdvancedDependencyNote.textContent = "Requires the latest Comfyui-MMH3-UltimateUpscale. Pass 1 is saved as a backup; Pass 2 uses temporal chunks and spatial tiles and becomes the final timeline clip.";
+  miniMaxAdvancedDependencyNote.style.cssText = "font-size:11px;color:#facc15;line-height:1.45;";
+  const miniMaxAdvancedTileFields = makeSettingsSection("Hidden MMH3 Advanced Settings", [
+    makeField("Tile sizing mode", miniMaxAdvancedTileSizeMode),
+    makeField("Tile width", miniMaxAdvancedTileWidth),
+    makeField("Tile height", miniMaxAdvancedTileHeight),
+    makeField("Grid rows", miniMaxAdvancedGridRows),
+    makeField("Grid columns", miniMaxAdvancedGridCols),
+    makeField("Chunk length (multiple of 17)", miniMaxAdvancedChunkLength),
+    makeField("Temporal overlap (multiple of 17)", miniMaxAdvancedTemporalOverlap),
+    makeField("Anchor strength", miniMaxAdvancedAnchorStrength),
+    makeField("Horizontal tile overlap", miniMaxAdvancedSpatialWOverlap),
+    makeField("Vertical tile overlap", miniMaxAdvancedSpatialHOverlap),
+    makeField("Fade width", miniMaxAdvancedFadeWidth),
+    makeField("Fade height", miniMaxAdvancedFadeHeight),
+    makeField("Minimum tile size", miniMaxAdvancedMinTileSize),
+    makeField("Overlap ownership", miniMaxAdvancedOverlapMode),
+    makeField("Overlap blend", miniMaxAdvancedOverlapBlend),
+    makeField("Upscaler device", miniMaxAdvancedUpscalerDevice),
+    makeField("Upscaler precision", miniMaxAdvancedUpscalerPrecision),
+  ], false);
+  const miniMaxThreePassSettings = makeSettingsSection("2 Pass Advanced — MMH3 Ultimate Upscale", [
+    miniMaxAdvancedDependencyNote,
+    makeField("VRAM preset", miniMaxAdvancedVramPreset, "Presets apply conservative tile and temporal chunk starting points from the MMH3 guide."),
     makeField("Reference image sizing", miniMaxThreePassRefImageSize, "Controls the MiniMax H3 reference-conditioning image-size mode. Default: max."),
-    ...threePassControls.map((item) => item.section),
+    makeField("Latent upscaler model", miniMaxAdvancedLatentUpscalerPicker.wrapper),
+    miniMaxAdvancedUseTeSpeed.wrapper,
+    ...advancedTwoPassControls.map((item) => item.resolutionField),
+    miniMaxAdvancedSamplingFields,
+    miniMaxAdvancedTileFields,
   ], false);
   miniMaxThreePassSettings.style.display = "none";
   const miniMaxEasyCacheBypass = makeCheckbox("Bypass EasyCache", DEFAULT_MINIMAX_H3_SETTINGS.easy_cache_bypass);
@@ -7424,8 +7574,12 @@ function openBuilder(node) {
       two_pass_final_width: miniMaxTwoPassFinalWidth.value,
       two_pass_final_height: miniMaxTwoPassFinalHeight.value,
       two_pass_latent_upscale_scale: miniMaxTwoPassLatentScale.value,
-      two_pass_latent_upscaler_name: miniMaxTwoPassLatentUpscalerPicker.input.value,
-      two_pass_use_te_speed: miniMaxTwoPassUseTeSpeed.input.checked,
+      two_pass_latent_upscaler_name: state.miniMaxH3ThreePassEnabled
+        ? miniMaxAdvancedLatentUpscalerPicker.input.value
+        : miniMaxTwoPassLatentUpscalerPicker.input.value,
+      two_pass_use_te_speed: state.miniMaxH3ThreePassEnabled
+        ? miniMaxAdvancedUseTeSpeed.input.checked
+        : miniMaxTwoPassUseTeSpeed.input.checked,
       two_pass_te_speed_processing_control: miniMaxTwoPassTeProcessingControl.value,
       two_pass_te_speed_start_percent: miniMaxTwoPassTeStart.value,
       two_pass_te_speed_end_percent: miniMaxTwoPassTeEnd.value,
@@ -7436,6 +7590,25 @@ function openBuilder(node) {
       two_pass_output_crf: miniMaxTwoPassOutputCrf.value,
       three_pass_lightx_lora_name: miniMaxThreePassLoraPicker.input.value,
       three_pass_lightx_lora_strength: miniMaxThreePassLoraStrength.value,
+      advanced_two_pass_vram_preset: miniMaxAdvancedVramPreset.value,
+      advanced_two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_defaults_version,
+      advanced_two_pass_tile_size_mode: miniMaxAdvancedTileSizeMode.value,
+      advanced_two_pass_tile_width: miniMaxAdvancedTileWidth.value,
+      advanced_two_pass_tile_height: miniMaxAdvancedTileHeight.value,
+      advanced_two_pass_grid_rows: miniMaxAdvancedGridRows.value,
+      advanced_two_pass_grid_cols: miniMaxAdvancedGridCols.value,
+      advanced_two_pass_chunk_length: miniMaxAdvancedChunkLength.value,
+      advanced_two_pass_temporal_overlap: miniMaxAdvancedTemporalOverlap.value,
+      advanced_two_pass_anchor_strength: miniMaxAdvancedAnchorStrength.value,
+      advanced_two_pass_spatial_w_overlap: miniMaxAdvancedSpatialWOverlap.value,
+      advanced_two_pass_spatial_h_overlap: miniMaxAdvancedSpatialHOverlap.value,
+      advanced_two_pass_fade_width: miniMaxAdvancedFadeWidth.value,
+      advanced_two_pass_fade_height: miniMaxAdvancedFadeHeight.value,
+      advanced_two_pass_min_tile_size: miniMaxAdvancedMinTileSize.value,
+      advanced_two_pass_overlap_mode: miniMaxAdvancedOverlapMode.value,
+      advanced_two_pass_overlap_blend: miniMaxAdvancedOverlapBlend.value,
+      advanced_two_pass_upscaler_device: miniMaxAdvancedUpscalerDevice.value,
+      advanced_two_pass_upscaler_precision: miniMaxAdvancedUpscalerPrecision.value,
       ...Object.fromEntries(twoPassControls.flatMap((control) => [
         [`${control.prefix}steps`, control.steps.value],
         [`${control.prefix}denoise`, control.denoise.value],
@@ -7443,14 +7616,13 @@ function openBuilder(node) {
         [`${control.prefix}scheduler`, control.scheduler.value],
         [`${control.prefix}seed`, control.seed.value],
       ])),
-      ...Object.fromEntries(threePassControls.flatMap((control) => [
+      ...Object.fromEntries(advancedTwoPassControls.flatMap((control) => [
         [`${control.prefix}megapixels`, control.megapixels.value],
         [`${control.prefix}steps`, control.steps.value],
         [`${control.prefix}denoise`, control.denoise.value],
         [`${control.prefix}sampler`, control.sampler.value],
         [`${control.prefix}scheduler`, control.scheduler.value],
         [`${control.prefix}seed`, control.seed.value],
-        [`${control.prefix}te_speed`, control.teSpeed.input.checked],
       ])),
       easy_cache_bypass: miniMaxEasyCacheBypass.input.checked,
       easy_cache_bypass_before_turbo: turboEnabled
@@ -8124,7 +8296,9 @@ function openBuilder(node) {
     miniMaxTwoPassFinalHeight.value = String(settings.two_pass_final_height);
     miniMaxTwoPassLatentScale.value = String(settings.two_pass_latent_upscale_scale);
     miniMaxTwoPassLatentUpscalerPicker.input.value = settings.two_pass_latent_upscaler_name;
+    miniMaxAdvancedLatentUpscalerPicker.input.value = settings.two_pass_latent_upscaler_name;
     miniMaxTwoPassUseTeSpeed.input.checked = Boolean(settings.two_pass_use_te_speed);
+    miniMaxAdvancedUseTeSpeed.input.checked = Boolean(settings.two_pass_use_te_speed);
     miniMaxTwoPassTeProcessingControl.value = String(settings.two_pass_te_speed_processing_control);
     miniMaxTwoPassTeStart.value = String(settings.two_pass_te_speed_start_percent);
     miniMaxTwoPassTeEnd.value = String(settings.two_pass_te_speed_end_percent);
@@ -8135,6 +8309,24 @@ function openBuilder(node) {
     miniMaxTwoPassOutputCrf.value = String(settings.two_pass_output_crf);
     miniMaxThreePassLoraPicker.input.value = settings.three_pass_lightx_lora_name;
     miniMaxThreePassLoraStrength.value = String(settings.three_pass_lightx_lora_strength);
+    miniMaxAdvancedVramPreset.value = settings.advanced_two_pass_vram_preset;
+    miniMaxAdvancedTileSizeMode.value = settings.advanced_two_pass_tile_size_mode;
+    miniMaxAdvancedTileWidth.value = String(settings.advanced_two_pass_tile_width);
+    miniMaxAdvancedTileHeight.value = String(settings.advanced_two_pass_tile_height);
+    miniMaxAdvancedGridRows.value = String(settings.advanced_two_pass_grid_rows);
+    miniMaxAdvancedGridCols.value = String(settings.advanced_two_pass_grid_cols);
+    miniMaxAdvancedChunkLength.value = String(settings.advanced_two_pass_chunk_length);
+    miniMaxAdvancedTemporalOverlap.value = String(settings.advanced_two_pass_temporal_overlap);
+    miniMaxAdvancedAnchorStrength.value = String(settings.advanced_two_pass_anchor_strength);
+    miniMaxAdvancedSpatialWOverlap.value = String(settings.advanced_two_pass_spatial_w_overlap);
+    miniMaxAdvancedSpatialHOverlap.value = String(settings.advanced_two_pass_spatial_h_overlap);
+    miniMaxAdvancedFadeWidth.value = String(settings.advanced_two_pass_fade_width);
+    miniMaxAdvancedFadeHeight.value = String(settings.advanced_two_pass_fade_height);
+    miniMaxAdvancedMinTileSize.value = String(settings.advanced_two_pass_min_tile_size);
+    miniMaxAdvancedOverlapMode.value = settings.advanced_two_pass_overlap_mode;
+    miniMaxAdvancedOverlapBlend.value = settings.advanced_two_pass_overlap_blend;
+    miniMaxAdvancedUpscalerDevice.value = settings.advanced_two_pass_upscaler_device;
+    miniMaxAdvancedUpscalerPrecision.value = settings.advanced_two_pass_upscaler_precision;
     twoPassControls.forEach((control) => {
       control.steps.value = String(settings[`${control.prefix}steps`]);
       control.denoise.value = String(settings[`${control.prefix}denoise`]);
@@ -8142,14 +8334,13 @@ function openBuilder(node) {
       control.scheduler.value = settings[`${control.prefix}scheduler`];
       control.seed.value = String(settings[`${control.prefix}seed`]);
     });
-    threePassControls.forEach((control) => {
+    advancedTwoPassControls.forEach((control) => {
       control.megapixels.value = String(settings[`${control.prefix}megapixels`]);
       control.steps.value = String(settings[`${control.prefix}steps`]);
       control.denoise.value = String(settings[`${control.prefix}denoise`]);
       control.sampler.value = settings[`${control.prefix}sampler`];
       control.scheduler.value = settings[`${control.prefix}scheduler`];
       control.seed.value = String(settings[`${control.prefix}seed`]);
-      control.teSpeed.input.checked = Boolean(settings[`${control.prefix}te_speed`]);
     });
     const multiPassMode = state.miniMaxH3TwoPassEnabled || state.miniMaxH3ThreePassEnabled;
     miniMaxMegapixelsField.style.display = multiPassMode ? "none" : "";
@@ -8157,8 +8348,8 @@ function openBuilder(node) {
     miniMaxAdvancedSettings.style.display = multiPassMode ? "none" : "";
     miniMaxTwoPassSettings.style.display = state.miniMaxH3TwoPassEnabled ? "" : "none";
     miniMaxThreePassSettings.style.display = state.miniMaxH3ThreePassEnabled ? "" : "none";
-    miniMaxTwoPassLoraSection.style.display = state.miniMaxH3TwoPassEnabled ? "" : "none";
-    miniMaxThreePassLoraSection.style.display = state.miniMaxH3ThreePassEnabled ? "" : "none";
+    miniMaxTwoPassLoraSection.style.display = (state.miniMaxH3TwoPassEnabled || state.miniMaxH3ThreePassEnabled) ? "" : "none";
+    miniMaxThreePassLoraSection.style.display = "none";
     miniMaxEasyCacheBypass.input.checked = settings.easy_cache_bypass;
     miniMaxEasyCacheReuseThreshold.value = String(settings.easy_cache_reuse_threshold);
     miniMaxEasyCacheStartPercent.value = String(settings.easy_cache_start_percent);
@@ -8229,12 +8420,12 @@ function openBuilder(node) {
     const threePass = Boolean(state.miniMaxH3ThreePassEnabled) && mode === "reference_to_video";
     const hideMultiPassIgnoredSettings = twoPass || threePass;
     miniMaxLoraSlots.forEach((slot) => {
-      slot.applyToField.style.display = twoPass ? "flex" : "none";
-      slot.row.style.gridTemplateColumns = twoPass
+      slot.applyToField.style.display = (twoPass || threePass) ? "flex" : "none";
+      slot.row.style.gridTemplateColumns = (twoPass || threePass)
         ? "minmax(0,1fr) 92px minmax(120px,0.45fr)"
         : "minmax(0,1fr) 92px";
     });
-    if (twoPass) {
+    if (twoPass || threePass) {
       miniMaxLoraNote.textContent = settings.use_loras
         ? "Extra LoRAs are ON. Each can target pass 1, pass 2, or both. The required Turbo LoRA remains separate and pass-2-only."
         : "Optional extra LoRAs are OFF. Enable them, choose a count, then select the target pass for each LoRA.";
@@ -23190,13 +23381,13 @@ function openBuilder(node) {
         const timing = miniMaxH3CueTimingText(cue, segment, cueMap, index);
         if (cue.type === "instrumental") {
           const note = cue.action_note ? ` Action note: ${cue.action_note}` : "";
-          return `${timing}Instrumental / no vocal cue. No visible subject sings or lip-syncs; mouths stay closed or naturally relaxed.${note}`;
+          return `${timing}Use only the assigned visual action and camera direction for this interval.${note}`;
         }
         const subject = performers.find((item) => String(item.id) === String(cue.singer_id)) || { id: cue.singer_id, name: cue.singer_name };
         const vocalStart = Number(cue.vocal_start);
         const vocalEnd = Number(cue.vocal_end);
         const vocalWindow = Number.isFinite(vocalStart) && Number.isFinite(vocalEnd) && vocalEnd > vocalStart
-          ? ` Vocal lip-sync occurs only from ${vocalStart.toFixed(3)}s-${vocalEnd.toFixed(3)}s; before and after that window the mouth stays closed or naturally relaxed.`
+          ? ` The assigned performer lip-syncs from ${vocalStart.toFixed(3)}s-${vocalEnd.toFixed(3)}s.`
           : "";
         return `${timing}${miniMaxH3PerformerLabel(subject, labelMap)} performs "${miniMaxH3PunctuatedCueText(cue.text)}" from <Audio 1>.${vocalWindow}`;
       });
@@ -23204,7 +23395,7 @@ function openBuilder(node) {
       return [
         "Vocal cue map:",
         ...lines,
-        "Only the assigned performer sings or speaks each cue. Other visible performers remain silent, mouth closed or naturally reacting, until assigned their own cue.",
+        "Apply performer assignments only to vocal cues; use visual action and camera direction for all other cue rows.",
       ].join("\n");
     }
     if (performers.length === 1 && lyricText) {
@@ -23320,20 +23511,20 @@ function openBuilder(node) {
         : `from ${start.toFixed(3)}s`;
       if (cue.type === "instrumental") {
         const note = String(cue.action_note || "").trim();
-        return `[Shot ${index + 1}] ${timing}: instrumental/no vocal. No visible subject sings or lip-syncs.${note ? ` Visual action note: ${note}` : ""}`;
+        return `[Shot ${index + 1}] ${timing}: use only the assigned visual action and camera direction.${note ? ` Visual action note: ${note}` : ""}`;
       }
       const subject = performers.find((item) => String(item.id) === String(cue.singer_id)) || { id: cue.singer_id, name: cue.singer_name };
       const vocalStart = Number(cue.vocal_start);
       const vocalEnd = Number(cue.vocal_end);
       const vocalWindow = Number.isFinite(vocalStart) && Number.isFinite(vocalEnd) && vocalEnd > vocalStart
-        ? ` The singer begins lip-syncing only at ${vocalStart.toFixed(3)}s and stops at ${vocalEnd.toFixed(3)}s. Before and after that exact vocal window, the singer's mouth stays closed or naturally relaxed.`
+        ? ` The singer lip-syncs from ${vocalStart.toFixed(3)}s to ${vocalEnd.toFixed(3)}s.`
         : "";
       return `[Shot ${index + 1}] ${timing}: ${miniMaxH3PerformerLabel(subject, labelMap)} is the only performer singing/lip-syncing <d>[English] ${miniMaxH3PunctuatedCueText(cue.text)}</d> from <Audio 1>.${vocalWindow} Other visible performers remain silent, mouth closed or naturally reacting.`;
     });
     return [
       "Timed singer/lyric shot contract — authoritative:",
       ...lines,
-      "Each listed cue is its own shot. Do not swap singers, merge lyric cues, anticipate a later lyric, or make any visible performer sing outside the exact assigned vocal window.",
+      "Each listed cue is its own shot. Do not swap singers, merge lyric cues, or anticipate a later vocal cue. Apply vocal direction only to the assigned vocal row and its exact timing.",
     ].join("\n");
   }
 
@@ -36373,6 +36564,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       minimax_h3_settings: cloneMiniMaxH3Settings(state.miniMaxH3Settings),
         minimax_h3_two_pass: Boolean(state.miniMaxH3TwoPassEnabled),
         minimax_h3_three_pass: Boolean(state.miniMaxH3ThreePassEnabled),
+        minimax_h3_advanced_two_pass: Boolean(state.miniMaxH3ThreePassEnabled),
       image_model_mode: state.imageModelMode,
       zimage_settings: state.zimageSettings,
       reference_krea2_settings: cloneKrea2ReferenceSettings(state.referenceKrea2Settings),
@@ -36681,7 +36873,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         state.projectVideoEngine = normalizeProjectVideoEngine(data.session.video_engine ?? state.projectVideoEngine);
         state.miniMaxH3Settings = cloneMiniMaxH3Settings(data.session.minimax_h3_settings || state.miniMaxH3Settings);
         state.miniMaxH3TwoPassEnabled = Boolean(data.session.minimax_h3_two_pass ?? state.miniMaxH3TwoPassEnabled);
-        state.miniMaxH3ThreePassEnabled = Boolean(data.session.minimax_h3_three_pass ?? state.miniMaxH3ThreePassEnabled);
+        state.miniMaxH3ThreePassEnabled = Boolean(data.session.minimax_h3_advanced_two_pass ?? data.session.minimax_h3_three_pass ?? state.miniMaxH3ThreePassEnabled);
         state.imageModelMode = data.session.image_model_mode || data.session.flux_klein_settings?.image_model_mode || state.imageModelMode || "zimage";
         state.pxPerSecond = state.timelineZoom;
         waveformModeSelect.value = state.waveformMode;
@@ -37041,7 +37233,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       state.projectVideoEngine = normalizeProjectVideoEngine(session.video_engine);
       state.miniMaxH3Settings = cloneMiniMaxH3Settings(session.minimax_h3_settings || {});
       state.miniMaxH3TwoPassEnabled = Boolean(session.minimax_h3_two_pass);
-      state.miniMaxH3ThreePassEnabled = Boolean(session.minimax_h3_three_pass);
+      state.miniMaxH3ThreePassEnabled = Boolean(session.minimax_h3_advanced_two_pass ?? session.minimax_h3_three_pass);
       state.imageModelMode = session.image_model_mode || session.flux_klein_settings?.image_model_mode || state.imageModelMode || "zimage";
       state.pxPerSecond = state.timelineZoom;
       waveformModeSelect.value = state.waveformMode;
@@ -40109,7 +40301,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (vocalCueMap) {
       add(parts, "Performer / vocal cue map", vocalCueMap);
       if (selectedPerformerSubjectsForSegment(segment).length >= 2) {
-        parts.push("Multi-performer rule: use exact subject labels such as <Subject 1> (S1), <Subject 2> (S2), and <Audio 1> in the shot descriptions. For each assigned cue, write that the assigned subject precisely lip-syncs to <Audio 1>, singing or speaking the cue inside <d>[English] cue.</d>. Do not make an unassigned performer sing or speak during another performer's cue; keep them silent, mouth closed, or naturally reacting.");
+        parts.push("Multi-performer rule: use exact subject labels such as <Subject 1> (S1), <Subject 2> (S2), and <Audio 1> in the shot descriptions. For each vocal cue, write that the assigned subject precisely lip-syncs to <Audio 1>, singing or speaking the cue inside <d>[English] cue.</d>. Apply no performance direction to other performers during that cue.");
         parts.push("Shot wording rule: do not begin descriptions with 'The camera cuts to' or 'The camera...'. Start with the resulting framing or subject action, e.g. 'A panning medium shot shows...' or '<Subject 2> (S2) steps forward...'.");
       }
     }
@@ -40173,7 +40365,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const cuts = Array.isArray(cutPlan.cut_times_seconds) ? cutPlan.cut_times_seconds : [];
     if (cutPlan.cue_driven) {
       const timingText = cuts.map((time) => miniMaxH3Timecode(time)).join(", ");
-      return `EDITING / CUT PLAN — MANDATORY: The timed singer/lyric cue map controls this exact ${exactDuration}-second segment. Create exactly ${cuts.length + 1} shot${cuts.length ? "s" : ""}${cuts.length ? ` with hard cuts at ${timingText}` : ""}. Each shot corresponds to one cue row in order: instrumental rows mean no visible lip-sync, and lyric rows mean only the assigned subject sings that cue. The builder will write [Shot 1] and every later [Shot N] At MM:SS.mmm label. Return only the creative description for each shot. Do not omit, merge, add, reorder, or shift cue shots.`;
+      return `EDITING / CUT PLAN — MANDATORY: The timed singer/lyric cue map controls this exact ${exactDuration}-second segment. Create exactly ${cuts.length + 1} shot${cuts.length ? "s" : ""}${cuts.length ? ` with hard cuts at ${timingText}` : ""}. Each shot corresponds to one cue row in order: rows without assigned words use only their visual action and camera direction, while lyric rows use the assigned subject and exact cue. The builder will write [Shot 1] and every later [Shot N] At MM:SS.mmm label. Return only the creative description for each shot. Do not omit, merge, add, reorder, or shift cue shots.`;
     }
     if (!cuts.length) {
       return `EDITING / CUT PLAN — MANDATORY: Use one smooth, continuous, uninterrupted shot for the full ${exactDuration}-second segment. Output only [Shot 1]. Use no additional shot label, hard cut, angle reset, montage, dissolve, scene change, or transition. Camera and character movement may develop inside the same continuous take.`;
@@ -40550,13 +40742,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       || performers[0]
       || { id: cue.singer_id, name: cue.singer_name || "Singer" };
     const performer = miniMaxH3PerformerLabel(subject, labelMap);
-    const vocalMarker = /<d>|<\/d>|\b(?:sings?|singing|sung|speaks?|speaking|says?|saying|performs?|performing|dialogue|lip[ -]?sync(?:s|ing|ed)?|lyrics?|vocals?|mouth\s+(?:moves?|moving|shapes?|shaping|articulates?|articulating)|lips?\s+(?:moves?|moving|shapes?|shaping)|jaw\s+(?:moves?|moving|shapes?|shaping|articulates?|articulating))\b/i;
+    const vocalMarker = /<d>|<\/d>|\b(?:sings?|singing|sung|speaks?|speaking|says?|saying|performs?|performing|dialogue|lip[ -]?sync(?:s|ing|ed)?|lyrics?|vocals?|instrumental|no[- ]?vocal|mouth\s+(?:moves?|moving|shapes?|shaping|articulates?|articulating)|lips?\s+(?:moves?|moving|shapes?|shaping)|jaw\s+(?:moves?|moving|shapes?|shaping|articulates?|articulating))\b/i;
     if (cue.type === "instrumental") {
       const sentences = text.match(/[^.!?…]+[.!?…]+|[^.!?…]+$/g) || [];
       let clean = sentences.filter((sentence) => !vocalMarker.test(sentence)).join(" ").replace(/\s+/g, " ").trim();
       if (!clean) clean = miniMaxH3FallbackShotDescription(segment, shotIndex, mode);
-      const silentContract = `${performer} remains silent throughout this shot with mouth closed or naturally relaxed; no singing, lyric performance, or lip-sync occurs.`;
-      return normalizeMiniMaxH3ShotDescription(`${clean.replace(/[.!?…]+$/g, "").trim()}. ${silentContract}`);
+      return normalizeMiniMaxH3ShotDescription(clean);
     }
     // The application owns the exact lyric placement, but the LLM's shot
     // sentence also contains valuable blocking, camera, and ensemble action.
@@ -40912,22 +41103,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   function miniMaxH3OfficialAudioDefinition(segment) {
     const settings = miniMaxH3SettingsForSegment(segment);
     if (settings.audio_mode === "built_in_audio") return "";
-    const visualOnly = segmentUsesNoLipSyncPerformance(segment);
-    const dialogueAssignments = visualOnly ? [] : miniMaxDialogueAssignmentsForSegment(segment);
-    const lyricText = dialogueAssignments.length
-      ? dialogueAssignments.map((cue) => cue.text).join(" ")
-      : isInstrumentalLyricText(segment?.lyric_text) ? "" : flattenLyricForPrompt(segment?.lyric_text);
-    const hasExplicitCueMap = isMiniMaxSingerAssignmentMode(segment)
-      && normalizeLyricCueMapForSegment(segment).length > 0;
-    const performer = segment?.no_character_present || hasExplicitCueMap ? "the target video" : "<Subject 1> (S1)";
-    const lyricClause = lyricText && !visualOnly
-      ? selectedPerformerSubjectsForSegment(segment).length >= 2
-        ? ` ${miniMaxH3VocalCueMapText(segment, miniMaxH3ModeForSegment(segment), { compact: true })}`
-        : hasExplicitCueMap
-          ? ` ${miniMaxH3VocalCueMapText(segment, miniMaxH3ModeForSegment(segment), { compact: true })}`
-        : ` The exact performed lyric/dialogue line is "${miniMaxH3PunctuatedCueText(lyricText)}"`
-      : "";
-    return `<Audio 1> is the complete synchronized song and vocal track for ${performer}, reused as the target video's complete final soundtrack and timing reference.${lyricClause}`;
+    // Keep the audio definition deliberately standalone.  Cue timing and
+    // singer assignments belong in the shot descriptions, never on the
+    // <Audio 1> definition line in subject_definitions.
+    return "<Audio 1> is the complete synchronized song and vocal track for the target video, reused as the target video's complete final soundtrack and timing reference.";
   }
 
   function miniMaxH3OfficialSummary(segment, mode, refs) {
@@ -41021,7 +41200,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     return `${prefix}integrated_multimodal_description:\n${creative}`;
   }
 
-  function assertValidMiniMaxH3FinalPrompt(prompt, segment, mode = miniMaxH3ModeForSegment(segment)) {
+  function assertValidMiniMaxH3FinalPrompt(prompt, segment, mode = miniMaxH3ModeForSegment(segment), options = {}) {
     const text = String(prompt || "").trim();
     const normalizedMode = normalizeMiniMaxH3Mode(mode);
     if (!text) throw new Error("The assembled MiniMax H3 prompt is empty.");
@@ -41056,8 +41235,22 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }
         if (cue.type === "vocal") {
           const expectedTag = `<d>[English] ${miniMaxH3CapitalizeCueText(miniMaxH3PunctuatedCueText(cue.text))}</d>`;
-          if (dialogueTags.length !== 1 || dialogueTags[0] !== expectedTag) {
-            throw new Error(`${shotLabel} must contain exactly its assigned lyric cue: ${expectedTag}`);
+          const normalizeCueTag = (value) => String(value || "")
+            .replace(/\\</g, "<")
+            .replace(/\\>/g, ">")
+            .replace(/\\+/g, "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .toLocaleLowerCase();
+          const actualTag = dialogueTags.length === 1 ? dialogueTags[0] : "";
+          if (dialogueTags.length !== 1 || normalizeCueTag(actualTag) !== normalizeCueTag(expectedTag)) {
+            const warning = `${shotLabel} lyric cue mismatch. Expected ${expectedTag}; found ${actualTag || "no <d> cue"}.`;
+            if (options.allowCueValidationWarnings) {
+              console.warn(`[VRGDG Music Builder] ${warning}`);
+              if (typeof options.onCueValidationWarning === "function") options.onCueValidationWarning(warning);
+            } else {
+              throw new Error(`${shotLabel} must contain exactly its assigned lyric cue: ${expectedTag}`);
+            }
           }
         }
       });
@@ -41288,7 +41481,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     } else if (lyricText && cueShotContract) {
       parts.push(
         "Vocal performance: TIMED CUE MAP ONLY.",
-        "Audio 1 is the exact timing reference. Instrumental cue shots contain no singing, speaking, lyric performance, or lip sync. The assigned performer sings only the exact words inside each vocal cue and only during that cue's stated time range. Never stretch, restart, anticipate, or repeat the full lyric across other shots.",
+        "Audio 1 is the exact timing reference. For each vocal cue, the assigned performer uses only the exact words inside that cue and only during its stated time range. Use only visual action and camera direction for other cue shots. Never stretch, restart, anticipate, or repeat the full lyric across shots.",
       );
     } else if (lyricText) {
       parts.push(
@@ -45585,7 +45778,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const twoPass = Boolean(state.miniMaxH3TwoPassEnabled) && mode === "reference_to_video";
     const threePass = Boolean(state.miniMaxH3ThreePassEnabled) && mode === "reference_to_video";
     if ((twoPass || threePass) && builtInAudio) {
-      throw new Error(`MiniMax H3 ${threePass ? "3 Pass" : "2 Pass"} currently supports Input Audio only. Switch Audio Mode to Input Audio before rendering.`);
+      throw new Error(`MiniMax H3 ${threePass ? "2 Pass Advanced" : "2 Pass"} currently supports Input Audio only. Switch Audio Mode to Input Audio before rendering.`);
     }
     if (!projectFolder) throw new Error("Save or select a project folder before rendering MiniMax H3.");
     if (!Number.isFinite(timelineStart) || !Number.isFinite(timelineEnd) || sceneDuration <= 0) {
@@ -45606,7 +45799,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       ?? (segment?.minimax_h3_prompt || segment?.i2v_prompt || "")
     ).trim();
     if (!prompt) throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a MiniMax H3 prompt.`);
-    assertValidMiniMaxH3FinalPrompt(prompt, segment, mode);
+    assertValidMiniMaxH3FinalPrompt(prompt, segment, mode, {
+      allowCueValidationWarnings: true,
+      onCueValidationWarning: options.onCueValidationWarning,
+    });
 
     const sourceAudioPath = String(
       options.audioPath
@@ -45727,10 +45923,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     segment.video_status = "running";
     renderList();
     const activePanel = segment?.id === panelSegmentId;
-    const requestedTwoPassSteps = twoPass && activePanel
+    const requestedTwoPassSteps = (twoPass || threePass) && activePanel
       ? {
-        pass1: Math.max(1, Math.min(1000, Math.trunc(Number(twoPassControls[0].steps.value) || 20))),
-        pass2: Math.max(1, Math.min(1000, Math.trunc(Number(twoPassControls[1].steps.value) || 5))),
+        pass1: Math.max(1, Math.min(1000, Math.trunc(Number((threePass ? advancedTwoPassControls : twoPassControls)[0].steps.value) || 20))),
+        pass2: Math.max(1, Math.min(1000, Math.trunc(Number((threePass ? advancedTwoPassControls : twoPassControls)[1].steps.value) || 5))),
       }
       : null;
     progress?.set(`${batchLabel}Preparing exact MiniMax H3 scene timing and ${builtInAudio ? "native audio generation" : "input audio"}...`, pct(8));
@@ -45766,28 +45962,28 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         final_width: twoPass ? miniMaxSettings.two_pass_final_width : undefined,
         final_height: twoPass ? miniMaxSettings.two_pass_final_height : undefined,
         latent_upscale_scale: twoPass ? miniMaxSettings.two_pass_latent_upscale_scale : undefined,
-        latent_upscaler_name: twoPass ? miniMaxSettings.two_pass_latent_upscaler_name : undefined,
-        two_pass_use_te_speed: twoPass ? miniMaxSettings.two_pass_use_te_speed : undefined,
-        te_speed_processing_control: twoPass ? miniMaxSettings.two_pass_te_speed_processing_control : undefined,
-        te_speed_start_percent: twoPass ? miniMaxSettings.two_pass_te_speed_start_percent : undefined,
-        te_speed_end_percent: twoPass ? miniMaxSettings.two_pass_te_speed_end_percent : undefined,
-        te_speed_mcs: twoPass ? miniMaxSettings.two_pass_te_speed_mcs : undefined,
-        te_speed_cache_depth: twoPass ? miniMaxSettings.two_pass_te_speed_cache_depth : undefined,
-        te_speed_device: twoPass ? miniMaxSettings.two_pass_te_speed_device : undefined,
-        final_resize_method: twoPass ? miniMaxSettings.two_pass_final_resize_method : undefined,
-        output_crf: twoPass ? miniMaxSettings.two_pass_output_crf : undefined,
+        latent_upscaler_name: (twoPass || threePass) ? miniMaxSettings.two_pass_latent_upscaler_name : undefined,
+        two_pass_use_te_speed: (twoPass || threePass) ? miniMaxSettings.two_pass_use_te_speed : undefined,
+        te_speed_processing_control: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_processing_control : undefined,
+        te_speed_start_percent: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_start_percent : undefined,
+        te_speed_end_percent: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_end_percent : undefined,
+        te_speed_mcs: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_mcs : undefined,
+        te_speed_cache_depth: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_cache_depth : undefined,
+        te_speed_device: (twoPass || threePass) ? miniMaxSettings.two_pass_te_speed_device : undefined,
+        final_resize_method: (twoPass || threePass) ? miniMaxSettings.two_pass_final_resize_method : undefined,
+        output_crf: (twoPass || threePass) ? miniMaxSettings.two_pass_output_crf : undefined,
         three_pass_lightx_lora_name: miniMaxSettings.three_pass_lightx_lora_name,
         three_pass_lightx_lora_strength: miniMaxSettings.three_pass_lightx_lora_strength,
-        pass1_steps: twoPass ? (requestedTwoPassSteps?.pass1 ?? miniMaxSettings.two_pass_pass1_steps) : miniMaxSettings.steps,
-        pass1_denoise: twoPass ? miniMaxSettings.two_pass_pass1_denoise : miniMaxSettings.denoise,
-        pass1_sampler_name: twoPass ? miniMaxSettings.two_pass_pass1_sampler : miniMaxSettings.sampler_name,
-        pass1_scheduler: twoPass ? miniMaxSettings.two_pass_pass1_scheduler : miniMaxSettings.scheduler,
-        pass1_seed: twoPass ? miniMaxSettings.two_pass_pass1_seed : miniMaxSettings.seed,
-        pass2_steps: twoPass ? (requestedTwoPassSteps?.pass2 ?? miniMaxSettings.two_pass_pass2_steps) : 4,
-        pass2_denoise: twoPass ? miniMaxSettings.two_pass_pass2_denoise : 0.2,
-        pass2_sampler_name: twoPass ? miniMaxSettings.two_pass_pass2_sampler : miniMaxSettings.sampler_name,
-        pass2_scheduler: twoPass ? miniMaxSettings.two_pass_pass2_scheduler : miniMaxSettings.scheduler,
-        pass2_seed: twoPass ? miniMaxSettings.two_pass_pass2_seed : miniMaxSettings.seed,
+        pass1_steps: twoPass ? (requestedTwoPassSteps?.pass1 ?? miniMaxSettings.two_pass_pass1_steps) : threePass ? (requestedTwoPassSteps?.pass1 ?? miniMaxSettings.advanced_two_pass_pass1_steps) : miniMaxSettings.steps,
+        pass1_denoise: twoPass ? miniMaxSettings.two_pass_pass1_denoise : threePass ? miniMaxSettings.advanced_two_pass_pass1_denoise : miniMaxSettings.denoise,
+        pass1_sampler_name: twoPass ? miniMaxSettings.two_pass_pass1_sampler : threePass ? miniMaxSettings.advanced_two_pass_pass1_sampler : miniMaxSettings.sampler_name,
+        pass1_scheduler: twoPass ? miniMaxSettings.two_pass_pass1_scheduler : threePass ? miniMaxSettings.advanced_two_pass_pass1_scheduler : miniMaxSettings.scheduler,
+        pass1_seed: twoPass ? miniMaxSettings.two_pass_pass1_seed : threePass ? miniMaxSettings.advanced_two_pass_pass1_seed : miniMaxSettings.seed,
+        pass2_steps: twoPass ? (requestedTwoPassSteps?.pass2 ?? miniMaxSettings.two_pass_pass2_steps) : threePass ? (requestedTwoPassSteps?.pass2 ?? miniMaxSettings.advanced_two_pass_pass2_steps) : 4,
+        pass2_denoise: twoPass ? miniMaxSettings.two_pass_pass2_denoise : threePass ? miniMaxSettings.advanced_two_pass_pass2_denoise : 0.2,
+        pass2_sampler_name: twoPass ? miniMaxSettings.two_pass_pass2_sampler : threePass ? miniMaxSettings.advanced_two_pass_pass2_sampler : miniMaxSettings.sampler_name,
+        pass2_scheduler: twoPass ? miniMaxSettings.two_pass_pass2_scheduler : threePass ? miniMaxSettings.advanced_two_pass_pass2_scheduler : miniMaxSettings.scheduler,
+        pass2_seed: twoPass ? miniMaxSettings.two_pass_pass2_seed : threePass ? miniMaxSettings.advanced_two_pass_pass2_seed : miniMaxSettings.seed,
         three_pass_pass1_megapixels: miniMaxSettings.three_pass_pass1_megapixels,
         three_pass_pass1_steps: miniMaxSettings.three_pass_pass1_steps,
         three_pass_pass1_denoise: miniMaxSettings.three_pass_pass1_denoise,
@@ -45809,6 +46005,26 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         three_pass_pass3_scheduler: miniMaxSettings.three_pass_pass3_scheduler,
         three_pass_pass3_seed: miniMaxSettings.three_pass_pass3_seed,
         three_pass_pass3_te_speed: miniMaxSettings.three_pass_pass3_te_speed,
+        advanced_pass1_megapixels: miniMaxSettings.advanced_two_pass_pass1_megapixels,
+        advanced_pass2_megapixels: miniMaxSettings.advanced_two_pass_pass2_megapixels,
+        advanced_vram_preset: miniMaxSettings.advanced_two_pass_vram_preset,
+        advanced_tile_size_mode: miniMaxSettings.advanced_two_pass_tile_size_mode,
+        advanced_tile_width: miniMaxSettings.advanced_two_pass_tile_width,
+        advanced_tile_height: miniMaxSettings.advanced_two_pass_tile_height,
+        advanced_grid_rows: miniMaxSettings.advanced_two_pass_grid_rows,
+        advanced_grid_cols: miniMaxSettings.advanced_two_pass_grid_cols,
+        advanced_chunk_length: miniMaxSettings.advanced_two_pass_chunk_length,
+        advanced_temporal_overlap: miniMaxSettings.advanced_two_pass_temporal_overlap,
+        advanced_anchor_strength: miniMaxSettings.advanced_two_pass_anchor_strength,
+        advanced_spatial_w_overlap: miniMaxSettings.advanced_two_pass_spatial_w_overlap,
+        advanced_spatial_h_overlap: miniMaxSettings.advanced_two_pass_spatial_h_overlap,
+        advanced_fade_width: miniMaxSettings.advanced_two_pass_fade_width,
+        advanced_fade_height: miniMaxSettings.advanced_two_pass_fade_height,
+        advanced_min_tile_size: miniMaxSettings.advanced_two_pass_min_tile_size,
+        advanced_overlap_mode: miniMaxSettings.advanced_two_pass_overlap_mode,
+        advanced_overlap_blend: miniMaxSettings.advanced_two_pass_overlap_blend,
+        advanced_upscaler_device: miniMaxSettings.advanced_two_pass_upscaler_device,
+        advanced_upscaler_precision: miniMaxSettings.advanced_two_pass_upscaler_precision,
         easy_cache_bypass: miniMaxSettings.easy_cache_bypass,
         easy_cache_reuse_threshold: miniMaxSettings.easy_cache_reuse_threshold,
         easy_cache_start_percent: miniMaxSettings.easy_cache_start_percent,
@@ -45820,7 +46036,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         use_loras: miniMaxSettings.use_loras,
         lora_count: miniMaxSettings.lora_count,
         loras: miniMaxSettings.loras,
-        use_turbo_lora: (twoPass || threePass) ? false : miniMaxSettings.use_turbo_lora,
+        use_turbo_lora: miniMaxSettings.use_turbo_lora,
         turbo_lora_name: miniMaxSettings.turbo_lora_name,
         turbo_lora_strength: miniMaxSettings.turbo_lora_strength,
         image_paths: imagePaths,
@@ -45833,7 +46049,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const renderStartedAt = Date.now() / 1000 - 2;
       const built = await postJson(
         threePass
-          ? "/vrgdg/workflow_runner/build_minimax_h3_3pass_prompt"
+          ? "/vrgdg/workflow_runner/build_minimax_h3_advanced_2pass_prompt"
           : twoPass
             ? "/vrgdg/workflow_runner/build_minimax_h3_2pass_prompt"
           : "/vrgdg/workflow_runner/build_minimax_h3_prompt",
@@ -45845,17 +46061,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const builtLoraSettings = built?.lora_settings || {};
       const builtTurboSettings = built?.turbo_settings || {};
       const builtAdvancedSettings = built?.advanced_settings || {};
-      const exactTwoPassSteps = twoPass
+      const exactTwoPassSteps = (twoPass || threePass)
         ? {
           pass1: Number(built?.prompt?.["124"]?.inputs?.steps),
           pass2: Number(built?.prompt?.["190"]?.inputs?.value),
         }
         : null;
-      if (twoPass && (!Number.isInteger(exactTwoPassSteps.pass1) || !Number.isInteger(exactTwoPassSteps.pass2))) {
+      if ((twoPass || threePass) && (!Number.isInteger(exactTwoPassSteps.pass1) || !Number.isInteger(exactTwoPassSteps.pass2))) {
         throw new Error("The built MiniMax H3 two-pass prompt is missing its exact sampler step values.");
       }
-      const exactTwoPassStepsLine = twoPass
-        ? `\nRequested panel steps: Pass 1 = ${requestedTwoPassSteps?.pass1 ?? miniMaxSettings.two_pass_pass1_steps}; Pass 2 = ${requestedTwoPassSteps?.pass2 ?? miniMaxSettings.two_pass_pass2_steps}`
+      const exactTwoPassStepsLine = (twoPass || threePass)
+        ? `\nRequested panel steps: Pass 1 = ${requestedTwoPassSteps?.pass1 ?? (threePass ? miniMaxSettings.advanced_two_pass_pass1_steps : miniMaxSettings.two_pass_pass1_steps)}; Pass 2 = ${requestedTwoPassSteps?.pass2 ?? (threePass ? miniMaxSettings.advanced_two_pass_pass2_steps : miniMaxSettings.two_pass_pass2_steps)}`
           + `\nExact built-prompt sampler steps: Pass 1 = ${exactTwoPassSteps.pass1}; Pass 2 = ${exactTwoPassSteps.pass2}`
         : "";
       const exactModelChainLoras = (modelRef) => {
@@ -45880,7 +46096,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }
         return loras.reverse();
       };
-      const exactTwoPassLoras = twoPass
+      const exactTwoPassLoras = (twoPass || threePass)
         ? {
           pass1: exactModelChainLoras(built?.prompt?.["124"]?.inputs?.model),
           pass2: exactModelChainLoras(built?.prompt?.["192"]?.inputs?.model),
@@ -45889,10 +46105,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const formatExactLoras = (loras) => loras.length
         ? loras.map((item) => `${item.name} @ ${Number.isFinite(item.strength) ? item.strength : "unknown strength"} [node ${item.nodeId}]`).join(" → ")
         : "none";
-      const exactTwoPassLorasLine = twoPass
+      const exactTwoPassLorasLine = (twoPass || threePass)
         ? `\nExact built-prompt LoRAs:\nPass 1: ${formatExactLoras(exactTwoPassLoras.pass1)}\nPass 2: ${formatExactLoras(exactTwoPassLoras.pass2)}`
         : "";
-      const loraLine = twoPass
+      const loraLine = (twoPass || threePass)
         ? exactTwoPassLorasLine
         : builtLoraSettings.enabled
           ? `\nLoRAs: ${Number(builtLoraSettings.count || 0)} — ${(builtLoraSettings.loras || []).map((item) => `${item.name} @ ${item.strength}`).join(", ")}`
@@ -45912,10 +46128,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       }
 
       progress?.set(
-        `${batchLabel}${threePass ? "Queueing MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)..." : twoPass ? "Queueing MiniMax H3 2 Pass (Stage 1 → Stage 2)..." : "Queueing MiniMax H3..."}\n`
+        `${batchLabel}${threePass ? "Queueing MiniMax H3 2 Pass Advanced (Base → MMH3 tiled upscale)..." : twoPass ? "Queueing MiniMax H3 2 Pass (Stage 1 → Stage 2)..." : "Queueing MiniMax H3..."}\n`
         + `Timeline: ${sceneDuration.toFixed(3)}s\n`
         + `H3 render: ${Number(timing.h3_frame_count || 0)} frames`
-        + (threePass ? "\nStage 1 and Stage 2 are saved as backups; Stage 3 will be used for stitching." : twoPass ? "\nPass 1 is learned-latent upscaled and refined by pass 2; the final pass-2 video will be used for stitching." : "")
+        + (threePass ? "\nPass 1 is saved as a backup; the MMH3 tiled/chunked Pass 2 video will be used for stitching." : twoPass ? "\nPass 1 is learned-latent upscaled and refined by pass 2; the final pass-2 video will be used for stitching." : "")
         + exactTwoPassStepsLine
         + loraLine
         + turboLine
@@ -45937,7 +46153,6 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         }, 15000).catch(() => ({}));
         const paths = [
           ["stage1", stages.stage1_path],
-          ["stage2", stages.stage2_path],
         ].filter(([, path]) => Boolean(path));
         if (!paths.length) return;
         liveStageBackupCopying = true;
@@ -45966,7 +46181,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         liveStageBackupCopying = false;
         if (!changed) return;
         segment.minimax_h3_stage1_path = segment.minimax_h3_stage1_backup_path || segment.minimax_h3_stage1_path || "";
-        segment.minimax_h3_stage2_path = segment.minimax_h3_stage2_backup_path || segment.minimax_h3_stage2_path || "";
+        segment.minimax_h3_stage2_path = segment.minimax_h3_stage2_path || "";
         const previewStage = paths.reduce((highest, [stage]) => {
           const value = Number(String(stage || "").replace("stage", ""));
           return Number.isFinite(value) ? Math.max(highest, value) : highest;
@@ -45987,17 +46202,17 @@ Chrome vault corridor = Sealed industrial passage...</pre>
             syncPreview(segment);
           }
         }
-        liveStageBackupsRegistered = Boolean(stages.stage1_path && stages.stage2_path);
+        liveStageBackupsRegistered = Boolean(stages.stage1_path);
         segment.video_cache_bust = Date.now();
         renderList();
         render();
-        await autoSaveSessionQuiet("MiniMax H3 three-pass backup available");
+        await autoSaveSessionQuiet("MiniMax H3 2 Pass Advanced backup available");
       };
       const videos = await waitForVideos(
         promptId,
         (message) => {
           void registerLiveThreePassBackups();
-          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}${exactTwoPassLorasLine}\nPrompt ID: ${promptId}`, pct(62));
+          progress?.set(`${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced (Base → MMH3 tiled upscale)\n" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)\n" : ""}${message}${exactTwoPassStepsLine}${exactTwoPassLorasLine}\nPrompt ID: ${promptId}`, pct(62));
         },
         () => state.batchCancelled,
         null,
@@ -46006,7 +46221,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           timeoutMessage: () => sceneVideoTimeoutMessage({
             promptId,
             sceneLabel: sceneDisplayName(segment, sceneIndex),
-            modeLabel: threePass ? "MiniMax H3 3 Pass (Stage 1 → Stage 2 → Stage 3)" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)" : "MiniMax H3",
+            modeLabel: threePass ? "MiniMax H3 2 Pass Advanced (Base → MMH3 tiled upscale)" : twoPass ? "MiniMax H3 2 Pass (Stage 1 → Stage 2)" : "MiniMax H3",
             outputFolder: built.output_folder || "",
             projectFolder,
             finalFolder: collectedSceneVideoFolder(),
@@ -46022,7 +46237,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         ? videos.find((item) => videoName(item).includes("stage2")) || null
         : null;
       const video = threePass
-        ? videos.find((item) => videoName(item).includes("stage3")) || videos[videos.length - 1] || null
+        ? videos.find((item) => videoName(item).includes("stage2")) || videos[videos.length - 1] || null
         : twoPass
           ? videos.find((item) => videoName(item).includes("stage2")) || videos[videos.length - 1] || null
         : videos[videos.length - 1] || null;
@@ -46107,7 +46322,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         await autoSaveSessionQuiet(options.autoSaveReason || "MiniMax H3 scene video complete");
       }
       progress?.set(
-        `${batchLabel}${threePass ? "MiniMax H3 3 Pass complete — Stage 3 selected; Stage 1 and Stage 2 backups saved." : twoPass ? "MiniMax H3 learned-latent 2 Pass complete — final pass-2 video selected." : "MiniMax H3 scene ready."}\n${segment.video_path}\n`
+        `${batchLabel}${threePass ? "MiniMax H3 2 Pass Advanced complete — MMH3 Pass 2 selected; Pass 1 backup saved." : twoPass ? "MiniMax H3 learned-latent 2 Pass complete — final pass-2 video selected." : "MiniMax H3 scene ready."}\n${segment.video_path}\n`
         + `Exact duration: ${finalDuration.toFixed(3)}s`,
         pct(100),
       );
@@ -46622,6 +46837,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const skipFinalStitch = Boolean(options.skipFinalStitch || sceneScope === "selected");
     let renderLog = null;
     let currentSceneLog = null;
+    const renderWarnings = [];
     let previousRenderEndedMs = 0;
     if (!forceVideos) {
       try {
@@ -46745,6 +46961,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         upsertRenderLog(renderLog);
         const base = Math.floor((index / scenes.length) * 100);
         const span = Math.max(1, Math.floor(80 / scenes.length));
+        try {
         if (randomizeVideoSeed) {
           if (miniMaxProject) setMiniMaxH3SeedRandom(segment);
           else setVideoSeedRandom(segment);
@@ -46816,7 +47033,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           existingVideoAction: forceVideos ? "backup" : "overwrite",
         };
         const renderedVideoPath = miniMaxProject
-          ? await renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, sharedRenderOptions)
+          ? await renderMiniMaxSceneVideoWithProgress(segment, sceneIndex, progress, {
+            ...sharedRenderOptions,
+            onCueValidationWarning: (warning) => renderWarnings.push(`${sceneLabel}: ${warning}`),
+          })
           : await renderSceneVideoWithProgress(segment, sceneIndex, progress, {
             ...sharedRenderOptions,
             audioPathOverride: skipFinalStitch || segmentTrack(segment) === "overlay" ? "" : preparedAudio.audioPath,
@@ -46862,8 +47082,36 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         currentSceneLog.total_ms = Math.max(0, sceneEndedMs - sceneStartedMs);
         await persistRenderLog(renderLog);
         currentSceneLog = null;
+        } catch (sceneError) {
+          const failedAt = Date.now();
+          const message = String(sceneError?.message || sceneError);
+          currentSceneLog.status = state.batchCancelled ? "canceled" : "failed";
+          currentSceneLog.ended_at = new Date(failedAt).toISOString();
+          currentSceneLog.total_ms = Math.max(0, failedAt - sceneStartedMs);
+          currentSceneLog.error = message;
+          renderLog.last_scene_error = message;
+          await persistRenderLog(renderLog);
+          progress.set(`${sceneLabel} failed — continuing with the remaining scenes.\n\n${message}`, Math.min(98, base + span));
+          console.error(`[VRGDG Music Builder] Render All scene failed; continuing: ${sceneLabel}`, sceneError);
+          currentSceneLog = null;
+          if (state.batchCancelled) throw sceneError;
+          continue;
+        }
       }
       assertBatchNotStopped();
+      const failedScenes = renderLog.scenes.filter((item) => item.status === "failed");
+      if (failedScenes.length) {
+        const completedAt = Date.now();
+        renderLog.status = "partial";
+        renderLog.ended_at = new Date(completedAt).toISOString();
+        renderLog.total_ms = Math.max(0, completedAt - logStartedMs);
+        renderLog.error = `${failedScenes.length} scene${failedScenes.length === 1 ? "" : "s"} failed; final stitch deferred so the batch remains resumable.`;
+        await persistRenderLog(renderLog);
+        await autoSaveSessionQuiet("render all partial batch complete");
+        progress.set(`Render All finished with ${failedScenes.length} failed scene${failedScenes.length === 1 ? "" : "s"}.\n\nThe remaining scenes were rendered. Final stitching was deferred; run Render All again after fixing the failed scene${failedScenes.length === 1 ? "" : "s"}.\n\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}`, 100);
+        toast(`Render All finished with ${failedScenes.length} failed scene${failedScenes.length === 1 ? "" : "s"}. Remaining scenes continued rendering.`, true);
+        return;
+      }
       if (skipFinalStitch) {
         const completedAt = Date.now();
         renderLog.status = "complete";
@@ -46886,14 +47134,18 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       renderLog.stitch_ms = Math.max(0, stitchEndedMs - stitchStartedMs);
       renderLog.final_video_path = String(stitched.final_video_path || "");
       renderLog.status = "complete";
+      renderLog.warnings = renderWarnings;
       renderLog.ended_at = new Date(stitchEndedMs).toISOString();
       renderLog.total_ms = Math.max(0, stitchEndedMs - logStartedMs);
       await persistRenderLog(renderLog);
       await autoSaveSessionQuiet("render all final stitch complete");
       const summary = updateRenderLogSummary(renderLog);
-      progress.set(`Render All complete.\n\nFinal video:\n${stitched.final_video_path}\n\nScene clips:\n${stitched.video_folder}\n\nTotal time: ${renderLogDuration(summary.total_ms)}\nActive scene rendering: ${renderLogDuration(summary.render_ms)}\nFinal stitching: ${renderLogDuration(summary.stitch_ms)}\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}`, 100);
+      const reviewNotice = renderWarnings.length
+        ? `\n\nReview after render — ${renderWarnings.length} non-blocking prompt issue${renderWarnings.length === 1 ? "" : "s"}:\n${renderWarnings.join("\n")}`
+        : "";
+      progress.set(`Render All complete.\n\nFinal video:\n${stitched.final_video_path}\n\nScene clips:\n${stitched.video_folder}\n\nTotal time: ${renderLogDuration(summary.total_ms)}\nActive scene rendering: ${renderLogDuration(summary.render_ms)}\nFinal stitching: ${renderLogDuration(summary.stitch_ms)}\nRender Log:\n${renderLog.report_text_path || "saved in the project session"}${reviewNotice}`, 100);
       progress.close(6500);
-      toast(`Render All complete:\n${stitched.final_video_path}`);
+      toast(`Render All complete:\n${stitched.final_video_path}${reviewNotice}`, Boolean(renderWarnings.length));
       if (!options.suppressFinalModal) showFinalVideoReadyModal(stitched.final_video_path);
       return stitched;
     } catch (error) {
@@ -54770,7 +55022,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
                     ? `${start.toFixed(3)}s-${end.toFixed(3)}s`
                     : `cue ${cueIndex + 1}`;
                   return cue.type === "instrumental"
-                    ? `[${range}] INSTRUMENTAL: no singing or lip-sync; mouth stays closed or naturally relaxed.`
+                    ? `[${range}] Use only the assigned visual action and camera direction.`
                     : `[${range}] ${cue.singer_name || "the assigned singer"} sings only: "${flattenLyricForPrompt(cue.text)}".`;
                 }),
                 "Each cue is authoritative. Assign only the words in that interval to that shot."
@@ -56959,7 +57211,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       picker.options = values;
       const current = String(picker.input.value || fallback || "").trim();
       const exactOrSameBase = values.find((item) => item === current || basenameOnly(item) === basenameOnly(current));
-      picker.input.value = exactOrSameBase || current || fallback;
+      // ComfyUI's newer io.Combo nodes validate against their live option list.
+      // Do not preserve a stale saved filename when it is no longer available.
+      picker.input.value = exactOrSameBase || values[0] || fallback;
     };
     setOptions(i2vUnetPicker, data.video_gguf_unets || data.unets, DEFAULT_I2V_UNET);
     const ltx25Selected = (state.i2vVideoSettings?.ltx_version || "2.5") !== "2.3";
@@ -56975,7 +57229,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     setMiniMaxOptions(miniMaxClipPicker, data.clip, DEFAULT_MINIMAX_H3_SETTINGS.clip_name);
     setMiniMaxOptions(miniMaxVideoVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.video_vae_name);
     setMiniMaxOptions(miniMaxAudioVaePicker, data.vae, DEFAULT_MINIMAX_H3_SETTINGS.audio_vae_name);
-    setMiniMaxOptions(miniMaxTwoPassLatentUpscalerPicker, data.upscale_models, DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
+    const miniMaxLatentUpscalerChoices = (data.upscale_models || [])
+      .filter((item) => /minimax_h3_latent_upscaler_3d/i.test(String(item || "")));
+    setMiniMaxOptions(miniMaxTwoPassLatentUpscalerPicker, miniMaxLatentUpscalerChoices, DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
+    setMiniMaxOptions(miniMaxAdvancedLatentUpscalerPicker, miniMaxLatentUpscalerChoices, DEFAULT_MINIMAX_H3_SETTINGS.two_pass_latent_upscaler_name);
     saveMiniMaxH3SettingsFromPanel();
     setOptions(fluxUnetPicker, data.unets, ["flux\\flux-2-klein-4b-fp8.safetensors", "flux-2-klein-4b-fp8.safetensors"]);
     setOptions(fluxClipPicker, data.clip, ["qwen_3_4b.safetensors", "flux\\qwen_3_4b.safetensors"]);
@@ -57103,7 +57360,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     saveMiniMaxH3SettingsFromPanel();
     autoSaveSessionQuiet("MiniMax H3 project settings").catch(() => null);
   };
-  for (const picker of [miniMaxDiffusionModelPicker, miniMaxClipPicker, miniMaxVideoVaePicker, miniMaxAudioVaePicker, miniMaxTwoPassLatentUpscalerPicker]) {
+  for (const picker of [miniMaxDiffusionModelPicker, miniMaxClipPicker, miniMaxVideoVaePicker, miniMaxAudioVaePicker, miniMaxTwoPassLatentUpscalerPicker, miniMaxAdvancedLatentUpscalerPicker]) {
     wireSearchablePicker(picker, saveMiniMaxH3SettingsFromPanel);
     picker.input.addEventListener("change", persistMiniMaxSettings);
   }
@@ -57149,6 +57406,25 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     miniMaxTwoPassFinalHeight,
     miniMaxTwoPassRefImageSize,
     miniMaxThreePassRefImageSize,
+    miniMaxAdvancedVramPreset,
+    miniMaxAdvancedTileSizeMode,
+    miniMaxAdvancedTileWidth,
+    miniMaxAdvancedTileHeight,
+    miniMaxAdvancedGridRows,
+    miniMaxAdvancedGridCols,
+    miniMaxAdvancedChunkLength,
+    miniMaxAdvancedTemporalOverlap,
+    miniMaxAdvancedAnchorStrength,
+    miniMaxAdvancedSpatialWOverlap,
+    miniMaxAdvancedSpatialHOverlap,
+    miniMaxAdvancedFadeWidth,
+    miniMaxAdvancedFadeHeight,
+    miniMaxAdvancedMinTileSize,
+    miniMaxAdvancedOverlapMode,
+    miniMaxAdvancedOverlapBlend,
+    miniMaxAdvancedUpscalerDevice,
+    miniMaxAdvancedUpscalerPrecision,
+    miniMaxAdvancedUseTeSpeed.input,
     miniMaxTwoPassLatentScale,
     miniMaxTwoPassUseTeSpeed.input,
     miniMaxTwoPassTeProcessingControl,
@@ -57166,18 +57442,66 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       pass.scheduler,
       pass.seed,
     ]),
-    ...threePassControls.flatMap((pass) => [
+    ...advancedTwoPassControls.flatMap((pass) => [
       pass.megapixels,
       pass.steps,
       pass.denoise,
       pass.sampler,
       pass.scheduler,
       pass.seed,
-      pass.teSpeed.input,
     ]),
   ]) {
     control.addEventListener("input", saveMiniMaxH3SettingsFromPanel);
     control.addEventListener("change", persistMiniMaxSettings);
+  }
+  miniMaxAdvancedVramPreset.addEventListener("change", () => {
+    const preset = {
+      "8gb": { tile: 352, chunk: 51 },
+      "12gb": { tile: 448, chunk: 68 },
+      "16gb": { tile: 544, chunk: 119 },
+      "24gb": { tile: 672, chunk: 153 },
+    }[miniMaxAdvancedVramPreset.value];
+    if (!preset) return;
+    miniMaxAdvancedTileSizeMode.value = "specific_size";
+    miniMaxAdvancedTileWidth.value = String(preset.tile);
+    miniMaxAdvancedTileHeight.value = String(preset.tile);
+    miniMaxAdvancedChunkLength.value = String(preset.chunk);
+    miniMaxAdvancedTemporalOverlap.value = "17";
+    miniMaxAdvancedSpatialWOverlap.value = "128";
+    miniMaxAdvancedSpatialHOverlap.value = "128";
+    miniMaxAdvancedFadeWidth.value = "32";
+    miniMaxAdvancedFadeHeight.value = "32";
+    miniMaxAdvancedMinTileSize.value = "256";
+    miniMaxAdvancedAnchorStrength.value = "0.999";
+    persistMiniMaxSettings();
+  });
+  for (const control of [
+    miniMaxAdvancedTileSizeMode,
+    miniMaxAdvancedTileWidth,
+    miniMaxAdvancedTileHeight,
+    miniMaxAdvancedGridRows,
+    miniMaxAdvancedGridCols,
+    miniMaxAdvancedChunkLength,
+    miniMaxAdvancedTemporalOverlap,
+    miniMaxAdvancedAnchorStrength,
+    miniMaxAdvancedSpatialWOverlap,
+    miniMaxAdvancedSpatialHOverlap,
+    miniMaxAdvancedFadeWidth,
+    miniMaxAdvancedFadeHeight,
+    miniMaxAdvancedMinTileSize,
+    miniMaxAdvancedOverlapMode,
+    miniMaxAdvancedOverlapBlend,
+    miniMaxAdvancedUpscalerDevice,
+    miniMaxAdvancedUpscalerPrecision,
+  ]) {
+    const markCustom = () => {
+      if (miniMaxAdvancedVramPreset.value === "custom") return;
+      miniMaxAdvancedVramPreset.value = "custom";
+      saveMiniMaxH3SettingsFromPanel();
+      autoSaveSessionQuiet("MiniMax H3 custom MMH3 settings").catch(() => null);
+    };
+    control.addEventListener("input", markCustom);
+    control.addEventListener("change", markCustom);
   }
   miniMaxUseLoras.input.addEventListener("change", () => {
     const segment = activeSegment();
@@ -57251,7 +57575,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     state.miniMaxH3ThreePassEnabled = true;
     setMiniMaxH3ModeForSegment(segment, "reference_to_video");
     syncMiniMaxH3Panel();
-    await autoSaveSessionQuiet("MiniMax H3 three-pass project mode");
+    await autoSaveSessionQuiet("MiniMax H3 2 Pass Advanced project mode");
   };
   miniMaxAudioMode.addEventListener("change", syncMiniMaxH3Panel);
   miniMaxContinuityMode.addEventListener("change", () => {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -2343,8 +2343,14 @@ async function postJson(url, payload, timeoutMs = 120000) {
 // also in flight; without this queue an older snapshot can finish last and
 // restore stale lyrics/cast assignments.
 let builderSessionSaveQueue = Promise.resolve();
+let builderSessionSaveRevision = 0;
 
 function saveBuilderSessionJson(payload, timeoutMs = 60000) {
+  const revision = ++builderSessionSaveRevision;
+  payload.session = {
+    ...(payload.session || {}),
+    builder_save_revision: revision,
+  };
   const save = () => postJson("/vrgdg/music_builder/save_session", payload, timeoutMs);
   const result = builderSessionSaveQueue.then(save, save);
   builderSessionSaveQueue = result.catch(() => null);
@@ -36926,6 +36932,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         project_folder: folder,
       });
       const session = data.session || {};
+      builderSessionSaveRevision = Math.max(
+        builderSessionSaveRevision,
+        Number(session.builder_save_revision || 0) || 0,
+      );
       faceFixTool.reset?.();
       pushHistory();
       state.segments = Array.isArray(session.segments) ? session.segments : [];
@@ -43023,6 +43033,12 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const segments = allEditableSegments()
         .slice()
         .sort((a, b) => Number(a.start || 0) - Number(b.start || 0));
+      // Storyboard prompt/beat application is allowed to update visual fields,
+      // but it must never import lyric text from its older storyboard payload.
+      // Keep the live line-review text as the source of truth for this operation.
+      const lyricTextBySegmentId = new Map(
+        segments.map((segment) => [String(segment.id || ""), String(segment.lyric_text || "")]),
+      );
       let applied = 0;
       let storyChanged = false;
       let facialChanged = false;
@@ -43152,6 +43168,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (["i2v", "id_lora", "t2v", "rtv", "ingredients"].includes(videoType)) segment.video_prompt_type = videoType;
         if (String(scene.shot_type || "").trim()) segment.shot_type = String(scene.shot_type || "").trim();
         if (String(scene.camera_motion || "").trim()) segment.camera_motion = String(scene.camera_motion || "").trim();
+      }
+      for (const segment of segments) {
+        const savedLyricText = lyricTextBySegmentId.get(String(segment.id || ""));
+        if (savedLyricText !== undefined) segment.lyric_text = savedLyricText;
       }
       if (updates.story_layer || updates.storyLayer) {
         state.builderStoryLayer = normalizeBuilderStoryLayer(updates.story_layer || updates.storyLayer);

--- a/web/VRGDG_VideoCompare.js
+++ b/web/VRGDG_VideoCompare.js
@@ -54,6 +54,8 @@ function createCompareUI(node) {
   const root = document.createElement("div");
   root.style.cssText = [
     "width:100%",
+    `min-width:${MIN_WIDTH}px`,
+    "max-width:none",
     "height:430px",
     "display:flex",
     "flex-direction:column",
@@ -161,7 +163,7 @@ function createCompareUI(node) {
   stage.append(beforeVideo, afterClip, divider, handle, beforeLabel, afterLabel, empty);
 
   const controls = document.createElement("div");
-  controls.style.cssText = "display:grid;grid-template-columns:auto auto auto minmax(80px,1fr) auto auto;gap:7px;align-items:center;";
+  controls.style.cssText = "display:grid;grid-template-columns:auto auto auto minmax(80px,1fr) auto auto auto;gap:7px;align-items:center;";
   const playButton = createButton("▶", "Play or pause both videos");
   const restartButton = createButton("↺", "Restart both videos");
   const scrubber = document.createElement("input");
@@ -176,11 +178,12 @@ function createCompareUI(node) {
   timeLabel.style.cssText = "font:700 11px Arial,sans-serif;color:#67e8f9;white-space:nowrap;font-variant-numeric:tabular-nums;";
   const muteButton = createButton("🔇", "Mute or unmute before-video audio");
   const recordButton = createButton("● Record", "Record the labeled slider preview for the configured duration");
+  const fullscreenButton = createButton("⛶ Fullscreen", "Open the compare slider in a fullscreen viewer without recording");
   recordButton.style.background = "#7f1d1d";
   const recordStatus = document.createElement("div");
   recordStatus.textContent = "";
   recordStatus.style.cssText = "font:700 10px Arial,sans-serif;color:#fca5a5;white-space:nowrap;";
-  controls.append(playButton, restartButton, recordButton, scrubber, timeLabel, muteButton);
+  controls.append(playButton, restartButton, recordButton, scrubber, timeLabel, muteButton, fullscreenButton);
 
   const wipeRow = document.createElement("div");
   wipeRow.style.cssText = "display:grid;grid-template-columns:auto minmax(80px,1fr) auto;gap:8px;align-items:center;";
@@ -196,7 +199,18 @@ function createCompareUI(node) {
   const wipeValue = document.createElement("div");
   wipeValue.style.cssText = "min-width:34px;text-align:right;font:700 11px Arial,sans-serif;color:#d4d4d8;";
   wipeRow.append(wipeTitle, wipeSlider, wipeValue);
-  root.append(stage, controls, wipeRow, recordStatus);
+
+  const fileRow = document.createElement("div");
+  fileRow.style.cssText = "display:flex;flex-wrap:wrap;gap:7px;align-items:center;";
+  const chooseBeforeButton = createButton("Choose Before Video", "Upload a video directly from your computer as the original video");
+  const chooseAfterButton = createButton("Choose After Video", "Upload a video directly from your computer as the processed video");
+  const beforeFileInput = document.createElement("input");
+  const afterFileInput = document.createElement("input");
+  for (const input of [beforeFileInput, afterFileInput]) { input.type = "file"; input.accept = ".mp4,.mov,.webm,.mkv,.avi,.m4v,video/*"; input.style.display = "none"; }
+  const fileStatus = document.createElement("div");
+  fileStatus.style.cssText = "font:700 10px Arial,sans-serif;color:#a1a1aa;white-space:nowrap;";
+  fileRow.append(chooseBeforeButton, chooseAfterButton, beforeFileInput, afterFileInput, fileStatus);
+  root.append(stage, controls, wipeRow, fileRow, recordStatus);
 
   let dragging = false;
   let animationFrame = 0;
@@ -205,6 +219,13 @@ function createCompareUI(node) {
   let recordingTimer = 0;
   let recordingFrame = 0;
   let recordingChunks = [];
+  const selectedPaths = { before: "", after: "" };
+  let fullscreenOverlay = null;
+  let fullscreenStageStyle = "";
+  let fullscreenZoom = 1;
+  let fullscreenZoomOrigin = { x: 50, y: 50 };
+  let fullscreenZoomLabel = null;
+  let fullscreenResetButton = null;
 
   function showLabels() {
     const visible = !!widgetValue(node, "show_labels", true);
@@ -440,6 +461,93 @@ function createCompareUI(node) {
     muteButton.textContent = beforeVideo.muted ? "🔇" : "🔊";
   }
 
+  function closeFullscreen(exitBrowserFullscreen = true) {
+    if (!fullscreenOverlay) return;
+    if (exitBrowserFullscreen && document.fullscreenElement === fullscreenOverlay) {
+      document.exitFullscreen?.().catch?.(() => {});
+    }
+    if (fullscreenOverlay.parentNode) fullscreenOverlay.parentNode.removeChild(fullscreenOverlay);
+    root.insertBefore(stage, root.firstChild);
+    stage.style.cssText = fullscreenStageStyle;
+    setFullscreenZoom(1, 50, 50);
+    fullscreenZoomLabel = null;
+    fullscreenResetButton = null;
+    fullscreenOverlay = null;
+    fullscreenButton.textContent = "⛶ Fullscreen";
+    app.graph?.setDirtyCanvas?.(true, true);
+  }
+
+  function setFullscreenZoom(value, originX = fullscreenZoomOrigin.x, originY = fullscreenZoomOrigin.y) {
+    fullscreenZoom = Math.max(1, Math.min(6, Number(value) || 1));
+    fullscreenZoomOrigin = {
+      x: Math.max(0, Math.min(100, Number(originX) || 50)),
+      y: Math.max(0, Math.min(100, Number(originY) || 50)),
+    };
+    const transform = `scale(${fullscreenZoom})`;
+    beforeVideo.style.transform = transform;
+    afterVideo.style.transform = transform;
+    beforeVideo.style.transformOrigin = `${fullscreenZoomOrigin.x}% ${fullscreenZoomOrigin.y}%`;
+    afterVideo.style.transformOrigin = `${fullscreenZoomOrigin.x}% ${fullscreenZoomOrigin.y}%`;
+    if (fullscreenZoomLabel) fullscreenZoomLabel.textContent = `${Math.round(fullscreenZoom * 100)}%`;
+    if (fullscreenResetButton) {
+      fullscreenResetButton.disabled = fullscreenZoom === 1;
+      fullscreenResetButton.style.opacity = fullscreenZoom === 1 ? "0.55" : "1";
+    }
+  }
+
+  function openFullscreen() {
+    if (fullscreenOverlay) return;
+    fullscreenStageStyle = stage.style.cssText;
+    fullscreenOverlay = document.createElement("div");
+    fullscreenOverlay.style.cssText = "position:fixed;inset:0;z-index:100000;display:flex;flex-direction:column;gap:10px;padding:14px;background:#09090b;color:#f4f4f5;font-family:Arial,sans-serif;";
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:34px;";
+    const title = document.createElement("div");
+    title.textContent = "VRGDG Video Compare Slider";
+    title.style.cssText = "font:900 15px Arial,sans-serif;color:#cffafe;";
+    fullscreenZoomLabel = document.createElement("div");
+    fullscreenZoomLabel.textContent = "100%";
+    fullscreenZoomLabel.title = "Fullscreen zoom level. Scroll over the video to zoom.";
+    fullscreenZoomLabel.style.cssText = "font:800 12px Arial,sans-serif;color:#a5f3fc;min-width:42px;text-align:center;";
+    fullscreenResetButton = createButton("Reset Zoom", "Reset fullscreen zoom to 100%");
+    fullscreenResetButton.disabled = true;
+    fullscreenResetButton.style.opacity = "0.55";
+    fullscreenResetButton.addEventListener("click", () => setFullscreenZoom(1));
+    const closeButton = createButton("✕ Exit Fullscreen", "Return to the ComfyUI node");
+    closeButton.addEventListener("click", () => closeFullscreen(true));
+    const headerActions = document.createElement("div");
+    headerActions.style.cssText = "display:flex;align-items:center;gap:8px;";
+    headerActions.append(fullscreenZoomLabel, fullscreenResetButton, closeButton);
+    header.append(title, headerActions);
+    fullscreenOverlay.append(header, stage);
+    stage.style.cssText = "position:relative;flex:1 1 auto;min-height:0;width:100%;overflow:hidden;border:1px solid #3f3f46;border-radius:8px;background:#050505;touch-action:none;cursor:ew-resize;";
+    setFullscreenZoom(1, 50, 50);
+    document.body.append(fullscreenOverlay);
+    fullscreenButton.textContent = "✕ Exit Fullscreen";
+    fullscreenOverlay.addEventListener("fullscreenchange", () => {
+      if (fullscreenOverlay && document.fullscreenElement !== fullscreenOverlay) closeFullscreen(false);
+    });
+    fullscreenOverlay.requestFullscreen?.().catch?.(() => {});
+  }
+
+  async function uploadSelectedVideo(file, slot) {
+    if (!file) return;
+    fileStatus.textContent = `Uploading ${file.name}…`;
+    const form = new FormData();
+    form.append("video", file, file.name);
+    try {
+      const response = await api.fetchApi("/vrgdg/video_compare/upload", { method: "POST", body: form });
+      const data = await response.json();
+      if (!response.ok || !data.ok || !data.path) throw new Error(data.error || `Upload failed (${response.status})`);
+      selectedPaths[slot] = data.path;
+      setWidgetValue(node, slot === "before" ? "before_selected" : "after_selected", data.path);
+      fileStatus.textContent = `${slot === "before" ? "Before" : "After"}: ${data.name || file.name}`;
+    } catch (error) {
+      fileStatus.textContent = String(error?.message || error);
+      fileStatus.style.color = "#fca5a5";
+    }
+  }
+
   stage.addEventListener("pointerdown", (event) => {
     dragging = true;
     stage.setPointerCapture?.(event.pointerId);
@@ -455,6 +563,17 @@ function createCompareUI(node) {
   stage.addEventListener("pointercancel", () => {
     dragging = false;
   });
+  stage.addEventListener("wheel", (event) => {
+    if (!fullscreenOverlay) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const direction = event.deltaY < 0 ? 1 : -1;
+    const factor = direction > 0 ? 1.12 : 1 / 1.12;
+    const rect = stage.getBoundingClientRect();
+    const originX = rect.width ? ((event.clientX - rect.left) / rect.width) * 100 : 50;
+    const originY = rect.height ? ((event.clientY - rect.top) / rect.height) * 100 : 50;
+    setFullscreenZoom(fullscreenZoom * factor, originX, originY);
+  }, { passive: false });
   wipeSlider.addEventListener("input", () => setWipe(wipeSlider.value, true));
   scrubber.addEventListener("input", () => seekBoth(scrubber.value));
   playButton.addEventListener("click", () => {
@@ -473,6 +592,11 @@ function createCompareUI(node) {
     muteButton.textContent = muted ? "🔇" : "🔊";
   });
   recordButton.addEventListener("click", startRecording);
+  chooseBeforeButton.addEventListener("click", () => beforeFileInput.click());
+  chooseAfterButton.addEventListener("click", () => afterFileInput.click());
+  beforeFileInput.addEventListener("change", () => uploadSelectedVideo(beforeFileInput.files?.[0], "before"));
+  afterFileInput.addEventListener("change", () => uploadSelectedVideo(afterFileInput.files?.[0], "after"));
+  fullscreenButton.addEventListener("click", () => { if (fullscreenOverlay) closeFullscreen(true); else openFullscreen(); });
   beforeVideo.addEventListener("loadedmetadata", calculateDuration);
   afterVideo.addEventListener("loadedmetadata", calculateDuration);
   for (const video of [beforeVideo, afterVideo]) {
@@ -530,6 +654,7 @@ function createCompareUI(node) {
       node.setDirtyCanvas?.(true, true);
     },
     destroy() {
+      closeFullscreen(true);
       if (recorder) stopRecording();
       pauseBoth();
       clearVideo(beforeVideo);
@@ -568,9 +693,22 @@ app.registerExtension({
       });
       if (domWidget) {
         domWidget.serialize = false;
-        domWidget.computeSize = (width) => [width, 430];
+        domWidget.element.style.width = "100%";
+        domWidget.element.style.minWidth = `${MIN_WIDTH}px`;
+        domWidget.element.style.maxWidth = "none";
+        ui.root.style.width = `${Math.max(MIN_WIDTH, this.size[0])}px`;
+        // LiteGraph may pass the DOM widget a default width that is narrower
+        // than the node itself.  Returning that width makes the embedded UI
+        // render in a small column and leaves the rest of the node blank.
+        // Keep the widget's measured width aligned with the node minimum.
+        domWidget.computeSize = () => [MIN_WIDTH, 430];
       }
       for (const widget of this.widgets || []) {
+        if (widget.name === "before_selected" || widget.name === "after_selected") {
+          widget.hidden = true;
+          widget.serialize = true;
+          widget.computeSize = () => [0, -4];
+        }
         if (widget.name === "video_compare" || widget._vrgdgVideoCompareBound) continue;
         const callback = widget.callback;
         widget.callback = function () {
@@ -589,6 +727,9 @@ app.registerExtension({
         Math.max(MIN_WIDTH, this.size?.[0] || MIN_WIDTH),
         Math.max(MIN_HEIGHT, this.size?.[1] || MIN_HEIGHT),
       ];
+      if (this._vrgdgVideoCompareUI?.root) {
+        this._vrgdgVideoCompareUI.root.style.width = `${Math.max(MIN_WIDTH, this.size[0])}px`;
+      }
       this._vrgdgVideoCompareUI?.applyWidgets();
       return result;
     };
@@ -608,6 +749,11 @@ app.registerExtension({
         Math.max(MIN_WIDTH, size?.[0] || MIN_WIDTH),
         Math.max(MIN_HEIGHT, size?.[1] || MIN_HEIGHT),
       ];
+      const root = this._vrgdgVideoCompareUI?.root;
+      if (root) {
+        root.style.width = `${Math.max(MIN_WIDTH, this.size[0])}px`;
+        root.style.minWidth = `${MIN_WIDTH}px`;
+      }
       return result;
     };
 


### PR DESCRIPTION
## Summary
- keep storyboard scene beats free of singing, lyrics, lip-sync, and audio metadata
- serialize builder session saves so stale autosaves cannot overwrite newer Quick Saves
- autosave manual performer/singer assignment changes
- stop restoring old lyric lines over legitimate multi-line edits
- add regression coverage for scene-beat filtering and save ordering

## Validation
- python -B -m py_compile VRGDG_MusicVideoBuilderNodes.py
- python -m unittest tests/test_builder_save_order.py tests/test_storyboard_scene_beat_audio_language.py

Node's default CommonJS syntax check is not applicable to ComfyUI's ES-module UI file.