### PR TITLE
Fix MiniMax 2 Pass Advanced sending prompt to Pass 2

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3437,6 +3437,7 @@ def _build_minimax_h3_advanced_2pass_api_prompt(payload):
     pass2_conditioning = copy.deepcopy(prompt["136"])
     pass2_conditioning["inputs"]["width"] = ["9301", 0]
     pass2_conditioning["inputs"]["height"] = ["9301", 1]
+    pass2_conditioning["inputs"]["prompt"] = ""
     pass2_conditioning["_meta"] = {"title": "2 Pass Advanced - Final Resolution Conditioning"}
     prompt["9302"] = pass2_conditioning
 

--- a/tests/test_builder_minimax_advanced_two_pass.py
+++ b/tests/test_builder_minimax_advanced_two_pass.py
@@ -98,7 +98,10 @@ class BuilderMiniMaxAdvancedTwoPassTests(unittest.TestCase):
         result = namespace["_build_minimax_h3_advanced_2pass_api_prompt"]({})
         prompt = result["prompt"]
         self.assertEqual(prompt["136"]["inputs"]["width"], ["9300", 0])
+        self.assertEqual(prompt["136"]["inputs"]["prompt"], ["138", 0])
         self.assertEqual(prompt["9302"]["inputs"]["width"], ["9301", 0])
+        self.assertEqual(prompt["9302"]["inputs"]["prompt"], "")
+        self.assertEqual(prompt["9306"]["inputs"]["conditioning"], ["9302", 0])
         self.assertEqual(prompt["9306"]["inputs"]["model"], prompt["192"]["inputs"]["model"])
         self.assertEqual(prompt["142"]["inputs"]["images"], ["122", 0])
         self.assertEqual(prompt["9308"]["inputs"]["images"], ["9307", 0])


### PR DESCRIPTION
## Summary
- Video Builder **Ref to Video 2 Pass Advanced** was copying Pass 1 \MiniMaxH3ReferenceToVideo\ for Pass 2, including the scene prompt.
- Pass 2 (\MMH3UltimateUpscale\) now gets that same conditioning at Pass 2 resolution, but with an empty prompt. Pass 1 still uses the scene prompt.
- Regular **Ref to Video 2 Pass** is unchanged.

## Test plan
- [x] Render **Ref to Video 2 Pass Advanced** and confirm Pass 1 still uses the scene prompt.
- [x] Confirm Pass 2 has no prompt input in the built hidden workflow (\9302.inputs.prompt\ is empty; ^\ still links to 8\).
- [x] \python -m unittest tests.test_builder_minimax_advanced_two_pass -v