### PR TITLE
Improve Builder lyric mapping and add Match Grain workflows

### DIFF
--- a/Workflows/match grain/Match_Grain_Image.json
+++ b/Workflows/match grain/Match_Grain_Image.json
@@ -1,0 +1,285 @@
+{
+  "id": "vrgdg-match-grain-image",
+  "revision": 0,
+  "last_node_id": 11,
+  "last_link_id": 3,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadImage",
+      "pos": [
+        0,
+        140
+      ],
+      "size": [
+        280,
+        326
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "target.png",
+        "image"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "LoadImage",
+      "pos": [
+        0,
+        560
+      ],
+      "size": [
+        280,
+        326
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            2
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "reference_with_grain.png",
+        "image"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "MatchGrainToReference",
+      "pos": [
+        430,
+        260
+      ],
+      "size": [
+        330,
+        300
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "name": "reference_image",
+          "type": "IMAGE",
+          "link": 2
+        },
+        {
+          "name": "strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength"
+          },
+          "link": null
+        },
+        {
+          "name": "grain_size",
+          "type": "INT",
+          "widget": {
+            "name": "grain_size"
+          },
+          "link": null
+        },
+        {
+          "name": "chroma_amount",
+          "type": "FLOAT",
+          "widget": {
+            "name": "chroma_amount"
+          },
+          "link": null
+        },
+        {
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": null
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "widget": {
+            "name": "batch_size"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-vrgamedevgirl",
+        "ver": "0.16.3",
+        "Node name for S&R": "MatchGrainToReference"
+      },
+      "widgets_values": [
+        1,
+        2,
+        0.35,
+        1234,
+        8
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 4,
+      "type": "SaveImage",
+      "pos": [
+        850,
+        300
+      ],
+      "size": [
+        320,
+        512
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 3
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "match_grain/image"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "Note",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        430,
+        180
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "MATCH GRAIN — IMAGE\n\n1. Load a clean target image on the left.\n2. Load a finished reference image that already has the grain look you want.\n3. Match Grain measures the reference grain and synthesizes similar grain on the target.\n4. Save Image writes the result."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 11,
+      "type": "Note",
+      "pos": [
+        430,
+        0
+      ],
+      "size": [
+        430,
+        180
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "WHAT THE CONTROLS DO\n\nStrength: overall amount.\nGrain size: 1 is fine; larger values make broader grain.\nChroma amount: 0 is monochrome; higher values allow colored grain.\nSeed: repeatable result.\nBatch size matters mainly for video; leave it at 8 for still images."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      3,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      2,
+      0,
+      3,
+      1,
+      "IMAGE"
+    ],
+    [
+      3,
+      3,
+      0,
+      4,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "workflow_notes": "Standalone Match Grain image example. Replace the LoadImage filenames with files from ComfyUI/input."
+  },
+  "version": 0.4
+}

--- a/Workflows/match grain/Match_Grain_Video.json
+++ b/Workflows/match grain/Match_Grain_Video.json
@@ -1,0 +1,488 @@
+{
+  "id": "vrgdg-match-grain-video",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 6,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "VHS_BatchManager",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        280,
+        90
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "frames_per_batch",
+          "type": "INT",
+          "widget": {
+            "name": "frames_per_batch"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "meta_batch",
+          "type": "VHS_BatchManager",
+          "links": [
+            5,
+            6
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "0.16.3",
+        "Node name for S&R": "VHS_BatchManager"
+      },
+      "widgets_values": {
+        "frames_per_batch": 8,
+        "count": 0
+      },
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 2,
+      "type": "VHS_LoadVideoPath",
+      "pos": [
+        0,
+        180
+      ],
+      "size": [
+        300,
+        300
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": 5
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        },
+        {
+          "name": "video",
+          "type": "STRING",
+          "widget": {
+            "name": "video"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1
+          ]
+        },
+        {
+          "name": "frame_count",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            3
+          ]
+        },
+        {
+          "name": "video_info",
+          "type": "VHS_VIDEOINFO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "0.16.3",
+        "Node name for S&R": "VHS_LoadVideoPath"
+      },
+      "widgets_values": {
+        "video": "",
+        "force_rate": 0,
+        "custom_width": 0,
+        "custom_height": 0,
+        "frame_load_cap": 0,
+        "skip_first_frames": 0,
+        "select_every_nth": 1,
+        "format": "AnimateDiff",
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "",
+            "type": "path",
+            "format": "video/",
+            "force_rate": 0,
+            "custom_width": 0,
+            "custom_height": 0,
+            "frame_load_cap": 0,
+            "skip_first_frames": 0,
+            "select_every_nth": 1
+          }
+        }
+      },
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 3,
+      "type": "LoadImage",
+      "pos": [
+        0,
+        590
+      ],
+      "size": [
+        280,
+        326
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            2
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "reference_with_grain.png",
+        "image"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "MatchGrainToReference",
+      "pos": [
+        450,
+        350
+      ],
+      "size": [
+        340,
+        300
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "name": "reference_image",
+          "type": "IMAGE",
+          "link": 2
+        },
+        {
+          "name": "strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength"
+          },
+          "link": null
+        },
+        {
+          "name": "grain_size",
+          "type": "INT",
+          "widget": {
+            "name": "grain_size"
+          },
+          "link": null
+        },
+        {
+          "name": "chroma_amount",
+          "type": "FLOAT",
+          "widget": {
+            "name": "chroma_amount"
+          },
+          "link": null
+        },
+        {
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": null
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "widget": {
+            "name": "batch_size"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            4
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-vrgamedevgirl",
+        "ver": "0.16.3",
+        "Node name for S&R": "MatchGrainToReference"
+      },
+      "widgets_values": [
+        1,
+        2,
+        0.35,
+        1234,
+        8
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 5,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        900,
+        350
+      ],
+      "size": [
+        300,
+        460
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 4
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": 3
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": 6
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "widget": {
+            "name": "frame_rate"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "0.16.3",
+        "Node name for S&R": "VHS_VideoCombine"
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "match_grain/video",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 24
+          }
+        }
+      },
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 10,
+      "type": "Note",
+      "pos": [
+        0,
+        1000
+      ],
+      "size": [
+        430,
+        180
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "MATCH GRAIN — VIDEO\n\nTarget video goes into the VHS loader. The reference image goes into LoadImage.\nUse a still frame or reference image that already has the grain look you want.\nThe one reference image is analyzed once and its grain statistics are applied to every target-video frame.\nThe Batch Manager streams the target video in 8-frame groups so long videos do not create one giant working batch.\nThe output keeps the target video audio."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 11,
+      "type": "Note",
+      "pos": [
+        450,
+        0
+      ],
+      "size": [
+        430,
+        180
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "VIDEO SETTINGS\n\nBatch Manager frames_per_batch: lower this if memory is tight; raise it if you have plenty of VRAM/RAM.\nMatch Grain batch_size: usually keep it equal to frames_per_batch.\nFrame rate: set it to the target video's original FPS.\nframe_load_cap 0 means load all frames; the Batch Manager still controls processing groups."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 12,
+      "type": "Note",
+      "pos": [
+        900,
+        0
+      ],
+      "size": [
+        430,
+        180
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "IMPORTANT\n\nThe target video provides the frames to process. The reference image provides only grain statistics; its scene content is not copied.\nIf you have reference footage instead of a still, first extract a representative frame or use the separate reference-video approach manually.\nThis node matches grain character; it does not copy the reference scene."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    }
+  ],
+  "links": [
+    [
+      1,
+      2,
+      0,
+      4,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      3,
+      0,
+      4,
+      1,
+      "IMAGE"
+    ],
+    [
+      3,
+      2,
+      2,
+      5,
+      1,
+      "AUDIO"
+    ],
+    [
+      4,
+      4,
+      0,
+      5,
+      0,
+      "IMAGE"
+    ],
+    [
+      5,
+      1,
+      0,
+      2,
+      0,
+      "VHS_BatchManager"
+    ],
+    [
+      6,
+      1,
+      0,
+      5,
+      2,
+      "VHS_BatchManager"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "workflow_notes": "Standalone Match Grain video example. Use a target video plus a still reference image with the desired grain look. Install ComfyUI-VideoHelperSuite."
+  },
+  "version": 0.4
+}

--- a/tests/test_builder_lyric_mapping_sync.py
+++ b/tests/test_builder_lyric_mapping_sync.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+UI_SOURCE = (Path(__file__).parents[1] / "web" / "VRGDG_MusicVideoBuilderUI.js").read_text(encoding="utf-8")
+
+
+def test_mapper_apply_keeps_stable_scene_link_for_instrumental_corrections():
+    assert "lyric_mapper_line_id" in UI_SOURCE
+    assert "If a mapper row was added while its corresponding scene is still instrumental" in UI_SOURCE
+    assert "segment.lyric_text = String(line.text || \"\").trim();" in UI_SOURCE
+
+
+def test_lyric_mapping_is_saved_in_both_directions():
+    assert "function syncLyricMapperFromSegments()" in UI_SOURCE
+    assert UI_SOURCE.count("syncLyricMapperFromSegments();") >= 3
+    assert "applyLyricMapperToSegments({ overwriteSingers: true });" in UI_SOURCE
+
+
+def test_unchecking_instrumental_restores_review_text():
+    assert "text.dataset.reviewPreInstrumentalText" in UI_SOURCE
+    assert "const restored = String(text.dataset.reviewPreInstrumentalText || \"\");" in UI_SOURCE
+
+
+def test_instrumental_section_is_recomputed_after_lyric_text_is_added():
+    assert 'existingSection !== "instrumental"' in UI_SOURCE
+    assert 'if (!lyricText || isInstrumentalLyricText(lyricText))' in UI_SOURCE
+    assert 'applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper?.source_text || "");' in UI_SOURCE

--- a/tests/test_builder_lyric_mapping_sync.py
+++ b/tests/test_builder_lyric_mapping_sync.py
@@ -6,7 +6,8 @@ UI_SOURCE = (Path(__file__).parents[1] / "web" / "VRGDG_MusicVideoBuilderUI.js")
 
 def test_mapper_apply_keeps_stable_scene_link_for_instrumental_corrections():
     assert "lyric_mapper_line_id" in UI_SOURCE
-    assert "If a mapper row was added while its corresponding scene is still instrumental" in UI_SOURCE
+    assert "If a mapper row was added while its corresponding scene is still" in UI_SOURCE
+    assert "instrumental, preserve the user's line order as the final fallback." in UI_SOURCE
     assert "segment.lyric_text = String(line.text || \"\").trim();" in UI_SOURCE
 
 

--- a/tests/test_storyboard_adjacent_lyric_context.py
+++ b/tests/test_storyboard_adjacent_lyric_context.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+UI_SOURCE = (Path(__file__).parents[1] / "web" / "VRGDG_StoryboardBuilderUI.js").read_text(encoding="utf-8")
+
+
+def test_adjacent_lyric_context_is_optional_and_saved():
+    assert "Send last and next lyric line for context" in UI_SOURCE
+    assert "send_adjacent_lyric_context: Boolean(state.sendAdjacentLyricContext)" in UI_SOURCE
+    assert "state.sendAdjacentLyricContext = adjacentLyricContextInput.checked;" in UI_SOURCE
+
+
+def test_adjacent_lines_are_added_to_scene_beat_requests_only_when_enabled():
+    assert "if (!state.sendAdjacentLyricContext)" in UI_SOURCE
+    assert 'previous_lyrics: previousLyrics' in UI_SOURCE
+    assert 'next_lyrics: nextLyrics' in UI_SOURCE

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,6 +3,46 @@
   "product": "AI Video Builder",
   "releases": [
     {
+      "id": "2026-09-08-builder-storyboard-match-grain-workflows",
+      "version": "2026.09.08-builder-storyboard-match-grain-workflows",
+      "date": "2026-09-08",
+      "title": "Builder lyric mapping, Storyboard context, and Match Grain workflows",
+      "commit": "4341371",
+      "restart_required": false,
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
+      "sections": [
+        {
+          "title": "Added",
+          "items": [
+            "Added Ctrl/Cmd-click multi-selection for base scenes and inserts in both the Video Builder timeline and scene lists.",
+            "Added an optional Storyboard Builder setting that sends the previous and next lyric lines as context when generating each scene beat.",
+            "Added ready-to-use Match Grain workflows for still images and VHS meta-batched video processing."
+          ]
+        },
+        {
+          "title": "Improved",
+          "items": [
+            "Video Builder and Storyboard Builder now use the selected LLM Runner models and runner names consistently in prompts, progress text, controls, and error messages.",
+            "Renamed the MiniMax two-pass image mode to Image + Reference 2 Pass so its scene-image and optional Reference Builder inputs are clearer."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Fixed lyric mapper edits failing to update scenes previously marked instrumental by keeping stable mapper-row links and synchronizing lyric text, singers, instrumental status, and lyric sections in both directions.",
+            "Fixed unchecking instrumental in lyric editing and review views so the previous lyric text is restored instead of remaining empty."
+          ]
+        },
+        {
+          "title": "Compatibility Notes",
+          "items": [
+            "Hard-refresh the browser after updating so the revised Video Builder and Storyboard Builder JavaScript is loaded.",
+            "The Match Grain video workflow requires ComfyUI-VideoHelperSuite for video loading, meta-batching, audio passthrough, and video output."
+          ]
+        }
+      ]
+    },
+    {
       "id": "2026-09-04-pr173-video-builder-image-reference-and-new-nodes",
       "version": "2026.09.04-pr173-video-builder-image-reference-and-new-nodes",
       "date": "2026-09-04",
@@ -205,8 +245,7 @@
             "Fixed saved Qwen, Gemma, and mmproj selections being replaced by stale Builder dropdown values after loading a project or refreshing the available model lists.",
             "Fixed Story Arc generation failing when Qwen echoed an instruction heading instead of immediately returning the exact lyric-section headings. Clearly instructional preambles are ignored when a valid arc follows, and invalid structures receive one automatic strict-format retry before an error is shown.",
             "Fixed model-emitted <think>, Thought, Thinking, Analysis, and Reasoning preambles leaking into Builder and Storyboard output even when local thinking mode is disabled.",
-            "Story Arc format failures now include a collapsed diagnostics panel with the runner, expected headings, raw model response, cleaned response, and a copy-output button.",
-            "Added an optional Storyboard Builder checkbox, Send last and next lyric line for context, which gives each scene beat the adjacent lyric lines when they exist while keeping the default request unchanged."
+            "Story Arc format failures now include a collapsed diagnostics panel with the runner, expected headings, raw model response, cleaned response, and a copy-output button."
           ]
         },
         {

--- a/update_notes.json
+++ b/update_notes.json
@@ -205,7 +205,8 @@
             "Fixed saved Qwen, Gemma, and mmproj selections being replaced by stale Builder dropdown values after loading a project or refreshing the available model lists.",
             "Fixed Story Arc generation failing when Qwen echoed an instruction heading instead of immediately returning the exact lyric-section headings. Clearly instructional preambles are ignored when a valid arc follows, and invalid structures receive one automatic strict-format retry before an error is shown.",
             "Fixed model-emitted <think>, Thought, Thinking, Analysis, and Reasoning preambles leaking into Builder and Storyboard output even when local thinking mode is disabled.",
-            "Story Arc format failures now include a collapsed diagnostics panel with the runner, expected headings, raw model response, cleaned response, and a copy-output button."
+            "Story Arc format failures now include a collapsed diagnostics panel with the runner, expected headings, raw model response, cleaned response, and a copy-output button.",
+            "Added an optional Storyboard Builder checkbox, Send last and next lyric line for context, which gives each scene beat the adjacent lyric lines when they exist while keeping the default request unchanged."
           ]
         },
         {

--- a/update_notes.json
+++ b/update_notes.json
@@ -9,7 +9,7 @@
       "title": "Builder lyric mapping, Storyboard context, and Match Grain workflows",
       "commit": "4341371",
       "restart_required": false,
-      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
+      "guide_url": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl/pull/177",
       "sections": [
         {
           "title": "Added",

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -1393,7 +1393,7 @@ function showGemmaBatchFailures(failures, options = {}) {
   const box = document.createElement("div");
   box.style.cssText = "width:min(980px,calc(100vw - 36px));max-height:calc(100vh - 36px);overflow:auto;border:1px solid #991b1b;border-radius:10px;background:#111827;color:#f8fafc;box-shadow:0 22px 80px rgba(0,0,0,.65);padding:16px;box-sizing:border-box;";
   const title = document.createElement("div");
-  title.innerHTML = `<div style="font-size:17px;font-weight:900;color:#fecaca;">Gemma skipped ${items.length} scene${items.length === 1 ? "" : "s"}</div><div style="font-size:12px;color:#cbd5e1;margin-top:5px;">Successful scenes were kept. Only these scenes will be retried.</div>`;
+  title.innerHTML = `<div style="font-size:17px;font-weight:900;color:#fecaca;">LLM skipped ${items.length} scene${items.length === 1 ? "" : "s"}</div><div style="font-size:12px;color:#cbd5e1;margin-top:5px;">Successful scenes were kept. Only these scenes will be retried.</div>`;
   const list = document.createElement("div");
   list.style.cssText = "display:flex;flex-direction:column;gap:12px;margin-top:14px;";
   items.forEach((item) => {
@@ -4383,7 +4383,7 @@ function openBuilder(node) {
   const editImagePromptButtons = [];
   function makeEditImagePromptButton() {
     const button = makeButton("Edit Prompt");
-    button.title = "Ask Gemma to make a focused edit to the current image prompt.";
+  button.title = "Ask the selected LLM runner to make a focused edit to the current image prompt.";
     button.style.display = "none";
     editImagePromptButtons.push(button);
     return button;
@@ -4411,7 +4411,7 @@ function openBuilder(node) {
   const fluxNotes = document.createElement("textarea");
   fluxNotes.placeholder = "Optional pose, camera, wardrobe, lighting, or mood notes...";
   fluxNotes.style.cssText = "width:100%;box-sizing:border-box;min-height:72px;resize:vertical;border:1px solid #3f3f46;border-radius:6px;background:#18181b;color:#fafafa;padding:9px;font-size:12px;line-height:1.45;";
-  const fluxUseTextOnlyGemmaPrompt = makeCheckbox("Use text-only Gemma for Flux prompts", false);
+  const fluxUseTextOnlyGemmaPrompt = makeCheckbox("Use text-only LLM for Flux prompts", false);
   const fluxUseDirectorNotes = makeCheckbox("Use Director Notes in Flux prompt", false);
   const fluxGemmaModelSelect = makeSelect([""], "");
   const fluxMmprojSelect = makeSelect([""], "");
@@ -4460,7 +4460,7 @@ function openBuilder(node) {
   const nbModelSelect = makeSelect(NB_IMAGE_MODELS, DEFAULT_NB_IMAGE_MODEL);
   const nbGemmaModelSelect = makeSelect([""], "");
   const nbMmprojSelect = makeSelect([""], "");
-  const nbUseTextOnlyGemmaPrompt = makeCheckbox("Use text-only Gemma for Nano B prompts", false);
+  const nbUseTextOnlyGemmaPrompt = makeCheckbox("Use text-only LLM for Nano B prompts", false);
   const nbUseDirectorNotes = makeCheckbox("Use Director Notes in Nano B prompt", false);
   const nbNotes = document.createElement("textarea");
   nbNotes.placeholder = "Optional camera, framing, pose, scene, or edit notes for NanoBanana...";
@@ -5786,7 +5786,7 @@ function openBuilder(node) {
           makeField("Flux VAE", fluxVaePicker.wrapper),
         ]),
         makeSettingsSection("Vision LLM Models", [
-          makeField("Gemma vision model", fluxGemmaModelSelect),
+        makeField("Vision LLM model", fluxGemmaModelSelect),
           makeField("Vision mmproj", fluxMmprojSelect),
         ]),
         fluxUseLora.wrapper,
@@ -5835,7 +5835,7 @@ function openBuilder(node) {
           makeField("Model", nbModelSelect),
         ]),
         makeSettingsSection("Vision LLM Models", [
-          makeField("Gemma vision model", nbGemmaModelSelect),
+        makeField("Vision LLM model", nbGemmaModelSelect),
           makeField("Vision mmproj", nbMmprojSelect),
         ]),
         makeNBCreateButton(),
@@ -5939,7 +5939,7 @@ function openBuilder(node) {
         makeField("CLIP", zEnhanceClipPicker.wrapper),
         makeField("VAE", zEnhanceVaePicker.wrapper),
         makeSettingsSection("Vision LLM Models", [
-          makeField("Gemma vision model", zEnhanceGemmaModelSelect),
+        makeField("Vision LLM model", zEnhanceGemmaModelSelect),
           makeField("Vision mmproj", zEnhanceMmprojSelect),
         ]),
         zEnhanceUseLora.wrapper,
@@ -5961,7 +5961,7 @@ function openBuilder(node) {
       label: "LLM Prompting",
       value: "prompting",
       content: makeSettingsPanel([
-        makeField("Gemma notes", zEnhanceGemmaNotes),
+        makeField("LLM notes", zEnhanceGemmaNotes),
         zEnhanceGemmaButton,
         makeField("Enhance prompt", zEnhancePromptPreview),
       ]),
@@ -10860,8 +10860,10 @@ function openBuilder(node) {
 
   function runnerAwareLlmText(value) {
     return String(value || "")
-      .replace(/\b(?:Vision Gemma|Gemma Vision)\b/gi, gemmaRunnerLabel({ vision: true }))
+      .replace(/\b(?:Vision Gemma|Gemma Vision|Gemma vision)\b/gi, gemmaRunnerLabel({ vision: true }))
+      .replace(/\bGemma Local\b/gi, promptRunnerActionName())
       .replace(/\bGemma4?\b/g, promptRunnerActionName())
+      .replace(/\bGemma\b/g, promptRunnerActionName())
       .replace(/\bAPI LLM\b/g, "LLM API")
       .replace(/\bOwn server\b/gi, "Custom Server");
   }
@@ -10930,12 +10932,12 @@ function openBuilder(node) {
   async function describeReferenceImageWithGemma(target, referenceType = "subject", options = {}) {
     const image = target?.image || {};
     if (!hasReferenceImage(image)) {
-      throw new Error(referenceType === "location" ? "This location has no image for Gemma to describe." : "This reference has no image for Gemma to describe.");
+      throw new Error(referenceType === "location" ? `This location has no image for ${gemmaRunnerLabel({ vision: true })} to describe.` : `This reference has no image for ${gemmaRunnerLabel({ vision: true })} to describe.`);
     }
     const modelFile = referenceDescriptionVisionModel();
     const mmprojFile = referenceDescriptionMmproj();
     if (!["lm_studio", "llm_api", "own_server"].includes(state.textGemmaRunner) && (!modelFile || !mmprojFile)) {
-      throw new Error("Choose a Gemma vision model and Vision mmproj first.");
+      throw new Error(`Choose a ${gemmaRunnerLabel({ vision: true })} model and Vision mmproj first.`);
     }
     const data = await postJson("/vrgdg/music_builder/describe_reference_image", {
       ...textGemmaRunnerPayload(),

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -44442,6 +44442,14 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       await autoSaveSessionQuiet("MiniMax timeline segments created from storyboard");
       return { message: `Created ${nextSegments.length} MiniMax timeline segment${nextSegments.length === 1 ? "" : "s"} from the reviewed storyboard.` };
     };
+    const storyboardRunnerSettings = textGemmaRunnerPayload();
+    const storyboardUsesQwen = state.textGemmaRunner === "qwen_local";
+    const storyboardSelectedModel = storyboardUsesQwen
+      ? String(storyboardRunnerSettings.qwen_model_file || "").trim()
+      : String(storyboardRunnerSettings.gemma_model_file || "").trim();
+    const storyboardSelectedMmproj = storyboardUsesQwen
+      ? String(storyboardRunnerSettings.qwen_mmproj_file || "").trim()
+      : String(i2vMmprojSelect.value || mmprojSelect.value || "").trim();
     window.VRGDGStoryboardBuilder.open({
       projectFolder: projectInput.value || state.projectFolder || "",
       projectVideoEngine: normalizeProjectVideoEngine(state.projectVideoEngine),
@@ -44485,10 +44493,10 @@ Chrome vault corridor = Sealed industrial passage...</pre>
       referenceBuilder: storyboardReferenceBuilderWithIdLoraRefs(state.fluxReferenceBuilder),
       storyLayer: normalizeBuilderStoryLayer(state.builderStoryLayer),
       gemmaSettings: {
-        ...textGemmaRunnerPayload(),
-        model_file: i2vTextGemmaModelSelect.value || t2iTextGemmaModelSelect.value || "",
-        vision_model_file: i2vGemmaModelSelect.value || gemmaModelSelect.value || "",
-        mmproj_file: i2vMmprojSelect.value || mmprojSelect.value || "",
+        ...storyboardRunnerSettings,
+        model_file: storyboardSelectedModel,
+        vision_model_file: storyboardSelectedModel,
+        mmproj_file: storyboardSelectedMmproj,
         n_ctx: normalizeGemmaContextLimit(state.gemmaContextLimit),
         n_gpu_layers: normalizeGemmaGpuLayers(state.gemmaGpuLayers),
         n_threads: 8,

--- a/web/VRGDG_MusicVideoBuilderUI.js
+++ b/web/VRGDG_MusicVideoBuilderUI.js
@@ -153,7 +153,7 @@ const BUILDER_FONT_STACK = "Segoe UI, Inter, Roboto, Arial, sans-serif";
 const MINIMAX_H3_MODE_OPTIONS = [
   { value: "text_to_video", label: "Text to Video", buttonLabel: "T2V" },
   { value: "image_to_video", label: "Image to Video", buttonLabel: "I2V" },
-  { value: "image_reference_to_video", label: "Image to Video 2 Pass", buttonLabel: "Image to Video\n2 Pass" },
+  { value: "image_reference_to_video", label: "Image + Reference 2 Pass", buttonLabel: "Image + Ref\n2 Pass" },
   { value: "reference_to_video", label: "Reference to Video", buttonLabel: "Ref to\nVideo" },
   { value: "video_to_video", label: "Video to Video", buttonLabel: "V2V" },
 ];
@@ -374,7 +374,7 @@ const MINIMAX_H3_SAGE_ATTENTION_OPTIONS = [
 
 function normalizeMiniMaxH3Mode(value) {
   const clean = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
-  if (clean === "image_reference_to_video" || clean === "image_plus_reference_to_video" || clean === "i2v_r2v") return "image_reference_to_video";
+  if (["image_reference_to_video", "image_plus_reference_to_video", "i2v_r2v"].includes(clean)) return "image_reference_to_video";
   return MINIMAX_H3_MODE_OPTIONS.some((item) => item.value === clean) ? clean : "text_to_video";
 }
 
@@ -6833,8 +6833,8 @@ function openBuilder(node) {
   redoButton.title = "Redo";
   playButton.title = "Play / Pause (Space)";
   stopButton.title = "Stop";
-  multiSelectButton.title = "Select multiple scenes, then batch-apply image/video settings or stitch a preview.";
-  multiSelectHintButton.title = "What does Select Multi do?";
+  multiSelectButton.title = "Select multiple scenes, or hold Ctrl/Cmd while clicking scenes in the timeline or scene list.";
+  multiSelectHintButton.title = "What does Select Multi do? Ctrl/Cmd-click also toggles scene selection.";
   deleteSegmentButton.title = "Delete selected segment";
   deleteAllSegmentsButton.title = "Delete every base and insert/overlay segment from the timeline.";
   zoomOutButton.title = "Zoom out timeline";
@@ -7424,6 +7424,7 @@ function openBuilder(node) {
     miniMaxH3PanelSegmentId: "",
     activeTrack: "base",
     multiSelectMode: false,
+    modifierMultiSelectMode: false,
     selectedSegmentIds: [],
     inspectorTab: "scene",
     leftPanelTab: "scenes",
@@ -11104,17 +11105,35 @@ function openBuilder(node) {
     if (ids.has(segment.id)) ids.delete(segment.id);
     else ids.add(segment.id);
     state.selectedSegmentIds = Array.from(ids);
-    if (!state.activeId || !ids.has(state.activeId)) {
+    if (ids.has(segment.id)) {
       state.activeId = segment.id;
       state.activeTrack = segmentTrack(segment);
-      syncInspector();
+    } else if (state.activeId === segment.id) {
+      const next = allEditableSegments().find((item) => ids.has(item.id));
+      state.activeId = next?.id || "";
+      state.activeTrack = next ? segmentTrack(next) : state.activeTrack || "base";
     }
+    syncInspector();
     render();
   }
 
-  function handleSegmentPick(segment) {
-    if (state.multiSelectMode) toggleMultiSegmentSelection(segment);
-    else {
+  function handleSegmentPick(segment, event = null) {
+    const ctrlPressed = Boolean(event?.ctrlKey || event?.metaKey);
+    if (ctrlPressed) {
+      state.multiSelectMode = true;
+      state.modifierMultiSelectMode = true;
+      toggleMultiSegmentSelection(segment);
+    } else if (state.multiSelectMode) {
+      if (state.modifierMultiSelectMode) {
+        state.multiSelectMode = false;
+        state.modifierMultiSelectMode = false;
+        state.selectedSegmentIds = [];
+        setActiveSegment(segment);
+        selectSegmentGlobalAudioStart(segment);
+      } else {
+        toggleMultiSegmentSelection(segment);
+      }
+    } else {
       setActiveSegment(segment);
       selectSegmentGlobalAudioStart(segment);
     }
@@ -14666,43 +14685,109 @@ function openBuilder(node) {
     state.lyricMapper = normalizeLyricMapper(state.lyricMapper);
     const mapperLines = state.lyricMapper.lines || [];
     if (!mapperLines.length) return 0;
-    let applied = 0;
-    for (const segment of allEditableSegments()) {
-      const lyric = String(segment.lyric_text || "").trim();
-      if (!lyric) {
-        segment.lyric_text = "[instrumental]";
-        segment.lyric_no_lip_sync = true;
-        applied += 1;
-        continue;
-      }
+    // Keep an explicit relationship between a mapper row and its timeline
+    // scene. Text matching alone cannot find a scene that is currently marked
+    // instrumental, which made correcting an instrumental row a no-op.
+    const segments = state.segments.filter((segment) => segment && typeof segment === "object");
+    const byMapperId = new Map(segments
+      .filter((segment) => segment.lyric_mapper_line_id)
+      .map((segment) => [String(segment.lyric_mapper_line_id), segment]));
+    const assignments = new Map();
+    const usedSegments = new Set();
+    const assign = (line, segment) => {
+      if (!line || !segment || usedSegments.has(segment.id)) return false;
+      assignments.set(line.id, segment);
+      usedSegments.add(segment.id);
+      return true;
+    };
+    for (const line of mapperLines) assign(line, byMapperId.get(String(line.id || "")));
+    if (mapperLines.length === segments.length) {
+      mapperLines.forEach((line, index) => assign(line, segments[index]));
+    }
+    for (const line of mapperLines) {
+      if (assignments.has(line.id)) continue;
       let best = null;
       let bestScore = 0;
-      for (const line of mapperLines) {
-        const score = line.instrumental && isInstrumentalLyricText(lyric) ? 1000 : lyricMatchScore(lyric, line.text);
-        if (score > bestScore) {
-          best = line;
-          bestScore = score;
-        }
+      for (const segment of segments) {
+        if (usedSegments.has(segment.id)) continue;
+        const current = String(segment.lyric_text || "").trim();
+        const score = line.instrumental && isInstrumentalLyricText(current)
+          ? 1000
+          : lyricMatchScore(current, line.text);
+        if (score > bestScore) { best = segment; bestScore = score; }
       }
-      if (!best || bestScore < 0.32) continue;
-      if (best.instrumental) {
-        if (overwriteSingers || !String(segment.lyric_text || "").trim()) segment.lyric_text = "[instrumental]";
-        const singers = Array.isArray(best.singers) ? best.singers.filter((value) => !isNoLipSyncSingerChoice(value)) : [];
-        if (overwriteSingers && singers.length) segment.lyric_singers = [...singers];
+      if (best && bestScore >= 0.32) assign(line, best);
+    }
+    // If a mapper row was added while its corresponding scene is still
+    // instrumental, preserve the user's line order as the final fallback.
+    mapperLines.forEach((line, index) => assign(line, segments[index]));
+    let applied = 0;
+    for (const line of mapperLines) {
+      const segment = assignments.get(line.id);
+      if (!segment) continue;
+      segment.lyric_mapper_line_id = line.id;
+      if (line.instrumental) {
+        segment.lyric_text = "[instrumental]";
+        segment.lyric_section = "instrumental";
+        if (overwriteSingers) segment.lyric_singers = [];
         segment.lyric_no_lip_sync = true;
-      } else if (overwriteSingers || !Array.isArray(segment.lyric_singers) || !segment.lyric_singers.length) {
-        const singers = Array.isArray(best.singers) ? [...best.singers] : [];
-        if (best.no_lip_sync || singers.some(isNoLipSyncSingerChoice)) {
+      } else {
+        segment.lyric_text = String(line.text || "").trim();
+        if (String(segment.lyric_section || "").trim().toLowerCase() === "instrumental") segment.lyric_section = "";
+        if (overwriteSingers || !Array.isArray(segment.lyric_singers) || !segment.lyric_singers.length) {
+        const singers = Array.isArray(line.singers) ? [...line.singers] : [];
+        if (line.no_lip_sync || singers.some(isNoLipSyncSingerChoice)) {
           segment.lyric_singers = singers.filter((value) => !isNoLipSyncSingerChoice(value));
           segment.lyric_no_lip_sync = true;
         } else {
           segment.lyric_singers = singers;
           segment.lyric_no_lip_sync = false;
         }
+        }
       }
       applied += 1;
     }
     return applied;
+  }
+
+  function syncLyricMapperFromSegments() {
+    const segments = state.segments.filter((segment) => segment && typeof segment === "object");
+    if (!segments.length) return 0;
+    const mapper = normalizeLyricMapper(state.lyricMapper);
+    const lines = Array.isArray(mapper.lines) ? mapper.lines : [];
+    const byId = new Map(lines.map((line) => [String(line.id || ""), line]));
+    const used = new Set();
+    const pairs = [];
+    const pair = (segment, line) => {
+      if (!segment || !line || used.has(line.id)) return false;
+      used.add(line.id); pairs.push([segment, line]); return true;
+    };
+    for (const segment of segments) pair(segment, byId.get(String(segment.lyric_mapper_line_id || "")));
+    if (lines.length === segments.length) segments.forEach((segment, index) => pair(segment, lines[index]));
+    for (const segment of segments) {
+      if (pairs.some(([item]) => item === segment)) continue;
+      let best = null; let score = 0;
+      for (const line of lines) {
+        if (used.has(line.id)) continue;
+        const candidate = segment.lyric_no_lip_sync && isInstrumentalLyricText(segment.lyric_text) ? 1 : lyricMatchScore(segment.lyric_text, line.text);
+        if (candidate > score) { best = line; score = candidate; }
+      }
+      if (best && score >= 0.32) pair(segment, best);
+    }
+    if (!lines.length) {
+      for (const segment of segments) lines.push({ id: `lyric_line_${Date.now()}_${lines.length}`, text: "", singers: [], instrumental: false });
+      segments.forEach((segment, index) => pair(segment, lines[index]));
+    }
+    for (const [segment, line] of pairs) {
+      const instrumental = Boolean(segment.lyric_no_lip_sync && isInstrumentalLyricText(segment.lyric_text));
+      line.instrumental = instrumental;
+      line.text = instrumental ? "" : String(segment.lyric_text || "").trim();
+      line.singers = instrumental ? [] : (Array.isArray(segment.lyric_singers) ? [...segment.lyric_singers] : []);
+      line.no_lip_sync = Boolean(segment.lyric_no_lip_sync && !instrumental);
+      segment.lyric_mapper_line_id = line.id;
+    }
+    state.lyricMapper = normalizeLyricMapper({ ...mapper, lines });
+    return pairs.length;
   }
 
   function normalizeFluxReferenceBuilder(value = {}) {
@@ -15401,6 +15486,7 @@ function openBuilder(node) {
 
   function setMultiSelectMode(enabled) {
     state.multiSelectMode = Boolean(enabled);
+    state.modifierMultiSelectMode = false;
     if (!state.multiSelectMode) {
       state.selectedSegmentIds = [];
     } else if (state.activeId && !state.selectedSegmentIds.length) {
@@ -15489,7 +15575,7 @@ function openBuilder(node) {
     const clickCard = document.createElement("div");
     clickCard.style.cssText = "border:1px solid #334155;border-radius:7px;background:#0f172a;padding:11px;display:flex;align-items:center;justify-content:space-between;gap:12px;";
     const clickCopy = document.createElement("div");
-    clickCopy.innerHTML = `<strong style="color:#e0f2fe;">Click timeline clips</strong><br><span style="font-size:12px;color:#94a3b8;">Turn multi-select on, then click any base scene or insert to add or remove it.</span>`;
+    clickCopy.innerHTML = `<strong style="color:#e0f2fe;">Click timeline clips</strong><br><span style="font-size:12px;color:#94a3b8;">Turn multi-select on, or hold Ctrl/Cmd while clicking any base scene or insert to add or remove it.</span>`;
     const clickSelect = makeButton("Start Clicking", "primary");
     clickSelect.style.flex = "0 0 auto";
     clickCard.append(clickCopy, clickSelect);
@@ -20104,7 +20190,7 @@ function openBuilder(node) {
       const rightHandle = document.createElement("div");
       rightHandle.style.cssText = "position:absolute;right:0;top:0;bottom:0;width:8px;background:rgba(255,255,255,.25);cursor:ew-resize;z-index:4;";
       block.append(leftHandle, rightHandle);
-      block.onclick = () => handleSegmentPick(segment);
+      block.onclick = (event) => handleSegmentPick(segment, event);
       block.oncontextmenu = (event) => openSegmentContextMenu(event, segment);
       enableImageDrop(block, segment);
       enableLutDrop(block, segment);
@@ -20242,6 +20328,8 @@ function openBuilder(node) {
             lyricTextInput.dataset.vrgdgUserEdited = "0";
           }
           lyricBox.dataset.savedValue = lyricBox.value;
+          applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper?.source_text || "");
+          syncLyricMapperFromSegments();
           autoSaveSessionQuiet("timeline line note edited");
         };
         lyricBox.onchange = saveTimelineLyricEdit;
@@ -21450,7 +21538,7 @@ function openBuilder(node) {
         if (finishEvent?.pointerId != null && finishEvent.pointerId !== pointerId) return;
         const shouldSelectScene = finishEvent?.type === "pointerup" && mode === "move" && !dragStarted;
         cleanup();
-        if (shouldSelectScene) handleSegmentPick(segment);
+        if (shouldSelectScene) handleSegmentPick(segment, finishEvent);
       };
       activeSegmentDragCleanup = cleanup;
       window.addEventListener("pointermove", move, { passive: false });
@@ -21498,11 +21586,11 @@ function openBuilder(node) {
       const isMultiSelected = isSegmentMultiSelected(segment);
       row.style.cssText = `width:100%;text-align:left;border:${isActive || isMultiSelected ? "3px" : "1px"} solid ${isActive || isMultiSelected ? "#ef4444" : inserted ? "#f59e0b" : "#3f3f46"};border-radius:7px;background:${isActive || isMultiSelected ? "#3f1d24" : inserted ? "#451a03" : "#27272a"};color:#fafafa;padding:8px;margin-bottom:8px;cursor:pointer;box-shadow:${isActive || isMultiSelected ? "0 0 0 2px rgba(239,68,68,.25), 0 0 18px rgba(239,68,68,.42)" : "none"};`;
       row.innerHTML = `<div style="font-weight:800;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${index + 1}. ${escapeHtml(segment.label || "Scene")}</div><div style="font-size:11px;color:#a1a1aa;margin-top:4px;">Duration in seconds: ${formatDurationSeconds(segment.start, segment.end)}</div><div style="font-size:11px;color:#71717a;margin-top:2px;">${formatTime(segment.start)} - ${formatTime(segment.end)}</div>${status}${thumb}`;
-      row.onclick = () => handleSegmentPick(segment);
+      row.onclick = (event) => handleSegmentPick(segment, event);
       row.onkeydown = (event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
-          handleSegmentPick(segment);
+          handleSegmentPick(segment, event);
         }
       };
       const optionsButton = document.createElement("span");
@@ -21544,11 +21632,11 @@ function openBuilder(node) {
       const isMultiSelected = isSegmentMultiSelected(segment);
       row.style.cssText = `width:100%;text-align:left;border:${isActive || isMultiSelected ? "3px" : "1px"} solid ${isActive || isMultiSelected ? "#ef4444" : "#f97316"};border-radius:7px;background:${isActive || isMultiSelected ? "#3f1d24" : "#431407"};color:#fafafa;padding:8px;margin-bottom:8px;cursor:pointer;box-shadow:${isActive || isMultiSelected ? "0 0 0 2px rgba(239,68,68,.25), 0 0 18px rgba(239,68,68,.42)" : "none"};`;
       row.innerHTML = `<div style="font-weight:800;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">Insert ${index + 1}. ${escapeHtml(segment.label || "Insert")}</div><div style="font-size:11px;color:#fed7aa;margin-top:4px;">${formatTime(segment.start)} - ${formatTime(segment.end)} | ${formatDurationSeconds(segment.start, segment.end)}s</div>${thumb}`;
-      row.onclick = () => handleSegmentPick(segment);
+      row.onclick = (event) => handleSegmentPick(segment, event);
       row.onkeydown = (event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
-          handleSegmentPick(segment);
+          handleSegmentPick(segment, event);
         }
       };
       enableImageDrop(row, segment);
@@ -25257,7 +25345,17 @@ function openBuilder(node) {
     const sectionEntries = Array.from(sectionMap.entries());
     let applied = 0;
     for (const segment of segments) {
-      if (!segment || String(segment.lyric_section || "").trim()) continue;
+      if (!segment) continue;
+      const existingSection = String(segment.lyric_section || "").trim().toLowerCase();
+      const lyricText = String(segment.lyric_text || "").trim();
+      // Instrumental is a derived status when a scene contains no lyric text.
+      // Do not let that old marker block a later lyric correction from getting
+      // its real section assigned.
+      if (existingSection && existingSection !== "instrumental") continue;
+      if (!lyricText || isInstrumentalLyricText(lyricText)) {
+        segment.lyric_section = "instrumental";
+        continue;
+      }
       const lyricLines = String(segment.lyric_text || "")
         .replace(/\r\n/g, "\n")
         .replace(/\r/g, "\n")
@@ -25750,12 +25848,14 @@ function openBuilder(node) {
           text.disabled = instrumental.input.checked;
           singers.disabled = instrumental.input.checked;
           if (instrumental.input.checked) {
+            if (text.value.trim()) text.dataset.preInstrumentalText = text.value;
             text.value = "";
             for (const input of singers.querySelectorAll("[data-lyric-singer-choice='1']")) {
               input.checked = false;
               input.disabled = true;
             }
           } else {
+            if (!text.value.trim() && text.dataset.preInstrumentalText) text.value = text.dataset.preInstrumentalText;
             for (const input of singers.querySelectorAll("[data-lyric-singer-choice='1']")) {
               input.disabled = false;
             }
@@ -25810,6 +25910,8 @@ function openBuilder(node) {
         source_text: sourceLyrics.value || "",
         lines: collectLines(),
       });
+      applyLyricMapperToSegments({ overwriteSingers: true });
+      applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper.source_text);
       collectLyricIngredientsMappings();
       if (currentVideoMode() === "ingredients") applyIngredientsReferenceMappings(state.fluxReferenceBuilder);
       await saveSession({ quiet: true, throwOnError: true });
@@ -25833,6 +25935,8 @@ function openBuilder(node) {
         await saveMapper();
         pushHistory();
         const count = applyLyricMapperToSegments({ overwriteSingers: true });
+        applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper.source_text);
+        syncLyricMapperFromSegments();
         const syncedIngredients = syncIngredientsSceneMapFromSubjectMappings(state.fluxReferenceBuilder);
         state.fluxReferenceBuilder = syncedIngredients.refs;
         if (currentVideoMode() === "ingredients") applyIngredientsReferenceMappings(state.fluxReferenceBuilder);
@@ -26970,6 +27074,8 @@ function openBuilder(node) {
               const segment = scenes.find((item) => item.id === row.dataset.reviewSegmentId);
               if (segment) applyReviewRowValues(row, segment, false);
             }
+            applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper?.source_text || "");
+            syncLyricMapperFromSegments();
             const syncedIngredients = syncIngredientsSceneMapFromSubjectMappings(state.fluxReferenceBuilder);
             state.fluxReferenceBuilder = syncedIngredients.refs;
             if (currentVideoMode() === "ingredients") applyIngredientsReferenceMappings(state.fluxReferenceBuilder);
@@ -27101,9 +27207,14 @@ function openBuilder(node) {
       };
       const updateDisabled = () => {
         if (instrumental.input.checked) {
+          if (!isInstrumentalLyricText(text.value)) text.dataset.reviewPreInstrumentalText = text.value;
           text.value = "[instrumental]";
           text.dataset.reviewRawLyricText = "[instrumental]";
           broll.input.checked = false;
+        } else if (isInstrumentalLyricText(text.value)) {
+          const restored = String(text.dataset.reviewPreInstrumentalText || "");
+          text.value = restored;
+          text.dataset.reviewRawLyricText = restored;
         }
         if (broll.input.checked && isInstrumentalLyricText(text.value)) {
           text.value = text.dataset.reviewRawLyricText && !isInstrumentalLyricText(text.dataset.reviewRawLyricText)
@@ -27215,6 +27326,8 @@ function openBuilder(node) {
           if (!segment) continue;
           applyReviewRowValues(row, segment, true, { lyricTextOverride: lyricOverrides.get(segment.id) });
         }
+        applyLyricSectionsFromReferenceText(state.segments, state.lyricMapper?.source_text || "");
+        syncLyricMapperFromSegments();
         const syncedIngredients = syncIngredientsSceneMapFromSubjectMappings(state.fluxReferenceBuilder);
         state.fluxReferenceBuilder = syncedIngredients.refs;
         if (currentVideoMode() === "ingredients") applyIngredientsReferenceMappings(state.fluxReferenceBuilder);
@@ -47291,7 +47404,7 @@ Chrome vault corridor = Sealed industrial passage...</pre>
     const preview = document.createElement("div");
     preview.innerHTML = `<strong style="color:#e0f2fe;">Stitch Preview</strong><br>Use the Stitch Preview menu option to make a quick complete video from selected scenes or from a start/end scene range. Inserts are included automatically, and no Gemma, image generation, or video rendering is run.`;
     const note = document.createElement("div");
-    note.textContent = "Selected scenes turn red. Open Select Multi again to change the list, keep clicking, or exit multi-select and return to normal single-scene editing.";
+    note.textContent = "Selected scenes turn red. Ctrl/Cmd-click toggles scenes on or off; a plain click returns to normal single-scene editing.";
     note.style.cssText = "border:1px solid #334155;border-radius:6px;background:#0f172a;padding:9px;color:#cbd5e1;";
     body.append(batch, selectedBatch, preview, note);
     const ok = makeButton("Got it", "primary");

--- a/web/VRGDG_StoryboardBuilderUI.js
+++ b/web/VRGDG_StoryboardBuilderUI.js
@@ -3355,6 +3355,7 @@ function openStoryboardBuilder(payload = {}) {
     selected: new Set(),
     saving: false,
     gemmaSettings: payload.gemmaSettings || payload.gemma_settings || {},
+    sendAdjacentLyricContext: Boolean(payload.sendAdjacentLyricContext ?? payload.send_adjacent_lyric_context ?? payload.builderStoryboardDefaults?.send_adjacent_lyric_context ?? payload.builder_storyboard_defaults?.send_adjacent_lyric_context),
     cameraFlow: String(payload.cameraFlow || payload.camera_flow || "balanced"),
     customCameraFlowSequence: normalizeStoryboardCustomCameraFlowSequence(payload.customCameraFlowSequence || payload.custom_camera_flow_sequence || payload.builderStoryboardDefaults?.custom_camera_flow_sequence || payload.builder_storyboard_defaults?.custom_camera_flow_sequence),
     imageShotFlow: String(payload.imageShotFlow || payload.image_shot_flow || (usesFilmPlanningProfile ? "film_dialogue_coverage" : "intimate")),
@@ -3421,6 +3422,7 @@ function openStoryboardBuilder(payload = {}) {
       minimax_h3_cut_frequency: storyboardCutFrequencyValue(state.cutFrequency),
       camera_guidance: storyboardSpeedGuidance(state.cameraMotionSpeed, "camera"),
       character_guidance: storyboardSpeedGuidance(state.characterMotionSpeed, "character"),
+      send_adjacent_lyric_context: Boolean(state.sendAdjacentLyricContext),
       performance_style: String(state.performanceStyle || ""),
       short_film_planning_mode: normalizeStoryboardShortFilmPlanningMode(state.shortFilmPlanningMode),
       camera_flow: String(state.cameraFlow || ""),
@@ -4147,6 +4149,18 @@ function openStoryboardBuilder(payload = {}) {
   lyricStoryStrengthRow.style.cssText = "grid-column:1/-1;display:grid;grid-template-columns:minmax(0,1fr) auto auto;gap:8px;align-items:end;";
   lyricStoryStrengthRow.append(storyField("Lyric Story Strength", lyricStoryStrengthInput), lyricStoryStrengthValue, lyricStoryStrengthHintButton);
   lyricStoryStrengthRow.style.display = usesFilmPlanningProfile ? "none" : "grid";
+  const adjacentLyricContextLabel = document.createElement("label");
+  adjacentLyricContextLabel.style.cssText = "grid-column:1/-1;display:flex;align-items:center;gap:7px;color:#cbd5e1;font-size:12px;font-weight:800;";
+  const adjacentLyricContextInput = document.createElement("input");
+  adjacentLyricContextInput.type = "checkbox";
+  adjacentLyricContextInput.checked = Boolean(state.sendAdjacentLyricContext);
+  adjacentLyricContextLabel.append(adjacentLyricContextInput, document.createTextNode("Send last and next lyric line for context"));
+  adjacentLyricContextLabel.title = "When enabled, each scene story beat receives the previous scene's last lyric line and the next scene's first lyric line when available.";
+  adjacentLyricContextLabel.style.display = usesFilmPlanningProfile ? "none" : "flex";
+  adjacentLyricContextInput.onchange = () => {
+    state.sendAdjacentLyricContext = adjacentLyricContextInput.checked;
+    syncStoryLayerFromInputs({ notify: true });
+  };
   const idLoraDialoguePlanner = document.createElement("div");
   idLoraDialoguePlanner.style.cssText = "grid-column:1/-1;display:none;border:1px solid #155e75;border-radius:8px;background:#082f49;padding:12px;gap:10px;align-items:center;grid-template-columns:minmax(0,1fr) auto;";
   const idLoraDialoguePlannerText = document.createElement("div");
@@ -4202,6 +4216,7 @@ function openStoryboardBuilder(payload = {}) {
     storyLayerHeader,
     shortFilmPlanningModeWrap,
     lyricStoryStrengthRow,
+    adjacentLyricContextLabel,
     overallStoryIdeaField,
     storyField("User Story Arc", userStoryArcInput),
     storyField("Song Story Brief", songStoryBriefInput),
@@ -4715,6 +4730,15 @@ function openStoryboardBuilder(payload = {}) {
     top_p: 0.90,
   });
 
+  const adjacentLyricLine = (lyrics, direction = "first") => {
+    const lines = String(lyrics || "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (!lines.length) return "";
+    return direction === "last" ? lines[lines.length - 1] : lines[0];
+  };
+
   const propagateFlfEndStateToNextScene = (scene) => {
     if (state.videoPromptType !== "flf" && scene?.video_prompt_type !== "flf") return;
     const sceneIndex = state.scenes.findIndex((item) => item.id === scene?.id);
@@ -4729,10 +4753,14 @@ function openStoryboardBuilder(payload = {}) {
     const normalized = normalizeScene(scene, 0);
     const sceneIndex = state.scenes.findIndex((item) => item.id === scene.id);
     if (!previousBeat && sceneIndex > 0) previousBeat = String(state.scenes[sceneIndex - 1]?.story_beat || "");
-    if (!previousLyrics && sceneIndex > 0) previousLyrics = String(state.scenes[sceneIndex - 1]?.lyrics || "");
+    if (!previousLyrics && sceneIndex > 0) previousLyrics = adjacentLyricLine(state.scenes[sceneIndex - 1]?.lyrics, "last");
     if (!previousEndState && sceneIndex > 0) previousEndState = String(state.scenes[sceneIndex - 1]?.flf_end_state || "");
     if (!previousCarryForward && sceneIndex > 0) previousCarryForward = String(state.scenes[sceneIndex - 1]?.flf_carry_forward || "");
-    if (!nextLyrics && sceneIndex >= 0 && sceneIndex < state.scenes.length - 1) nextLyrics = String(state.scenes[sceneIndex + 1]?.lyrics || "");
+    if (!nextLyrics && sceneIndex >= 0 && sceneIndex < state.scenes.length - 1) nextLyrics = adjacentLyricLine(state.scenes[sceneIndex + 1]?.lyrics, "first");
+    if (!state.sendAdjacentLyricContext) {
+      previousLyrics = "";
+      nextLyrics = "";
+    }
     if ((state.videoPromptType === "flf" || normalized.video_prompt_type === "flf") && sceneIndex > 0 && previousEndState.trim()) {
       scene.flf_start_state = previousEndState.trim();
     }


### PR DESCRIPTION
## Summary
- improve Video Builder lyric mapping, instrumental restoration, and Ctrl/Cmd multi-selection
- use selected LLM Runner models and names consistently in Video Builder and Storyboard Builder
- add optional adjacent lyric context for Storyboard scene beats
- add ready-to-use Match Grain image and VHS meta-batched video workflows
- update release notes and add focused regression coverage

## Validation
- JSON validation for update notes and both workflow files
- Builder and Storyboard source regression tests
- existing Builder/Storyboard unittest modules: 10 passed
- Match Grain unittest: passed, with one CUDA-only test skipped
- JavaScript module syntax checks for both Builder UI files
- git diff --check

## Excluded
FaceFix V2, MiniMax still-image examples, overlap/meta-batch workflows and scripts, prompt caches, and local worktrees are intentionally excluded.