### PR TITLE
Align Advanced H3 Upscale with Sample Workflow

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3391,22 +3391,22 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
     if pass2_megapixels < pass1_megapixels:
         raise ValueError("2 Pass Advanced Pass 2 resolution must be at least Pass 1 resolution.")
 
-    tile_size_mode = str(payload.get("advanced_tile_size_mode") or "specific_size").strip().lower()
+    tile_size_mode = str(payload.get("advanced_tile_size_mode") or "rows_cols").strip().lower()
     if tile_size_mode not in {"specific_size", "rows_cols"}:
         tile_size_mode = "specific_size"
-    tile_width = _int_payload(payload, "advanced_tile_width", 448, 32, 16384)
-    tile_height = _int_payload(payload, "advanced_tile_height", 448, 32, 16384)
-    grid_rows = _int_payload(payload, "advanced_grid_rows", 3, 1, 9)
-    grid_cols = _int_payload(payload, "advanced_grid_cols", 5, 1, 9)
-    chunk_length = _int_payload(payload, "advanced_chunk_length", 68, 17, 100000)
+    tile_width = _int_payload(payload, "advanced_tile_width", 512, 32, 16384)
+    tile_height = _int_payload(payload, "advanced_tile_height", 512, 32, 16384)
+    grid_rows = _int_payload(payload, "advanced_grid_rows", 2, 1, 9)
+    grid_cols = _int_payload(payload, "advanced_grid_cols", 2, 1, 9)
+    chunk_length = _int_payload(payload, "advanced_chunk_length", 85, 17, 100000)
     temporal_overlap = _int_payload(payload, "advanced_temporal_overlap", 17, 0, 100000)
     anchor_strength = _float_payload(payload, "advanced_anchor_strength", 0.999, 0.0, 1.0)
     spatial_w_overlap = _int_payload(payload, "advanced_spatial_w_overlap", 128, 0, 16384)
     spatial_h_overlap = _int_payload(payload, "advanced_spatial_h_overlap", 128, 0, 16384)
-    fade_width = _int_payload(payload, "advanced_fade_width", 32, 0, 16384)
-    fade_height = _int_payload(payload, "advanced_fade_height", 32, 0, 16384)
+    fade_width = _int_payload(payload, "advanced_fade_width", 64, 0, 16384)
+    fade_height = _int_payload(payload, "advanced_fade_height", 64, 0, 16384)
     min_tile_size = _int_payload(payload, "advanced_min_tile_size", 256, 0, 16384)
-    overlap_mode = str(payload.get("advanced_overlap_mode") or "earlier").strip().lower()
+    overlap_mode = str(payload.get("advanced_overlap_mode") or "later").strip().lower()
     overlap_blend = str(payload.get("advanced_overlap_blend") or "linear").strip().lower()
     if overlap_mode not in {"earlier", "later"}:
         overlap_mode = "earlier"

--- a/tests/test_builder_minimax_advanced_two_pass.py
+++ b/tests/test_builder_minimax_advanced_two_pass.py
@@ -22,8 +22,8 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
     def test_vram_presets_match_mmh3_starting_points(self):
         for text in (
             '"8gb": { tile: 352, chunk: 51 }',
-            '"12gb": { tile: 448, chunk: 68 }',
-            '"16gb": { tile: 544, chunk: 119 }',
+            '"12gb": { tile: 512, chunk: 85 }',
+            '"16gb": { tile: 576, chunk: 119 }',
             '"24gb": { tile: 672, chunk: 153 }',
         ):
             self.assertIn(text, BUILDER_SOURCE)
@@ -102,6 +102,14 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
         self.assertEqual(prompt["9306"]["inputs"]["model"], prompt["192"]["inputs"]["model"])
         self.assertEqual(prompt["142"]["inputs"]["images"], ["122", 0])
         self.assertEqual(prompt["9308"]["inputs"]["images"], ["9307", 0])
+        self.assertEqual(prompt["9304"]["inputs"]["chunk_length"], 85)
+        self.assertEqual(prompt["9305"]["inputs"]["tile_size_mode"], "rows_cols")
+        self.assertEqual(prompt["9305"]["inputs"]["grid_rows"], 2)
+        self.assertEqual(prompt["9305"]["inputs"]["grid_cols"], 2)
+        self.assertEqual(prompt["9305"]["inputs"]["fade_width"], 64)
+        self.assertEqual(prompt["9305"]["inputs"]["overlap_mode"], "later")
+        self.assertEqual(result["advanced_two_pass"]["pass2_width"], 1920)
+        self.assertEqual(result["advanced_two_pass"]["pass2_height"], 1088)
 
         result = namespace["_build_minimax_h3_advanced_2pass_api_prompt"]({
             "advanced_pass1_megapixels": 0.4,

--- a/update_notes.json
+++ b/update_notes.json
@@ -22,7 +22,7 @@
         {
           "title": "Improved",
           "items": [
-            "Advanced resolution controls now offer 1K, 2K, and 4K long-edge presets while retaining custom megapixel control for experienced users.",
+            "Advanced resolution controls now offer H3-aligned 1K, 2K, 1440p, and 4K presets while retaining custom megapixel control for experienced users.",
             "Advanced MiniMax progress now reports the exact Pass 1 and Pass 2 dimensions sent to the workflow and the saved API snapshot path.",
             "H3 latent upscaler model selection now resolves registered model directories reliably instead of depending on one custom-node folder."
           ]

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -307,21 +307,21 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   three_pass_pass3_seed: 69,
   three_pass_pass3_te_speed: false,
   advanced_two_pass_vram_preset: "12gb",
-  advanced_two_pass_defaults_version: 1,
-  advanced_two_pass_tile_size_mode: "specific_size",
-  advanced_two_pass_tile_width: 448,
-  advanced_two_pass_tile_height: 448,
+  advanced_two_pass_defaults_version: 2,
+  advanced_two_pass_tile_size_mode: "rows_cols",
+  advanced_two_pass_tile_width: 512,
+  advanced_two_pass_tile_height: 512,
   advanced_two_pass_grid_rows: 3,
   advanced_two_pass_grid_cols: 5,
-  advanced_two_pass_chunk_length: 68,
+  advanced_two_pass_chunk_length: 85,
   advanced_two_pass_temporal_overlap: 17,
   advanced_two_pass_anchor_strength: 0.999,
   advanced_two_pass_spatial_w_overlap: 128,
   advanced_two_pass_spatial_h_overlap: 128,
-  advanced_two_pass_fade_width: 32,
-  advanced_two_pass_fade_height: 32,
+  advanced_two_pass_fade_width: 64,
+  advanced_two_pass_fade_height: 64,
   advanced_two_pass_min_tile_size: 256,
-  advanced_two_pass_overlap_mode: "earlier",
+  advanced_two_pass_overlap_mode: "later",
   advanced_two_pass_overlap_blend: "linear",
   advanced_two_pass_upscaler_device: "cuda",
   advanced_two_pass_upscaler_precision: "bf16",
@@ -333,7 +333,7 @@ const DEFAULT_MINIMAX_H3_SETTINGS = {
   advanced_two_pass_pass1_scheduler: "beta",
   advanced_two_pass_pass1_seed: 69,
   advanced_two_pass_pass2_megapixels: 2,
-  advanced_two_pass_pass2_resolution_preset: "custom",
+  advanced_two_pass_pass2_resolution_preset: "2k",
   advanced_two_pass_pass2_steps: 1,
   advanced_two_pass_pass2_denoise: 0.2,
   advanced_two_pass_pass2_sampler: "sa_solver",
@@ -460,7 +460,7 @@ function normalizeMiniMaxH3VideoPurpose(value) {
 function cloneMiniMaxH3Settings(value = {}) {
   const source = value && typeof value === "object" ? value : {};
   const hasCurrentTwoPassDefaults = Number(source.two_pass_defaults_version || 0) >= 1;
-  const hasCurrentAdvancedTwoPassDefaults = Number(source.advanced_two_pass_defaults_version || 0) >= 1;
+  const hasCurrentAdvancedTwoPassDefaults = Number(source.advanced_two_pass_defaults_version || 0) >= 2;
   const sourceLoras = Array.isArray(source.loras)
     ? source.loras
     : Array.from({ length: 4 }, (_, index) => ({
@@ -572,10 +572,10 @@ function cloneMiniMaxH3Settings(value = {}) {
     advanced_two_pass_upscaler_precision: ["fp32", "fp16", "bf16"].includes(String(source.advanced_two_pass_upscaler_precision || "").toLowerCase())
       ? String(source.advanced_two_pass_upscaler_precision).toLowerCase()
       : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_upscaler_precision,
-    advanced_two_pass_pass1_resolution_preset: ["custom", "1k", "2k", "4k"].includes(String(source.advanced_two_pass_pass1_resolution_preset || "").toLowerCase())
+    advanced_two_pass_pass1_resolution_preset: ["custom", "1k", "2k", "1440p", "4k"].includes(String(source.advanced_two_pass_pass1_resolution_preset || "").toLowerCase())
       ? String(source.advanced_two_pass_pass1_resolution_preset).toLowerCase()
       : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_pass1_resolution_preset,
-    advanced_two_pass_pass2_resolution_preset: ["custom", "1k", "2k", "4k"].includes(String(source.advanced_two_pass_pass2_resolution_preset || "").toLowerCase())
+    advanced_two_pass_pass2_resolution_preset: ["custom", "1k", "2k", "1440p", "4k"].includes(String(source.advanced_two_pass_pass2_resolution_preset || "").toLowerCase())
       ? String(source.advanced_two_pass_pass2_resolution_preset).toLowerCase()
       : DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_pass2_resolution_preset,
     advanced_two_pass_defaults_version: DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_defaults_version,
@@ -6068,15 +6068,16 @@ function openBuilder(node) {
   ];
   const advancedResolutionPresets = [
     { value: "custom", label: "Custom megapixels" },
-    { value: "1k", label: "1K (long edge)" },
-    { value: "2k", label: "2K (long edge)" },
-    { value: "4k", label: "4K (long edge)" },
+    { value: "1k", label: "H3 1K (1024×576)" },
+    { value: "2k", label: "H3 2K (1920×1088)" },
+    { value: "1440p", label: "1440p (2560×1440)" },
+    { value: "4k", label: "H3 4K (3840×2176)" },
   ];
   const advancedPresetMegapixels = (preset, aspectRatio) => {
     const match = String(aspectRatio || "16:9").match(/(\d+)\s*:\s*(\d+)/);
     const ratioWidth = Number(match?.[1] || 16);
     const ratioHeight = Number(match?.[2] || 9);
-    const longEdge = { "1k": 1024, "2k": 2048, "4k": 4096 }[String(preset || "").toLowerCase()];
+    const longEdge = { "1k": 1024, "2k": 1920, "1440p": 2560, "4k": 3840 }[String(preset || "").toLowerCase()];
     if (!longEdge) return null;
     const scale = longEdge / Math.max(ratioWidth, ratioHeight);
     const width = Math.round(ratioWidth * scale / 32) * 32;
@@ -6234,8 +6235,8 @@ function openBuilder(node) {
   miniMaxTwoPassSettings.style.display = "none";
   const miniMaxAdvancedVramPreset = makeSelect([
     { value: "8gb", label: "8 GB — 352px tiles / 51 frames" },
-    { value: "12gb", label: "12 GB — 448px tiles / 68 frames" },
-    { value: "16gb", label: "16 GB — 544px tiles / 119 frames" },
+    { value: "12gb", label: "12 GB — 512px tiles / 85 frames" },
+    { value: "16gb", label: "16 GB — 576px tiles / 119 frames" },
     { value: "24gb", label: "24 GB — 672px tiles / 153 frames" },
     { value: "custom", label: "Custom — keep advanced values" },
   ], DEFAULT_MINIMAX_H3_SETTINGS.advanced_two_pass_vram_preset);
@@ -57508,8 +57509,8 @@ Chrome vault corridor = Sealed industrial passage...</pre>
   miniMaxAdvancedVramPreset.addEventListener("change", () => {
     const preset = {
       "8gb": { tile: 352, chunk: 51 },
-      "12gb": { tile: 448, chunk: 68 },
-      "16gb": { tile: 544, chunk: 119 },
+      "12gb": { tile: 512, chunk: 85 },
+      "16gb": { tile: 576, chunk: 119 },
       "24gb": { tile: 672, chunk: 153 },
     }[miniMaxAdvancedVramPreset.value];
     if (!preset) return;


### PR DESCRIPTION
## Summary
- Align the hidden Advanced 2-Pass H3 workflow with the upstream sample workflow.
- Use H3-aligned 1K, 2K, 1440p, and 4K resolution presets.
- Apply sample-aligned tiled-upscale defaults, including rows/columns tiling, 512px tiles, 64px fades, and later-overlap blending.
- Keep the existing builder UI and advanced controls while updating the workflow defaults.

## Validation
- Advanced two-pass builder tests pass.
- Python compilation and JavaScript syntax checks pass.