### PR TITLE
Use native MiniMax H3 Image-to-Video frames

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -665,6 +665,41 @@ def _minimax_h3_video_references(payload):
     return references
 
 
+def _patch_minimax_h3_image_to_video_node(prompt, image_paths):
+    """Replace the H3 reference node with the native first/last-frame node.
+
+    The standard MiniMax builder graph intentionally keeps the same downstream
+    sampler/audio/output chain for both nodes: both emit positive conditioning
+    and the combined H3 video/audio latent.  The media loader's first two image
+    outputs therefore map directly to the native node's optional frame inputs.
+    """
+    node = prompt.get("136")
+    if not isinstance(node, dict):
+        raise KeyError("MiniMax H3 image-to-video node 136 was not found.")
+
+    paths = list(image_paths or [])
+    if not paths:
+        raise ValueError("MiniMax H3 image-to-video requires a first-frame image.")
+    if len(paths) > 2:
+        raise ValueError("MiniMax H3 image-to-video accepts at most a first and last frame.")
+
+    inputs = {
+        "prompt": ["138", 0],
+        "width": ["115", 0],
+        "height": ["115", 1],
+        "length": ["131", 1],
+        "clip": ["128", 0],
+        "vae": ["119", 0],
+        "first_frame": ["180", 0],
+    }
+    if len(paths) > 1:
+        inputs["last_frame"] = ["180", 1]
+
+    node["class_type"] = "MiniMaxH3ImageToVideo"
+    node["_meta"] = {"title": "MiniMax H3 Image to Video"}
+    node["inputs"] = inputs
+
+
 def _probe_media_duration_seconds(path):
     ffprobe_path = _ffprobe_path_for(_find_ffmpeg_path())
     cmd = [
@@ -3007,6 +3042,19 @@ def _build_minimax_h3_api_prompt(payload):
 
     image_paths = _minimax_h3_image_paths(payload)
     video_references = _minimax_h3_video_references(payload)
+    video_mode = str(payload.get("video_mode") or payload.get("mode") or "text_to_video").strip().lower().replace("-", "_").replace(" ", "_")
+    if video_mode == "image_to_video":
+        if not image_paths:
+            raise ValueError("MiniMax H3 image-to-video requires a scene image as the first frame.")
+        last_frame_path = str(payload.get("last_frame_path") or "").strip().strip('"')
+        if last_frame_path:
+            last_frame_path = os.path.abspath(last_frame_path)
+            if not os.path.isfile(last_frame_path):
+                raise FileNotFoundError(f"MiniMax H3 last-frame image was not found: {last_frame_path}")
+            if os.path.abspath(image_paths[0]) != last_frame_path:
+                image_paths = [image_paths[0], last_frame_path]
+        _patch_minimax_h3_image_to_video_node(prompt, image_paths)
+        video_references = []
     aspect_ratio = str(payload.get("aspect_ratio") or "16:9 (Widescreen)").strip()
     if aspect_ratio not in _MINIMAX_H3_ASPECT_RATIOS:
         raise ValueError(f"Unsupported MiniMax H3 aspect ratio: {aspect_ratio}")

--- a/Workflows/LTX-2_Workflows/Video_Builder/readme.md
+++ b/Workflows/LTX-2_Workflows/Video_Builder/readme.md
@@ -2759,7 +2759,7 @@ Mode-specific notes:
 | Builder feature | Extra dependency notes |
 | --- | --- |
 | `Image to Video` / `Text to Video` | Requires the LTXVideo, VideoHelperSuite, GGUF, and KJNodes packs above |
-| `MiniMax H3` | Requires a current ComfyUI build with `MiniMaxH3ReferenceToVideo`, KJNodes for the standard diffusion loader, VideoHelperSuite for reference video/audio loading and combining, and this repo's H3 timing/audio/reference nodes. Built-in audio also uses the installed LTX audio VAE decode node. GGUF is not supported on this path. |
+| `MiniMax H3` | Requires a current ComfyUI build with `MiniMaxH3ReferenceToVideo` and `MiniMaxH3ImageToVideo`, KJNodes for the standard diffusion loader, VideoHelperSuite for reference video/audio loading and combining, and this repo's H3 timing/audio/reference nodes. Built-in audio also uses the installed LTX audio VAE decode node. GGUF is not supported on this path. |
 | `MiniMax-H3 Turbo` | Optional. Requires `ComfyUI-MiniMax-H3-Turbo`, the selected Turbo LoRA under `models/loras`, and a ComfyUI restart after installation/update. Standard MiniMax does not require this extension while Turbo is disabled. |
 | `First Last Frame` | Requires the same LTX stack plus the bundled `LTX2.3_FLF_API.json` hidden workflow and both start/end images |
 | `ID-LoRA I2V` | Requires LTXVideo plus the required ID-LoRA/model shown in the Video tab |

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -45974,7 +45974,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       throw new Error(`${sceneDisplayName(segment, sceneIndex)} has invalid timeline boundaries.`);
     }
 
-    const continuityInput = options.continuityInput === undefined
+    const continuityInput = mode === "image_to_video"
+      ? null
+      : options.continuityInput === undefined
       ? await prepareMiniMaxH3ContinuityReference(
         segment,
         progress,
@@ -46125,6 +46127,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         project_folder: projectFolder,
         scene_number: slotNumber,
         audio_mode: miniMaxSettings.audio_mode,
+        video_mode: mode,
         audio_path: builtInAudio ? "" : sourceAudioPath,
         prompt,
         timeline_start_seconds: timelineStart,
@@ -46231,6 +46234,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         image_paths: imagePaths,
         video_references: videoReferences,
       };
+      if (mode === "image_to_video") {
+        const lastFrame = firstLastFrameEndImageSource(segment) || {};
+        if (lastFrame.path) payload.last_frame_path = lastFrame.path;
+      }
       if (!builtInAudio && Number.isFinite(sourceDurationSeconds) && sourceDurationSeconds > 0) {
         payload.source_duration_seconds = sourceDurationSeconds;
       }


### PR DESCRIPTION
## Summary
- swap MiniMax H3 Image-to-Video mode to the native MiniMaxH3ImageToVideo node
- map the selected scene image to irst_frame
- map an explicit stored scene end frame to last_frame
- prevent previous-scene continuity from being injected as a fake last frame
- document the native node dependency

## Validation
- Python syntax check passed
- JavaScript module syntax check passed
- git diff check passed

Unrelated pre-existing worktree changes were left out of this PR.