### PR TITLE
Add H3 overlap audio and fast VAE nodes

### DIFF
--- a/VRGDG_MiniMaxH3FastVAEDecode.py
+++ b/VRGDG_MiniMaxH3FastVAEDecode.py
@@ -1,0 +1,112 @@
+import copy
+import time
+from functools import partial
+
+import torch
+
+import comfy.model_management as mm
+from comfy.ldm.minimax.vae import MiniMaxH3VideoVAE
+
+
+def tiled_decode_batched(model, z, tile_batch_size):
+    height, width = z.shape[-2] * model.vae_ratio, z.shape[-1] * model.vae_ratio
+    y_idx, y_len, y_overlap = model.split_tiles(height)
+    x_idx, x_len, x_overlap = model.split_tiles(width)
+    tiles = [(i, j, yp // model.vae_ratio, yl // model.vae_ratio,
+              xp // model.vae_ratio, xl // model.vae_ratio)
+             for i, (yp, yl) in enumerate(zip(y_idx, y_len))
+             for j, (xp, xl) in enumerate(zip(x_idx, x_len))]
+    canvas = None
+    row_tails = []
+    new_tails = []
+    left_tail = None
+    out_y = 0
+    out_x = 0
+    start = 0
+    while start < len(tiles):
+        mm.throw_exception_if_processing_interrupted()
+        end = start + 1
+        shape = (tiles[start][3], tiles[start][5])
+        while end < min(start + tile_batch_size, len(tiles)):
+            if (tiles[end][3], tiles[end][5]) != shape:
+                break
+            end += 1
+        batch = torch.cat([z[..., yp:yp + yl, xp:xp + xl]
+                           for _, _, yp, yl, xp, xl in tiles[start:end]], dim=0)
+        decoded = model._decode_pixels(batch)
+        for k, (i, j, _, _, _, _) in enumerate(tiles[start:end]):
+            tile = decoded[k * z.shape[0]:(k + 1) * z.shape[0]]
+            if i < len(y_idx) - 1:
+                new_tails.append(tile[..., -y_overlap[i]:, :].clone())
+            next_left_tail = tile[..., :, -x_overlap[j]:].clone() if j < len(x_idx) - 1 else None
+            if i > 0:
+                tile = model.blend(row_tails[j], tile, y_overlap[i - 1], dim=-2)
+            if j > 0:
+                tile = model.blend(left_tail, tile, x_overlap[j - 1], dim=-1)
+            left_tail = next_left_tail
+            if i < len(y_idx) - 1:
+                tile = tile[..., :-y_overlap[i], :]
+            if j < len(x_idx) - 1:
+                tile = tile[..., :, :-x_overlap[j]]
+            if canvas is None:
+                canvas = torch.empty(*tile.shape[:-2], height, width, dtype=tile.dtype, device=tile.device)
+            canvas[..., out_y:out_y + tile.shape[-2], out_x:out_x + tile.shape[-1]].copy_(tile)
+            out_x += tile.shape[-1]
+            if j == len(x_idx) - 1:
+                row_tails = new_tails
+                new_tails = []
+                out_y += tile.shape[-2]
+                out_x = 0
+        del tile, decoded, batch
+        start = end
+    return canvas
+
+
+class H3FastVAEDecode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "samples": ("LATENT",),
+            "vae": ("VAE",),
+            "tile_batch_size": ("INT", {"default": 4, "min": 1, "max": 16,
+                "tooltip": "Spatial tiles decoded together. Uses more VRAM. 1 runs stock decoding."}),
+        }}
+
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("images", "report")
+    FUNCTION = "decode"
+    CATEGORY = "MiniMax H3/VAE"
+    DESCRIPTION = "Experimental H3 video decode with batched spatial tiles; preserves stock temporal processing and blending."
+
+    def decode(self, samples, vae, tile_batch_size=4):
+        if not isinstance(vae.first_stage_model, MiniMaxH3VideoVAE):
+            raise ValueError("H3 VAE Decode Fast requires the MiniMax H3 video VAE.")
+        latent = samples["samples"]
+        if latent.is_nested:
+            latent = latent.unbind()[0]
+        start = time.perf_counter()
+        if tile_batch_size == 1:
+            images = vae.decode(latent)
+        else:
+            work_vae = copy.copy(vae)
+            work_vae.patcher = vae.patcher.clone()
+            work_vae.patcher.add_object_patch("tiled_decode", partial(
+                tiled_decode_batched, vae.first_stage_model, tile_batch_size=tile_batch_size))
+            memory_estimate = vae.memory_used_decode
+            work_vae.memory_used_decode = lambda shape, dtype: memory_estimate(shape, dtype) * tile_batch_size
+            try:
+                images = work_vae.decode(latent)
+            finally:
+                mm.unload_model_and_clones(work_vae.patcher)
+                work_vae.patcher.unpatch_model(unpatch_weights=False)
+        if images.ndim == 5:
+            images = images.reshape(-1, *images.shape[-3:])
+        if images.is_cuda:
+            torch.cuda.synchronize(images.device)
+        elapsed = time.perf_counter() - start
+        report = f"H3 decode: {elapsed:.2f}s, {images.shape[0]} frames, tile batch {tile_batch_size} (includes loading and cleanup)."
+        return images, report
+
+
+NODE_CLASS_MAPPINGS = {"H3FastVAEDecode": H3FastVAEDecode}
+NODE_DISPLAY_NAME_MAPPINGS = {"H3FastVAEDecode": "H3 VAE Decode Fast (Batched Tiles)"}

--- a/VRGDG_OverlapMetaBatch.py
+++ b/VRGDG_OverlapMetaBatch.py
@@ -404,6 +404,63 @@ class VRGDGOverlapWindow:
         return assembled, info, raw_count, final
 
 
+class VRGDGOverlapAudioWindow:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio": ("AUDIO",),
+                "video_info": ("VHS_VIDEOINFO",),
+                "overlap_info": ("VRGDG_OVERLAP_INFO",),
+            }
+        }
+
+    RETURN_TYPES = ("AUDIO",)
+    RETURN_NAMES = ("window_audio",)
+    FUNCTION = "slice_audio"
+    CATEGORY = "VRGDG/Video/Meta Batch"
+    DESCRIPTION = (
+        "Slices the source soundtrack to the exact overlap window being processed. "
+        "Synthetic leading and trailing video frames receive silence."
+    )
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return float("nan")
+
+    def slice_audio(self, audio, video_info, overlap_info):
+        if not isinstance(overlap_info, dict):
+            raise ValueError("Overlap Audio Window requires overlap_info from VRGDG Overlap Window.")
+        if not isinstance(video_info, dict):
+            raise ValueError("Overlap Audio Window requires video_info from the VHS video loader.")
+
+        waveform = audio["waveform"]
+        sample_rate = int(audio["sample_rate"])
+        if not isinstance(waveform, torch.Tensor) or waveform.ndim != 3:
+            raise ValueError("Overlap Audio Window expects AUDIO waveform [batch, channels, samples].")
+
+        fps = float(video_info.get("loaded_fps", 0.0))
+        if fps <= 0.0:
+            raise ValueError("The VHS video loader reported an invalid loaded frame rate.")
+
+        window = int(overlap_info["window"])
+        overlap = int(overlap_info["overlap"])
+        stride = int(overlap_info["stride"])
+        batch_index = int(overlap_info["batch_index"])
+        start_frame = batch_index * stride - overlap
+        start_sample = round(start_frame * sample_rate / fps)
+        end_sample = round((start_frame + window) * sample_rate / fps)
+        output_samples = end_sample - start_sample
+
+        output = waveform.new_zeros((*waveform.shape[:-1], output_samples))
+        source_start = max(start_sample, 0)
+        source_end = min(end_sample, waveform.shape[-1])
+        if source_end > source_start:
+            output_start = source_start - start_sample
+            output[..., output_start:output_start + source_end - source_start] = waveform[..., source_start:source_end]
+        return ({"waveform": output, "sample_rate": sample_rate},)
+
+
 def _blend_weights(count: int, mode: str, reference: torch.Tensor):
     t = torch.arange(1, count + 1, device=reference.device, dtype=torch.float32)
     t = t / float(count + 1)
@@ -512,6 +569,7 @@ NODE_CLASS_MAPPINGS = {
     "VRGDGOverlapPreset": VRGDGOverlapPreset,
     "VRGDGOverlapMetaBatchManager": VRGDGOverlapMetaBatchManager,
     "VRGDGOverlapWindow": VRGDGOverlapWindow,
+    "VRGDGOverlapAudioWindow": VRGDGOverlapAudioWindow,
     "VRGDGOverlapBlend": VRGDGOverlapBlend,
 }
 
@@ -519,5 +577,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VRGDGOverlapPreset": "VRGDG Overlap Preset",
     "VRGDGOverlapMetaBatchManager": "DEPRECATED - VRGDG Overlap Meta Batch Manager",
     "VRGDGOverlapWindow": "VRGDG Build Overlap Window",
+    "VRGDGOverlapAudioWindow": "VRGDG Build Overlap Audio Window",
     "VRGDGOverlapBlend": "VRGDG Blend Overlap Output",
 }

--- a/__init__.py
+++ b/__init__.py
@@ -40,6 +40,7 @@ _VRGDG_SUBMODULES = (
     ".VRGDG_LTXFirstLastGuide",
     ".VRGDG_LTXLoopingSampler",
     ".VRGDG_MiniMaxH3AudioDrive",
+    ".VRGDG_MiniMaxH3FastVAEDecode",
     ".VRGDG_MiniMaxH3LatentUpscaler",
     ".VRGDG_OverlapMetaBatch",
     ".VRGDG_MiniMaxH3ReferenceMedia",

--- a/tests/test_minimax_h3_fast_vae_decode.py
+++ b/tests/test_minimax_h3_fast_vae_decode.py
@@ -1,0 +1,60 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+try:
+    import torch
+except ModuleNotFoundError:
+    torch = None
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_SOURCE = ROOT / "VRGDG_MiniMaxH3FastVAEDecode.py"
+INIT_SOURCE = ROOT / "__init__.py"
+
+
+def comfy_root():
+    return next((parent for parent in ROOT.parents if (parent / "comfy").is_dir()), None)
+
+
+class MiniMaxH3FastVAEDecodeTests(unittest.TestCase):
+    def test_node_is_registered(self):
+        self.assertIn('".VRGDG_MiniMaxH3FastVAEDecode"', INIT_SOURCE.read_text(encoding="utf-8"))
+        source = NODE_SOURCE.read_text(encoding="utf-8")
+        self.assertIn('"H3FastVAEDecode": H3FastVAEDecode', source)
+
+    @unittest.skipUnless(torch is not None and comfy_root() is not None, "Requires ComfyUI's Python environment.")
+    def test_batched_tiles_match_stock_spatial_blending(self):
+        root = comfy_root()
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+
+        from comfy.ldm.minimax.vae import MiniMaxH3VideoVAE
+
+        spec = importlib.util.spec_from_file_location("vrgdg_h3_fast_vae", NODE_SOURCE)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        class TileFixture:
+            vae_ratio = 1
+            tile_size = 8
+            tile_overlap_min = 2
+            split_tiles = MiniMaxH3VideoVAE.split_tiles
+            blend = MiniMaxH3VideoVAE.blend
+
+            def _decode_pixels(self, z):
+                z = z.contiguous()
+                return z + z.mean(dim=(-3, -2, -1), keepdim=True)
+
+        fixture = TileFixture()
+        for height, width in ((4, 4), (8, 19), (19, 8), (19, 23), (24, 24)):
+            latent = torch.randn(2, 3, 7, height, width)
+            stock = MiniMaxH3VideoVAE.tiled_decode(fixture, latent)
+            for batch_size in (1, 2, 4, 16):
+                actual = module.tiled_decode_batched(fixture, latent, batch_size)
+                torch.testing.assert_close(actual, stock, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlap_meta_batch.py
+++ b/tests/test_overlap_meta_batch.py
@@ -121,6 +121,40 @@ class OverlapMetaBatchTests(unittest.TestCase):
         )
         self.assertEqual(info["batch_index"], 1)
 
+    def test_audio_window_tracks_overlapping_video_timeline(self):
+        audio = {
+            "waveform": torch.arange(10, dtype=torch.float32).reshape(1, 1, 10),
+            "sample_rate": 10,
+        }
+        video_info = {"loaded_fps": 10.0}
+        slicer = MODULE.VRGDGOverlapAudioWindow()
+
+        first = {
+            "batch_index": 0,
+            "window": 5,
+            "overlap": 1,
+            "stride": 4,
+        }
+        middle = {**first, "batch_index": 1}
+        final = {**first, "batch_index": 2}
+
+        first_audio, = slicer.slice_audio(audio, video_info, first)
+        middle_audio, = slicer.slice_audio(audio, video_info, middle)
+        final_audio, = slicer.slice_audio(audio, video_info, final)
+
+        torch.testing.assert_close(
+            first_audio["waveform"].flatten(),
+            torch.tensor([0.0, 0.0, 1.0, 2.0, 3.0]),
+        )
+        torch.testing.assert_close(
+            middle_audio["waveform"].flatten(),
+            torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0]),
+        )
+        torch.testing.assert_close(
+            final_audio["waveform"].flatten(),
+            torch.tensor([7.0, 8.0, 9.0, 0.0, 0.0]),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds an overlap-aware source-audio window node for MiniMax H3 meta-batches and a batched spatial-tile H3 VAE decode node. Includes focused tests for audio timeline alignment, node registration, and exact spatial decode equivalence. Tests: 9 passed using ComfyUI embedded Python; py_compile passed.