### PR TITLE
Fix LTX 2.5 and MiniMax render settings

### DIFF
--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -3053,7 +3053,7 @@ def _build_minimax_h3_api_prompt(payload):
     image_paths = _minimax_h3_image_paths(payload)
     video_references = _minimax_h3_video_references(payload)
     video_mode = str(payload.get("video_mode") or payload.get("mode") or "text_to_video").strip().lower().replace("-", "_").replace(" ", "_")
-    if video_mode == "image_to_video":
+    if video_mode in {"image_to_video", "image_reference_to_video"}:
         if not image_paths:
             raise ValueError("MiniMax H3 image-to-video requires a scene image as the first frame.")
         last_frame_path = str(payload.get("last_frame_path") or "").strip().strip('"')

--- a/VRGDG_WorkflowRunnerNodes.py
+++ b/VRGDG_WorkflowRunnerNodes.py
@@ -1854,8 +1854,10 @@ def _patch_t2v_api_prompt(prompt, payload):
     _set_api_input(prompt, "271:254", "vae_name", str(payload.get("audio_vae_name", "") or ""))
 
     _set_api_input(prompt, "736:424", "value", fps)
-    _set_api_input(prompt, "736:425", "value", width)
-    _set_api_input(prompt, "736:426", "value", height)
+    generation_width = int(math.ceil(width / 64.0) * 64) if is_ltx25 else width
+    generation_height = int(math.ceil(height / 64.0) * 64) if is_ltx25 else height
+    _set_api_input(prompt, "736:425", "value", generation_width)
+    _set_api_input(prompt, "736:426", "value", generation_height)
     _set_api_input(prompt, "736:449", "value", seed)
     _set_api_input(prompt, "736:551", "value", 0)
 
@@ -1881,6 +1883,14 @@ def _patch_t2v_api_prompt(prompt, payload):
     _set_api_input(prompt, "218:287", "overwrite_mode", "overwrite")
     _set_api_input(prompt, "218:287", "tail_loss_frames", tail_loss_frames)
     _set_api_input(prompt, "218:287", "pre_frames", pre_frames)
+    if is_ltx25:
+        final_resize_id = "vrgdg_ltx25_t2v_final_center_crop"
+        _replace_api_input_refs(prompt, ("936", 0), (final_resize_id, 0))
+        prompt[final_resize_id] = {
+            "class_type": "ImageScale",
+            "inputs": {"image": ["936", 0], "upscale_method": "lanczos", "width": width, "height": height, "crop": "center"},
+            "_meta": {"title": "Center crop LTX 2.5 T2V to requested output resolution"},
+        }
     _patch_ltx_two_pass_sampler_overrides(prompt, payload)
     _set_api_input(prompt, "437", "value", output_folder)
     return prompt, output_folder

--- a/tests/test_builder_ltx25_t2v_resolution.py
+++ b/tests/test_builder_ltx25_t2v_resolution.py
@@ -1,0 +1,36 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+RUNNER_SOURCE = (ROOT / "VRGDG_WorkflowRunnerNodes.py").read_text(encoding="utf-8")
+
+
+class Ltx25T2VResolutionTests(unittest.TestCase):
+    def test_ltx25_panel_exposes_explicit_dimensions(self):
+        self.assertIn('i2vSettingsGrid.style.display = "grid";', BUILDER_SOURCE)
+        self.assertIn('ltx25ResolutionGrid.style.display = "none";', BUILDER_SOURCE)
+        self.assertIn('makeField("FPS", i2vFpsInput)', BUILDER_SOURCE)
+        self.assertIn('makeField("Seed", i2vSeedInput)', BUILDER_SOURCE)
+        self.assertIn('makeField("Width", i2vWidthInput)', BUILDER_SOURCE)
+        self.assertIn('makeField("Height", i2vHeightInput)', BUILDER_SOURCE)
+
+    def test_ltx25_generates_aligned_and_outputs_exact_requested_size(self):
+        tree = ast.parse(RUNNER_SOURCE)
+        function = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_patch_t2v_api_prompt"
+        )
+        source = ast.get_source_segment(RUNNER_SOURCE, function)
+        self.assertIn("math.ceil(width / 64.0) * 64", source)
+        self.assertIn("math.ceil(height / 64.0) * 64", source)
+        self.assertIn('"width": width', source)
+        self.assertIn('"height": height', source)
+        self.assertIn('"crop": "center"', source)
+        self.assertIn('("936", 0), (final_resize_id, 0)', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builder_minimax_reference_conditioning_visibility.py
+++ b/tests/test_builder_minimax_reference_conditioning_visibility.py
@@ -1,0 +1,32 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER_SOURCE = (ROOT / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+
+
+class MiniMaxReferenceConditioningVisibilityTests(unittest.TestCase):
+    def test_generic_reference_sizing_is_only_visible_for_single_pass_reference_modes(self):
+        self.assertIn(
+            'miniMaxReferenceConditioningSettings.style.display = !hideMultiPassIgnoredSettings',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            '&& ["reference_to_video", "video_to_video"].includes(mode)',
+            BUILDER_SOURCE,
+        )
+
+    def test_two_pass_modes_keep_their_dedicated_reference_sizing_controls(self):
+        self.assertIn(
+            'makeField("Reference image sizing", miniMaxTwoPassRefImageSize',
+            BUILDER_SOURCE,
+        )
+        self.assertIn(
+            'makeField("Reference image sizing", miniMaxThreePassRefImageSize',
+            BUILDER_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -17312,7 +17312,7 @@ function openBuilder(node) {
   function miniMaxOrderedImageReferenceItemsForSegment(segment, mode = miniMaxH3ModeForSegment(segment)) {
     const normalizedMode = normalizeMiniMaxH3Mode(mode);
     const ordered = [];
-    if (normalizedMode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+    if (["reference_to_video", "image_reference_to_video"].includes(normalizedMode) && segment?.minimax_h3_use_scene_image_as_start_frame) {
       const startFrame = segmentImageSource(segment);
       if (startFrame?.path || startFrame?.data) {
         const characterInfluence = miniMaxH3StartFrameCharacterInfluenceForSegment(segment);
@@ -17417,7 +17417,7 @@ function openBuilder(node) {
     });
     const labels = desired.map((item) => item.label);
     let count = desired.length;
-    if (normalizedMode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+    if (["reference_to_video", "image_reference_to_video"].includes(normalizedMode) && segment?.minimax_h3_use_scene_image_as_start_frame) {
       const startFrame = segmentImageSource(segment);
       if (startFrame?.path || startFrame?.data) {
         const fingerprint = imageFingerprint(startFrame);
@@ -41869,7 +41869,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           + "In the finished prompt, convert permitted environmental observations into direct scene description without mentioning Attached Picture 1, inspiration, source imagery, or analysis. Renderer Image 1 is attached as Picture 2, Renderer Image 2 as Picture 3, and so on; use only the renderer Image N labels in the finished prompt.",
         );
       }
-      if (mode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame) {
+      if (["reference_to_video", "image_reference_to_video"].includes(mode) && segment?.minimax_h3_use_scene_image_as_start_frame) {
         const characterInfluence = miniMaxH3StartFrameCharacterInfluenceForSegment(segment);
         if (characterInfluence === "face_hair_only") {
           parts.push(
@@ -42194,7 +42194,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     }
     const rendererPromptImages = miniMaxH3PromptVisionImages(segment, mode);
     const visionImages = miniMaxH3PromptVisionImagesForRunner(segment, mode);
-    const rendererReferenceImages = mode === "reference_to_video"
+    const rendererReferenceImages = ["reference_to_video", "image_reference_to_video"].includes(mode)
       ? miniMaxOrderedImageReferenceItemsForSegment(segment, mode)
       : [];
     const sceneImageUse = miniMaxH3SceneImageUseForSegment(segment);
@@ -42203,7 +42203,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       toast("Image to Video needs a selected scene image before the LLM can create its MiniMax prompt.", true);
       return;
     }
-    if (mode === "reference_to_video" && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
+    if (["reference_to_video", "image_reference_to_video"].includes(mode) && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
       toast("The selected scene-image mode needs a timeline image for this scene before the LLM can create its MiniMax prompt.", true);
       return;
     }
@@ -44026,7 +44026,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
           : []).map((item) => ({ ...item }));
         const rendererPromptImages = miniMaxH3PromptVisionImages(workingSegment, mode);
         const visionImages = miniMaxH3PromptVisionImagesForRunner(workingSegment, mode);
-        const rendererReferenceImages = mode === "reference_to_video"
+        const rendererReferenceImages = ["reference_to_video", "image_reference_to_video"].includes(mode)
           ? miniMaxOrderedImageReferenceItemsForSegment(workingSegment, mode)
           : [];
         const sceneImageUse = miniMaxH3SceneImageUseForSegment(workingSegment);
@@ -44034,7 +44034,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         if (mode === "image_to_video" && !rendererPromptImages.length) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: MiniMax Image to Video needs a selected scene image.`);
         }
-        if (mode === "reference_to_video" && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
+        if (["reference_to_video", "image_reference_to_video"].includes(mode) && sceneImageUse !== "off" && !sceneImageSourceAvailable) {
           throw new Error(`${sceneDisplayName(segment, segmentIndexInfo(segment).index)}: the selected scene-image mode needs a timeline image for LLM prompting.`);
         }
         if (mode === "reference_to_video" && !rendererReferenceImages.length) {
@@ -44482,7 +44482,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     if (mode === "image_to_video" && !String(selectedSegmentImagePath(segment) || "").trim()) {
       missing.push(`${name}: MiniMax Image to Video needs a selected scene image.`);
     }
-    if (mode === "reference_to_video" && segment?.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
+    if (["reference_to_video", "image_reference_to_video"].includes(mode) && segment?.minimax_h3_use_scene_image_as_start_frame && !String(selectedSegmentImagePath(segment) || "").trim()) {
       missing.push(`${name}: MiniMax Reference to Video is set to use the scene image as its start frame, but no scene image is saved.`);
     }
     const continuityMode = miniMaxH3ContinuityModeForSegment(segment);

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -6508,10 +6508,10 @@ function openBuilder(node) {
   miniMaxReferenceModeNote.textContent = "Uses ordered character, location, ingredients-sheet, or storyboard-grid images. Add and map the library from the existing Reference Builder button at the top of the Builder.";
   miniMaxReferenceModeNote.style.cssText = miniMaxTextModeNote.style.cssText;
   const miniMaxSceneImageUse = makeSelect(MINIMAX_H3_SCENE_IMAGE_USE_OPTIONS, "off");
-  const miniMaxSceneImageUseField = makeField("Scene image use — all unlocked Reference-to-Video scenes", miniMaxSceneImageUse);
+  const miniMaxSceneImageUseField = makeField("Scene image use — all unlocked Image/Reference-to-Video scenes", miniMaxSceneImageUse);
   miniMaxSceneImageUseField.title = "Choose whether each scene image is unused, becomes the exact MiniMax start frame, or is shown only to the prompt-writing vision LLM as inspiration.";
   const miniMaxStartFrameCharacterInfluence = makeSelect(MINIMAX_H3_START_FRAME_CHARACTER_INFLUENCE_OPTIONS, "full_character");
-  const miniMaxStartFrameCharacterInfluenceField = makeField("Character reference influence — all Reference-to-Video scenes", miniMaxStartFrameCharacterInfluence);
+  const miniMaxStartFrameCharacterInfluenceField = makeField("Character reference influence — all Image/Reference-to-Video scenes", miniMaxStartFrameCharacterInfluence);
   miniMaxStartFrameCharacterInfluenceField.title = "Applies this character-reference priority across every eligible base scene that uses the scene image as its exact start frame.";
   const miniMaxStartFrameReferenceNote = document.createElement("div");
   miniMaxStartFrameReferenceNote.textContent = "Choose whether the scene image is unused, becomes MiniMax's exact start frame, or is shown only to the prompt-writing vision LLM as environment inspiration.";
@@ -8580,13 +8580,13 @@ function openBuilder(node) {
       : "Scene lock is OFF — this scene follows the project-global MiniMax mode, models, and video settings.";
     miniMaxSceneImageUseField.firstElementChild.textContent = sceneMiniMaxSettingsLocked
       ? "Scene image use — this locked scene"
-      : "Scene image use — all unlocked Reference-to-Video scenes";
+      : "Scene image use — all unlocked Image/Reference-to-Video scenes";
     miniMaxSceneImageUseField.title = sceneMiniMaxSettingsLocked
       ? "Changes only this locked scene. Prompt-only inspiration is sent to the vision LLM but not to MiniMax."
       : "Applies across every eligible unlocked base scene. Locked scenes remain unchanged; prompt-only inspiration is never sent to MiniMax.";
     miniMaxStartFrameCharacterInfluenceField.firstElementChild.textContent = sceneMiniMaxSettingsLocked
       ? "Character reference influence — this locked scene"
-      : "Character reference influence — all unlocked Reference-to-Video scenes";
+      : "Character reference influence — all unlocked Image/Reference-to-Video scenes";
     miniMaxStartFrameCharacterInfluenceField.title = sceneMiniMaxSettingsLocked
       ? "Changes only this locked scene's character-reference priority."
       : "Applies this priority across eligible unlocked base scenes; locked scenes remain unchanged.";
@@ -8611,6 +8611,10 @@ function openBuilder(node) {
     miniMaxSamplerSettings.style.display = hideMultiPassIgnoredSettings ? "none" : "";
     miniMaxEasyCacheSettings.style.display = hideMultiPassIgnoredSettings ? "none" : "";
     miniMaxModelLoaderSettings.style.display = hideMultiPassIgnoredSettings ? "none" : "";
+    miniMaxReferenceConditioningSettings.style.display = !hideMultiPassIgnoredSettings
+      && ["reference_to_video", "video_to_video"].includes(mode)
+      ? ""
+      : "none";
     // Multi-pass workflows have their own optional normal-LoRA controls.
     // Turbo is a separate single-pass acceleration path and must not be offered here.
     miniMaxLoraSection.style.display = "";
@@ -18917,8 +18921,8 @@ function openBuilder(node) {
     ltx25MegapixelsInput.value = Number(settings.resolution_megapixels || 1.2);
     const isLtx25 = settings.ltx_version !== "2.3";
     const isLtx25T2V = isLtx25 && currentVideoMode() === "t2v";
-    i2vSettingsGrid.style.display = isLtx25T2V ? "none" : "grid";
-    ltx25ResolutionGrid.style.display = isLtx25T2V ? "grid" : "none";
+    i2vSettingsGrid.style.display = "grid";
+    ltx25ResolutionGrid.style.display = "none";
     i2vUseGgufModel.wrapper.style.display = isLtx25 ? "none" : "flex";
     i2vClip2Picker.wrapper.parentElement.style.display = isLtx25 ? "none" : "flex";
     i2vSeedInput.value = settings.seed || 69;
@@ -58010,7 +58014,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const sceneLocked = Boolean(segment.use_scene_minimax_h3_settings);
     const candidates = (sceneLocked ? [segment] : allEditableSegments()).filter((item) => (
       segmentTrack(item) !== "overlay"
-      && miniMaxH3ModeForSegment(item) === "reference_to_video"
+      && ["reference_to_video", "image_to_video"].includes(miniMaxH3ModeForSegment(item))
       && (sceneLocked || !item.use_scene_minimax_h3_settings)
     ));
     const blocked = exactStartFrame
@@ -58069,7 +58073,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const sceneLocked = Boolean(segment.use_scene_minimax_h3_settings);
     const targets = (sceneLocked ? [segment] : allEditableSegments()).filter((item) => (
       segmentTrack(item) !== "overlay"
-      && miniMaxH3ModeForSegment(item) === "reference_to_video"
+      && ["reference_to_video", "image_to_video"].includes(miniMaxH3ModeForSegment(item))
       && (sceneLocked || !item.use_scene_minimax_h3_settings)
     ));
     if (!targets.length) {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -8643,8 +8643,17 @@ function openBuilder(node) {
     miniMaxStartFrameReferenceNote.style.display = hasSceneImage ? "block" : "none";
     miniMaxPrompt.value = String(segment?.minimax_h3_prompt || segment?.i2v_prompt || "");
     updateMiniMaxPromptCharacterStatus(segment);
-    miniMaxCreatePromptButton.textContent = `Create MiniMax ${modeLabel} Prompt`;
-    miniMaxEditInstructionsButton.textContent = `Edit ${modeLabel} Instructions`;
+    const compactMiniMaxModeLabel = mode === "reference_to_video"
+      ? "Ref2V"
+      : mode === "image_to_video"
+        ? "I2V"
+        : mode === "video_to_video"
+          ? "V2V"
+          : "T2V";
+    miniMaxCreatePromptButton.textContent = `Create ${compactMiniMaxModeLabel} Prompt`;
+    miniMaxCreatePromptButton.title = `Generate the MiniMax H3 ${modeLabel} prompt with the selected LLM. The prompt is saved to this scene; it does not render video.`;
+    miniMaxEditInstructionsButton.textContent = `Edit ${compactMiniMaxModeLabel} Instructions`;
+    miniMaxEditInstructionsButton.title = `Edit the LLM instructions used to create MiniMax H3 ${modeLabel} prompts.`;
     const assignmentTabButton = miniMaxSubTabs.wrapper.querySelector('[data-value="speakers"]');
     if (assignmentTabButton) applyCompactButtonLabel(assignmentTabButton, isMiniMaxSingerAssignmentMode(segment) ? "Singer Assignment" : "Speaker Assignment", { minWidth: 0, padding: "7px 6px" });
     miniMaxPromptRunnerNote.textContent = `Uses the existing ${gemmaRunnerLabel()} selection from LLM Runner. The result is saved only as this scene's MiniMax H3 prompt.`;

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -46195,7 +46195,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const normalizePathList = (value) => (Array.isArray(value) ? value : [])
       .map((item) => String(item?.path || item?.file || item || "").trim())
       .filter(Boolean);
-    const usesReferenceBuilderImages = ["reference_to_video", "video_to_video"].includes(mode);
+    const usesReferenceBuilderImages = ["reference_to_video", "image_reference_to_video", "video_to_video"].includes(mode);
     const referenceBuilderImagePaths = usesReferenceBuilderImages && options.imagePaths === undefined
       ? miniMaxReferenceBuilderImagePathsForSegment(segment)
       : [];
@@ -46213,9 +46213,9 @@ Chrome vault corridor = Sealed industrial passage...</pre>
         return true;
       })
       .slice(0, 9) : [];
-    if (mode === "image_to_video") {
+    if (["image_to_video", "image_reference_to_video"].includes(mode)) {
       const selectedImage = String(selectedSegmentImagePath(segment) || "").trim();
-      if (selectedImage) imagePaths = [selectedImage];
+      if (selectedImage) imagePaths = [selectedImage, ...imagePaths.filter((path) => mediaPathKey(path) !== mediaPathKey(selectedImage))].slice(0, 9);
     }
     let continuityImageNumber = 0;
     if (continuityInput?.framePath) {
@@ -46240,7 +46240,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       ?? segment?.minimax_video_references
       ?? [];
     const videoReferences = mode === "video_to_video" && Array.isArray(rawVideoReferences) ? rawVideoReferences : [];
-    if (mode === "image_to_video" && !imagePaths.length) {
+    if (["image_to_video", "image_reference_to_video"].includes(mode) && !imagePaths.length) {
       throw new Error(`${sceneDisplayName(segment, sceneIndex)} needs a selected scene image for MiniMax Image to Video.`);
     }
     if (mode === "reference_to_video" && !imagePaths.length) {

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -8625,14 +8625,16 @@ function openBuilder(node) {
     miniMaxUseTurboLora.input.checked = hideMultiPassIgnoredSettings ? false : settings.use_turbo_lora;
     miniMaxUseTurboLora.input.disabled = hideMultiPassIgnoredSettings || settings.use_loras;
     for (const button of miniMaxModeButtons) {
-      const active = !twoPass && !threePass && button.dataset.minimaxH3Mode === mode;
+      const active = button.dataset.minimaxH3Mode === mode
+        && ((!twoPass && !threePass) || mode === "image_reference_to_video");
       button.style.background = active ? "#06b6d4" : "#27272a";
       button.style.borderColor = active ? "#0891b2" : "#3f3f46";
       button.style.color = active ? "#082f49" : "#f4f4f5";
     }
-    miniMaxTwoPassButton.style.background = twoPass ? "#06b6d4" : "#27272a";
-    miniMaxTwoPassButton.style.borderColor = twoPass ? "#0891b2" : "#3f3f46";
-    miniMaxTwoPassButton.style.color = twoPass ? "#082f49" : "#f4f4f5";
+    const referenceTwoPassActive = twoPass && mode === "reference_to_video";
+    miniMaxTwoPassButton.style.background = referenceTwoPassActive ? "#06b6d4" : "#27272a";
+    miniMaxTwoPassButton.style.borderColor = referenceTwoPassActive ? "#0891b2" : "#3f3f46";
+    miniMaxTwoPassButton.style.color = referenceTwoPassActive ? "#082f49" : "#f4f4f5";
     miniMaxThreePassButton.style.background = threePass ? "#06b6d4" : "#27272a";
     miniMaxThreePassButton.style.borderColor = threePass ? "#0891b2" : "#3f3f46";
     miniMaxThreePassButton.style.color = threePass ? "#082f49" : "#f4f4f5";

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -153,6 +153,7 @@ const BUILDER_FONT_STACK = "Segoe UI, Inter, Roboto, Arial, sans-serif";
 const MINIMAX_H3_MODE_OPTIONS = [
   { value: "text_to_video", label: "Text to Video", buttonLabel: "T2V" },
   { value: "image_to_video", label: "Image to Video", buttonLabel: "I2V" },
+  { value: "image_reference_to_video", label: "Image + Reference 2 Pass", buttonLabel: "Image + Ref\n2 Pass" },
   { value: "reference_to_video", label: "Reference to Video", buttonLabel: "Ref to\nVideo" },
   { value: "video_to_video", label: "Video to Video", buttonLabel: "V2V" },
 ];
@@ -8592,8 +8593,10 @@ function openBuilder(node) {
       : "Applies this priority across eligible unlocked base scenes; locked scenes remain unchanged.";
     const mode = settings.video_mode;
     const modeLabel = miniMaxH3ModeLabel(mode);
-    const twoPass = Boolean(state.miniMaxH3TwoPassEnabled) && mode === "reference_to_video";
-    const threePass = Boolean(state.miniMaxH3ThreePassEnabled) && mode === "reference_to_video";
+    const twoPass = Boolean(state.miniMaxH3TwoPassEnabled)
+      && ["reference_to_video", "image_reference_to_video"].includes(mode);
+    const threePass = Boolean(state.miniMaxH3ThreePassEnabled)
+      && ["reference_to_video", "image_reference_to_video"].includes(mode);
     const hideMultiPassIgnoredSettings = twoPass || threePass;
     miniMaxLoraSlots.forEach((slot) => {
       slot.applyToField.style.display = (twoPass || threePass) ? "flex" : "none";
@@ -46134,8 +46137,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const miniMaxSettings = miniMaxH3SettingsForSegment(segment);
     const builtInAudio = miniMaxSettings.audio_mode === "built_in_audio";
     const mode = normalizeMiniMaxH3Mode(options.mode ?? miniMaxSettings.video_mode);
-    const twoPass = Boolean(state.miniMaxH3TwoPassEnabled) && mode === "reference_to_video";
-    const threePass = Boolean(state.miniMaxH3ThreePassEnabled) && mode === "reference_to_video";
+    const twoPass = Boolean(state.miniMaxH3TwoPassEnabled)
+      && ["reference_to_video", "image_reference_to_video"].includes(mode);
+    const threePass = Boolean(state.miniMaxH3ThreePassEnabled)
+      && ["reference_to_video", "image_reference_to_video"].includes(mode);
     if ((twoPass || threePass) && builtInAudio) {
       throw new Error(`MiniMax H3 ${threePass ? "2 Pass Advanced" : "2 Pass"} currently supports Input Audio only. Switch Audio Mode to Input Audio before rendering.`);
     }
@@ -57925,7 +57930,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       const segment = requireActiveSegment();
       if (!segment) return;
       pushHistory();
-      state.miniMaxH3TwoPassEnabled = false;
+      state.miniMaxH3TwoPassEnabled = button.dataset.minimaxH3Mode === "image_reference_to_video";
       state.miniMaxH3ThreePassEnabled = false;
       setMiniMaxH3ModeForSegment(segment, button.dataset.minimaxH3Mode);
       syncMiniMaxH3Panel();


### PR DESCRIPTION
## Summary
- show explicit FPS, seed, width, and height controls for LTX 2.5 T2V
- align LTX 2.5 generation dimensions and center-crop to the requested output size
- hide generic reference-conditioning controls when they do not apply to MiniMax modes
- allow scene-image settings to target image-to-video as well as reference-to-video scenes

## Validation
- focused Python unit tests pass
- Python compile check passes
- JavaScript syntax check passes